### PR TITLE
[bugfix] display next fasting day instead of start date of fast (can …

### DIFF
--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -39,6 +39,7 @@ class FastSerializer(serializers.ModelSerializer):
     end_date = serializers.SerializerMethodField()
     joined = serializers.SerializerMethodField()
     has_passed = serializers.SerializerMethodField()
+    next_fast_date = serializers.SerializerMethodField()
 
     def get_joined(self, obj):    
         # test if request is present otherwise return False
@@ -82,6 +83,9 @@ class FastSerializer(serializers.ModelSerializer):
     
     def get_has_passed(self, obj):
         return self.get_end_date(obj) < datetime.date.today()
+    
+    def get_next_fast_date(self, obj):
+        return obj.days.filter(date__gte=datetime.date.today()).order_by('date').first().date
 
     class Meta:
         model = models.Fast

--- a/hub/templates/components/fast_card.html
+++ b/hub/templates/components/fast_card.html
@@ -13,7 +13,7 @@
             </div>
             <div>
                 <h5 class="card-title text-shadow fw-bold">{{ fast.name }}</h5>
-                <p class="card-text font-weight-light">{{ fast.start_date|date:"F j"  }}</p>
+                <p class="card-text font-weight-light">{{ fast.next_fast_date|date:"F j"  }}</p>
                 <span class="card-text font-weight-light preparing p-1 rounded">{{ fast.participant_count }} 
                     {{ fast.participant_count|pluralize:"person,people" }} {% if fast.has_passed %}fasted{% else %}preparing{% endif %}</span>
             </div>


### PR DESCRIPTION
**Bug**
Fast card displays first date of fast. For year-long fasts like the Wednesday and Friday fasts, this shows a date in January all year.

**Fix**
Serialize the next fasting day (excludes days before today) instead of the start date.

Tested manually on local version of the site.