### PR TITLE
Bugfix/countdown not showing for fasts

### DIFF
--- a/hub/templates/home.html
+++ b/hub/templates/home.html
@@ -84,6 +84,7 @@
                     {% if upcoming_fasts %}
                         <div class="p-3 mb-3">
                             <div class="text-uppercase mb-3">{{ current_date|date:"l, F j, Y" }}</div>
+                            <div class="days_to_feast">{{ days_until_next }}</div>
                             <h2 class="fs-3">{{ days_until_next|pluralize:"day,days" }} until {{ upcoming_fasts.0.name }}</h2>
                         </div>
                         <div class="d-lg-flex flex-column flex-lg-row align-items-center col-lg-8 mx-auto">

--- a/hub/views.py
+++ b/hub/views.py
@@ -155,7 +155,7 @@ def home(request):
     # Query up to 6, for other participants for avatar display
     other_participants = current_fast.profiles.all()[:6] if current_fast else None
 
-    # Query for all upcoming fasts
+    # Query for all upcoming fasts and order by first day of the fast from today onward
     upcoming_fasts = Fast.objects.filter(
         church=church,
         days__date__gte=datetime.date.today()
@@ -165,7 +165,8 @@ def home(request):
 
     # calculate days until next upcoming fast
     if upcoming_fasts:
-        next_fast_date = upcoming_fasts[0].days.all()[0].date
+        next_fast = upcoming_fasts.first()
+        next_fast_date = next_fast.days.filter(date__gte=datetime.date.today()).first().date
         days_until_next = (next_fast_date - datetime.date.today()).days
     else:
         days_until_next = None


### PR DESCRIPTION
**Bugs**
1. Countdown on home page does not display a number of days until the next fast. 
2. The days until the fast was calculated by subtracting today's date from the start of the next fast, which gives a negative number of days for the Wednesday and Friday fasts after the first week.

**Fixes**
1. Add div for `days_to_feast` but display days to fast (somewhat of a patch since I couldn't create a separate CSS class that worked since I know nothing about CSS...ideally we create a new class `days_to_fast` but with the same properties for now).
2. Compute the number of days until the *next fast date* (instead of the start date)

Tested manually on local site.