### PR TITLE
Feature/admin add days to fast button

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -7,6 +7,7 @@ from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.html import format_html
 
+from hub.constants import DATE_FORMAT_STRING
 from hub.forms import AddDaysToFastAdminForm, CreateFastWithDatesAdminForm
 from hub.models import Church, Day, Fast, Profile
 
@@ -15,7 +16,8 @@ _MAX_NUM_TO_SHOW = 3  # maximum object names to show in list
 
 
 def _concatenate_queryset(queryset, delim=", ", num=_MAX_NUM_TO_SHOW):
-    return delim.join([str(obj) for obj in queryset][:num])
+    needs_ellipsis = len(queryset) > num
+    return delim.join([str(obj) for obj in queryset][:num]) + (needs_ellipsis * ",...")
 
 
 def _get_fast_links_url(obj, max_num_to_show=_MAX_NUM_TO_SHOW):
@@ -106,7 +108,7 @@ class FastAdmin(admin.ModelAdmin):
             form = AddDaysToFastAdminForm(request.POST)
             if form.is_valid():
                 days = [Day.objects.get_or_create(date=date)[0] for date in form.cleaned_data["dates"]]
-                fast.days.set(days)
+                fast.days.add(*days)
 
                 obj_url = reverse(f"admin:{self.opts.app_label}_{self.opts.model_name}_changelist")
                 

--- a/hub/constants.py
+++ b/hub/constants.py
@@ -1,2 +1,3 @@
 """App constants."""
 NUMBER_PARTICIPANTS_TO_SHOW_WEB = 6  # number of participant thumbnails to show on fast card on web version
+DATE_FORMAT_STRING = "%m/%d/%Y"  # format string for dates (month, day, year)

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -1,4 +1,6 @@
 """Django form classes."""
+import datetime
+
 from django.contrib.auth.forms import UserCreationForm 
 from django.core.exceptions import ValidationError
 from django import forms
@@ -9,6 +11,21 @@ from hub.models import Church, Day, Fast, Profile
 
 _MAX_FAST_LENGTH = 60  # days
 
+
+class AddDaysToFastAdminForm(forms.Form):
+    dates = forms.TextInput()
+
+    def clean_dates(self):
+        """Ensures that dates are entered properly (acceptable date format, line-separated)."""
+        date_strings = self.cleaned_data["dates"].split("\n")
+        dates = []
+        for date_str in date_strings:
+            try:
+                dates.append(datetime.datetime.strptime(date_str, "%m/%d/%Y").date())
+            except:
+                raise ValidationError(f"{date_str} not in valid date format (<month>/<day>/<year>)")
+        self.cleaned_data["dates"] = dates
+        
 
 class CreateFastWithDatesAdminForm(forms.ModelForm):
     first_day = forms.DateField(widget=forms.SelectDateWidget)

--- a/hub/models.py
+++ b/hub/models.py
@@ -33,6 +33,7 @@ class Fast(models.Model):
     culmination_feast = models.CharField(max_length=128, null=True, blank=True)
     culmination_feast_date = models.DateField(null=True, blank=True,
                                               help_text="You can enter in day/month/year format, e.g., 8/15/24")
+    # auto-saved to be the year of the first day of the fast
     year = models.IntegerField(
         validators=[
             MinValueValidator(2024), 

--- a/hub/templates/add_days_to_fast.html
+++ b/hub/templates/add_days_to_fast.html
@@ -1,0 +1,20 @@
+{% extends "admin/base_site.html" %}
+
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; {% translate "Add days to " %} {{ fast_name }}
+</div>
+{% endblock %}
+
+{% block content %}
+<form action="" method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Add">
+</form>
+{% endblock %}

--- a/hub/templates/admin/hub/fast/change_form.html
+++ b/hub/templates/admin/hub/fast/change_form.html
@@ -2,5 +2,6 @@
 
 {% block object-tools-items %}
   {{ block.super }}
+  <li><a href="add_days_to_fast/", class="addlink">Add Days</a></li>
   <li><a href="duplicate_fast_with_new_dates/", class="addlink">Duplicate Fast with New Dates</a></li>
 {% endblock %}


### PR DESCRIPTION
**Feature**

Add button to link to form that allows admin to add days by date to an existing fast.
This should speed up creation of weekly fasts (can duplicate an existing weekly fast, then add days with this form).

**Testing**
Try duplicating a weekly fast and adding a few days. Then save and add a few more. Check that they show up on the `Fast`'s entry on the `Fasts` page, as well as that the `Day`s show up associated with that weekly fast.