### PR TITLE
Bugfix/UI enhancement fixes

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -38,7 +38,7 @@ class FastAdmin(admin.ModelAdmin):
         """View to create fast along with its dates."""
         # form submitted with data
         if request.method == "POST":
-            form = CreateFastWithDatesAdminForm(request.POST, request.FILES)
+            form = CreateFastWithDatesAdminForm(request.POST)
             if form.is_valid():
                 fast = form.save()
                 data = form.cleaned_data

--- a/hub/admin.py
+++ b/hub/admin.py
@@ -38,16 +38,9 @@ class FastAdmin(admin.ModelAdmin):
         """View to create fast along with its dates."""
         # form submitted with data
         if request.method == "POST":
-            form = CreateFastWithDatesAdminForm(request.POST)
+            form = CreateFastWithDatesAdminForm(request.POST, request.FILES)
             if form.is_valid():
                 data = form.cleaned_data
-
-                # fast
-                fast = Fast.objects.get_or_create(
-                    name=data["name"], 
-                    church=data["church"],
-                    description=data["description"]
-                )[0]
 
                 # days
                 dates = [data["first_day"] + datetime.timedelta(days=num_days) 

--- a/hub/admin.py
+++ b/hub/admin.py
@@ -40,6 +40,7 @@ class FastAdmin(admin.ModelAdmin):
         if request.method == "POST":
             form = CreateFastWithDatesAdminForm(request.POST, request.FILES)
             if form.is_valid():
+                fast = form.save()
                 data = form.cleaned_data
 
                 # days

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -19,22 +19,34 @@ class CreateFastWithDatesAdminForm(forms.ModelForm):
         fields = ["name", "church", "description", "culmination_feast", "culmination_feast_date", "url"]
 
     def clean_last_day(self):
-        """Ensure last day is not before the first day."""
+        """Ensure last day is 
+        - not before the first day
+        - not longer than max length
+        - before the culmination feast.
+        """
+        # last day must be after first day
         first_day = self.cleaned_data["first_day"]
         last_day = self.cleaned_data["last_day"]
         length_of_fast = (last_day - first_day).days + 1
         if length_of_fast < 1:
             raise ValidationError(f"Last day ({last_day}) cannot be before the first day ({first_day})")
+        # length of fast must be within limit 
         if length_of_fast > _MAX_FAST_LENGTH:
             raise ValidationError(f"Tried to create a fast lasting {length_of_fast} days. "
                                   f"Fasts longer than {_MAX_FAST_LENGTH} days are not permitted.")
         self.cleaned_data["length_of_fast"] = length_of_fast
+        # last day must be before culmination feast, if present
+        culmination_feast_date = self.cleaned_data.get("culmination_feast_date")
+        if culmination_feast_date is not None and culmination_feast_date <= last_day:
+            raise ValidationError(
+                f"Last day ({last_day}) must be before culmination feast ({culmination_feast_date})"
+            )
 
         # also checks that does not overlap with other fasts from the same church
         days = Day.objects.filter(date__range=[first_day, last_day])
-        church_name = self.cleaned_data["church"]
-        church_names = sum([[f.church.name for f in day.fasts.all()] for day in days], []) + [church_name]
-        if len(church_names) > len(set(church_names)):
+        church_name = self.cleaned_data["church"].name
+        names_of_churches_with_overlapping_fasts = sum([[f.church.name for f in day.fasts.all()] for day in days], [])
+        if church_name in names_of_churches_with_overlapping_fasts:
             raise ValidationError("Fast overlaps with another fast from the same church (not permitted).")
 
 

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -16,6 +16,7 @@ class CreateFastWithDatesAdminForm(forms.ModelForm):
 
     class Meta:
         model = Fast
+        # "image" is excluded because it is not clear how to save an image with a form
         fields = ["name", "church", "description", "culmination_feast", "culmination_feast_date", "url"]
 
     def clean_last_day(self):

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -13,6 +13,7 @@ _MAX_FAST_LENGTH = 60  # days
 class CreateFastWithDatesAdminForm(forms.ModelForm):
     first_day = forms.DateField(widget=forms.SelectDateWidget)
     last_day = forms.DateField(widget=forms.SelectDateWidget)
+    culmination_feast_date = forms.DateField(widget=forms.SelectDateWidget)
     class Meta:
         model = Fast
         fields = ["name", "church", "description", "culmination_feast", "culmination_feast_date", "url"]

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -13,7 +13,7 @@ _MAX_FAST_LENGTH = 60  # days
 class CreateFastWithDatesAdminForm(forms.ModelForm):
     first_day = forms.DateField(widget=forms.SelectDateWidget)
     last_day = forms.DateField(widget=forms.SelectDateWidget)
-    culmination_feast_date = forms.DateField(widget=forms.SelectDateWidget)
+
     class Meta:
         model = Fast
         fields = ["name", "church", "description", "culmination_feast", "culmination_feast_date", "url"]

--- a/hub/models.py
+++ b/hub/models.py
@@ -19,7 +19,8 @@ class Fast(models.Model):
     church = models.ForeignKey(Church, on_delete=models.CASCADE, related_name="fasts")
     description = models.TextField(null=True, blank=True)
     culmination_feast = models.CharField(max_length=128, null=True, blank=True)
-    culmination_feast_date = models.DateField(null=True, blank=True)
+    culmination_feast_date = models.DateField(null=True, blank=True,
+                                              help_text="You can enter in day/month/year format, e.g., 8/15/24")
     image = models.ImageField(upload_to='fast_images/', null=True, blank=True)
     image_thumbnail = ImageSpecField(source='image',
                                      processors=[ResizeToFill(500, 500)],

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -38,6 +38,7 @@ class FastSerializer(serializers.ModelSerializer):
     start_date = serializers.SerializerMethodField()
     end_date = serializers.SerializerMethodField()
     joined = serializers.SerializerMethodField()
+    has_passed = serializers.SerializerMethodField()
 
     def get_joined(self, obj):    
         # test if request is present otherwise return False
@@ -78,6 +79,9 @@ class FastSerializer(serializers.ModelSerializer):
     
     def get_end_date(self, obj):
         return obj.days.order_by('date').last().date
+    
+    def get_has_passed(self, obj):
+        return self.get_end_date(obj) < datetime.date.today()
 
     class Meta:
         model = models.Fast

--- a/hub/templates/components/fast_card.html
+++ b/hub/templates/components/fast_card.html
@@ -14,7 +14,8 @@
             <div>
                 <h5 class="card-title text-shadow fw-bold">{{ fast.name }}</h5>
                 <p class="card-text font-weight-light">{{ fast.start_date|date:"F j"  }}</p>
-                <span class="card-text font-weight-light preparing p-1 rounded">{{ fast.participant_count }} {{ fast.participant_count|pluralize:"person,people" }} preparing</span>
+                <span class="card-text font-weight-light preparing p-1 rounded">{{ fast.participant_count }} 
+                    {{ fast.participant_count|pluralize:"person,people" }} {% if fast.has_passed %}fasted{% else %}preparing{% endif %}</span>
             </div>
         </div>
     </div>

--- a/hub/templates/components/fast_card.html
+++ b/hub/templates/components/fast_card.html
@@ -17,6 +17,14 @@
                 <span class="card-text font-weight-light preparing p-1 rounded">{{ fast.participant_count }} 
                     {{ fast.participant_count|pluralize:"person,people" }} {% if fast.has_passed %}fasted{% else %}preparing{% endif %}</span>
             </div>
+            {% if fast.joined %}
+            <div id="leave_button_holder" class="mt-3 pb-3">
+                <form action="{% url 'remove_fast_from_profile' fast.id %}" method="post">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-outline-light btn-sm rounded-pill">Leave Fast</button>
+                </form>
+            </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/hub/templates/components/fast_card.html
+++ b/hub/templates/components/fast_card.html
@@ -18,12 +18,14 @@
                     {{ fast.participant_count|pluralize:"person,people" }} {% if fast.has_passed %}fasted{% else %}preparing{% endif %}</span>
             </div>
             {% if fast.joined %}
-            <div id="leave_button_holder" class="mt-3 pb-3">
+            <div id="leave_button_holder" class="mt-3 pb-0">
                 <form action="{% url 'remove_fast_from_profile' fast.id %}" method="post">
                     {% csrf_token %}
                     <button type="submit" class="btn btn-outline-light btn-sm rounded-pill">Leave Fast</button>
                 </form>
             </div>
+            {% else %}
+            <div class="mt-5"></div>
             {% endif %}
         </div>
     </div>

--- a/hub/templates/home.html
+++ b/hub/templates/home.html
@@ -80,7 +80,7 @@
                     {% if upcoming_fasts %}
                         <div class="p-3 mb-3">
                             <div class="text-uppercase mb-3">{{ current_date|date:"l, F j, Y" }}</div>
-                            <h2 class="fs-3">{{ days_until_next }} days until {{ upcoming_fasts.0.name }}</h2>
+                            <h2 class="fs-3">{{ days_until_next|pluralize:"day,days" }} until {{ upcoming_fasts.0.name }}</h2>
                         </div>
                         <div class="d-lg-flex flex-column flex-lg-row align-items-center col-lg-8 mx-auto">
                             {% include 'components/fast_card.html' with fast=upcoming_fasts.0 %}

--- a/hub/templates/home.html
+++ b/hub/templates/home.html
@@ -44,6 +44,10 @@
                                 <div class="days_to_feast">{{ fast.days_to_feast }}</div>
                                 <div>{{ fast.days_to_feast|pluralize:"day,days" }} until {{ fast.culmination_feast }}</div>
                             </div>
+                            <form action="{% url 'remove_fast_from_profile' fast.id %}" method="post">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-light btn-pill rounded-pill">Leave Fast</button>
+                            </form>
                             <p><strong>{{ fast.participant_count }}</strong> faithful {{ fast.participant_count|pluralize:"is,are" }} fasting with you today!</p>
                             {% include 'components/participant_avatars.html' with participants=other_participants %}
                         </div>

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path("fast/", views.FastOnDate.as_view(), name="fast_on_date"),
     path("web/", views.home, name="web_home"),
     path('add_fast_to_profile/<int:fast_id>/', views.add_fast_to_profile, name='add_fast_to_profile'),
+    path('remove_fast_from_profile/<int:fast_id>/', views.remove_fast_from_profile, name='remove_fast_from_profile'),
 ]
 
 urlpatterns += router.urls

--- a/hub/views.py
+++ b/hub/views.py
@@ -273,3 +273,11 @@ def add_fast_to_profile(request, fast_id):
     request.user.profile.fasts.add(fast)
     messages.success(request, f"You have joined {fast.name}.")
     return redirect(request.META.get('HTTP_REFERER', 'home'))
+
+
+@login_required
+def remove_fast_from_profile(request, fast_id):
+    fast = get_object_or_404(Fast, id=fast_id)
+    request.user.profile.fasts.remove(fast)
+    messages.success(request, f"You have left {fast.name}.")
+    return redirect(request.META.get('HTTP_REFERER', 'home'))

--- a/hub/views.py
+++ b/hub/views.py
@@ -181,7 +181,8 @@ def home(request):
         "description": response.get("description", ""),
         "countdown": response.get("countdown"),
         "upcoming_fasts": serialized_fasts,
-        "days_until_next": days_until_next
+        "days_until_next": days_until_next,
+        "has_passed": response.get("has_passed", False)
     }
 
     # if user doesn't have a profile image or location create a message to prompt them to update their profile


### PR DESCRIPTION
Fixes some bugs and adds some features

**Bugs**
- In create fast with dates admin form, ensure last day is before the culmination feast and fix bug with checking for overlapping fasts in the same church
- show that people "fasted" for fasts that have already passed (instead of showing that they are "preparing")--added `has_passed` field to fast serializer

**Features**
- add help text to admin form for creating culmination feast date (specifies date format)
- button and corresponding view to allow users to leave a fast

**Cleanup**
- Simpler code for admin form to create fast with dates by using `form.save()` to generate the fast instead of explicitly creating
- remove `countdown` from fast serializer (not used anymore)