### PR TITLE
Feature/admin duplicate fast for next year

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -55,6 +55,7 @@ class FastAdmin(admin.ModelAdmin):
                     "url_link",)
     list_display_links = ("get_name", "church_link", "url_link",)
     ordering = ("-year", "church", "name",)
+    save_as = True
 
     def get_name(self, fast):
         return str(fast)

--- a/hub/admin.py
+++ b/hub/admin.py
@@ -155,7 +155,6 @@ class FastAdmin(admin.ModelAdmin):
                 "name": old_fast.name,
                 "church": old_fast.church,
                 "culmination_feast": old_fast.culmination_feast,
-                "culmination_feast_date": old_fast.culmination_feast_date,
                 "description": old_fast.description,
                 "url": old_fast.url,
             })

--- a/hub/admin.py
+++ b/hub/admin.py
@@ -55,7 +55,6 @@ class FastAdmin(admin.ModelAdmin):
                     "url_link",)
     list_display_links = ("get_name", "church_link", "url_link",)
     ordering = ("-year", "church", "name",)
-    save_as = True
 
     def get_name(self, fast):
         return str(fast)

--- a/hub/admin.py
+++ b/hub/admin.py
@@ -7,7 +7,7 @@ from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.html import format_html
 
-from hub.forms import CreateFastWithDatesAdminForm
+from hub.forms import CreateFastWithDatesAdminForm, DuplicateFastWithNewDatesAdminForm
 from hub.models import Church, Day, Fast, Profile
 
 
@@ -87,6 +87,11 @@ class FastAdmin(admin.ModelAdmin):
         return [
             path("create_fast_with_dates/", self.admin_site.admin_view(self.create_fast_with_dates),
                  name="create-fast-with-dates"),
+            path(
+                "<int:pk>/change/duplicate_fast_with_new_dates/", 
+                self.admin_site.admin_view(self.duplicate_fast_with_new_dates),
+                name="duplicate-fast-with-new-dates",
+            )
         ] + super().get_urls()
     
     def create_fast_with_dates(self, request):
@@ -119,6 +124,49 @@ class FastAdmin(admin.ModelAdmin):
         )
 
         return TemplateResponse(request, "create_fast_with_dates.html", context)
+    
+    def duplicate_fast_with_new_dates(self, request, pk):
+        """View to duplicate fast with new dates for a new year. Previous participants are not added."""
+        # form submitted with data
+        if request.method == "POST":
+            form = DuplicateFastWithNewDatesAdminForm(request.POST)
+            if form.is_valid():
+                data = form.cleaned_data
+                old_fast = Fast.objects.get(pk=pk)
+                duplicate_fast = Fast.objects.create(
+                    name=old_fast.name,
+                    church=old_fast.church,
+                    description=old_fast.description,
+                    culmination_feast=old_fast.culmination_feast,
+                    culmination_feast_date=data["culmination_feast_date"],
+                    image=old_fast.image,
+                    url=old_fast.url,
+                )
+
+                # days TODO
+                dates = [data["first_day"] + datetime.timedelta(days=num_days) 
+                         for num_days in range(data["length_of_fast"])]
+                days = [Day.objects.get_or_create(date=date)[0] for date in dates]
+                duplicate_fast.days.set(days)
+                duplicate_fast.save()  # updates year based on days
+
+                # go back to fast admin page
+                obj_url = reverse(f"admin:{self.opts.app_label}_{self.opts.model_name}_changelist")
+                
+                return redirect(to=obj_url)
+        else:
+            form = DuplicateFastWithNewDatesAdminForm()
+
+        fast_name = Fast.objects.get(pk=pk).name 
+        context = dict(
+            self.admin_site.each_context(request),
+            opts=Fast._meta,
+            title=f"Duplicate {fast_name} with new dates",
+            form=form,
+            fast_name=fast_name,
+        )
+
+        return TemplateResponse(request, "duplicate_fast_with_new_dates.html", context)
 
 
 @admin.register(Profile, site=admin.site)

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -44,12 +44,11 @@ class CreateFastWithDatesAdminForm(forms.ModelForm):
             )
 
         # also checks that does not overlap with other fasts from the same church
-        # TODO: do I need this validation still with the new migration?
-        # days = Day.objects.filter(date__range=[first_day, last_day])
-        # church_name = self.cleaned_data["church"].name
-        # names_of_churches_with_overlapping_fasts = sum([[f.church.name for f in day.fasts.all()] for day in days], [])
-        # if church_name in names_of_churches_with_overlapping_fasts:
-        #     raise ValidationError("Fast overlaps with another fast from the same church (not permitted).")
+        days = Day.objects.filter(date__range=[first_day, last_day])
+        church_name = self.cleaned_data["church"].name
+        names_of_churches_with_overlapping_fasts = sum([[f.church.name for f in day.fasts.all()] for day in days], [])
+        if church_name in names_of_churches_with_overlapping_fasts:
+            raise ValidationError("Fast overlaps with another fast from the same church (not permitted).")
 
 
 class CustomUserCreationForm(UserCreationForm):
@@ -63,14 +62,6 @@ class CustomUserCreationForm(UserCreationForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['church'].choices = [(church.name, church.name) for church in Church.objects.all()]
-
-
-class DuplicateFastWithNewDatesAdminForm(CreateFastWithDatesAdminForm):
-    class Meta:
-        model = Fast
-        # "image" is excluded because it is not clear how to save an image with a form
-        fields = ["culmination_feast_date"]
-
 
 
 class JoinFastsForm(forms.Form):

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -44,11 +44,12 @@ class CreateFastWithDatesAdminForm(forms.ModelForm):
             )
 
         # also checks that does not overlap with other fasts from the same church
-        days = Day.objects.filter(date__range=[first_day, last_day])
-        church_name = self.cleaned_data["church"].name
-        names_of_churches_with_overlapping_fasts = sum([[f.church.name for f in day.fasts.all()] for day in days], [])
-        if church_name in names_of_churches_with_overlapping_fasts:
-            raise ValidationError("Fast overlaps with another fast from the same church (not permitted).")
+        # TODO: do I need this validation still with the new migration?
+        # days = Day.objects.filter(date__range=[first_day, last_day])
+        # church_name = self.cleaned_data["church"].name
+        # names_of_churches_with_overlapping_fasts = sum([[f.church.name for f in day.fasts.all()] for day in days], [])
+        # if church_name in names_of_churches_with_overlapping_fasts:
+        #     raise ValidationError("Fast overlaps with another fast from the same church (not permitted).")
 
 
 class CustomUserCreationForm(UserCreationForm):
@@ -62,6 +63,14 @@ class CustomUserCreationForm(UserCreationForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['church'].choices = [(church.name, church.name) for church in Church.objects.all()]
+
+
+class DuplicateFastWithNewDatesAdminForm(CreateFastWithDatesAdminForm):
+    class Meta:
+        model = Fast
+        # "image" is excluded because it is not clear how to save an image with a form
+        fields = ["culmination_feast_date"]
+
 
 
 class JoinFastsForm(forms.Form):

--- a/hub/models.py
+++ b/hub/models.py
@@ -33,6 +33,7 @@ class Fast(models.Model):
     culmination_feast = models.CharField(max_length=128, null=True, blank=True)
     culmination_feast_date = models.DateField(null=True, blank=True,
                                               help_text="You can enter in day/month/year format, e.g., 8/15/24")
+    # auto-saved to be the year of the first day of the fast
     year = models.IntegerField(
         validators=[
             MinValueValidator(2024), 

--- a/hub/templates/admin/hub/fast/change_form.html
+++ b/hub/templates/admin/hub/fast/change_form.html
@@ -1,0 +1,6 @@
+{% extends "admin/change_form.html" %}
+
+{% block object-tools-items %}
+  {{ block.super }}
+  <li><a href="duplicate_fast_with_new_dates/", class="addlink">Duplicate Fast with New Dates</a></li>
+{% endblock %}

--- a/hub/templates/duplicate_fast_with_new_dates.html
+++ b/hub/templates/duplicate_fast_with_new_dates.html
@@ -1,0 +1,20 @@
+{% extends "admin/base_site.html" %}
+
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; {% translate "Duplicate " %} {{ fast_name }} {% translate " with new dates" %} 
+</div>
+{% endblock %}
+
+{% block content %}
+<form action="" method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Duplicate">
+</form>
+{% endblock %}


### PR DESCRIPTION
**Feature**

Button added to change fast detail page that auto-populates a create fast with dates form using the current fasts properties (except for the year and dates).

**Testing**

Try duplicating a fast! Check that all fields are transferred over except for dates. The year should be automatically calculated based on the days.