### PR TITLE
Adds settings required for celery worker to work on heroku

### DIFF
--- a/bahk/celery.py
+++ b/bahk/celery.py
@@ -13,19 +13,10 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 
 # Configure SSL settings for Redis if using rediss://
 broker_url = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
-if broker_url.startswith('rediss://'):
-    app.conf.broker_transport_options = {
-        'ssl_cert_reqs': CERT_NONE,
-        'ssl_ca_certs': None,
-        'ssl_certfile': None,
-        'ssl_keyfile': None,
-    }
-    app.conf.redis_backend_use_ssl = {
-        'ssl_cert_reqs': CERT_NONE,
-        'ssl_ca_certs': None,
-        'ssl_certfile': None,
-        'ssl_keyfile': None,
-    }
+app.conf.broker_url = broker_url
+
+# The SSL settings will be automatically picked up from Django settings
+# (CELERY_BROKER_USE_SSL and CELERY_REDIS_BACKEND_USE_SSL)
 
 # Discover tasks automatically
 app.autodiscover_tasks()

--- a/bahk/celery.py
+++ b/bahk/celery.py
@@ -2,14 +2,35 @@ from __future__ import absolute_import, unicode_literals
 import os
 from celery import Celery
 from celery.schedules import crontab
+from ssl import CERT_NONE
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'bahk.settings')
 
 app = Celery('bahk')
 
+# Basic configuration from Django settings
 app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Configure SSL settings for Redis if using rediss://
+broker_url = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+if broker_url.startswith('rediss://'):
+    app.conf.broker_transport_options = {
+        'ssl_cert_reqs': CERT_NONE,
+        'ssl_ca_certs': None,
+        'ssl_certfile': None,
+        'ssl_keyfile': None,
+    }
+    app.conf.redis_backend_use_ssl = {
+        'ssl_cert_reqs': CERT_NONE,
+        'ssl_ca_certs': None,
+        'ssl_certfile': None,
+        'ssl_keyfile': None,
+    }
+
+# Discover tasks automatically
 app.autodiscover_tasks()
 
+# Configure scheduled tasks
 app.conf.beat_schedule = {
     'send-fast-notifications-every-day': {
         'task': 'hub.tasks.send_fast_notifications',

--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -195,17 +195,25 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 # Celery Configuration
 CELERY_BROKER_URL = config('REDIS_URL', default='redis://localhost:6379/0')
 CELERY_RESULT_BACKEND = config('REDIS_URL', default='redis://localhost:6379/0')
+
+if CELERY_BROKER_URL.startswith('rediss://'):
+    CELERY_BROKER_USE_SSL = {
+        'ssl_cert_reqs': CERT_NONE,
+        'ssl_ca_certs': None,
+        'ssl_certfile': None,
+        'ssl_keyfile': None,
+    }
+    CELERY_REDIS_BACKEND_USE_SSL = {
+        'ssl_cert_reqs': CERT_NONE,
+        'ssl_ca_certs': None,
+        'ssl_certfile': None,
+        'ssl_keyfile': None,
+    }
+
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TIMEZONE = 'UTC'
-BROKER_USE_SSL = {
-    'ssl_cert_reqs': CERT_NONE
-}
-REDIS_BACKEND_USE_SSL = {
-    'ssl_cert_reqs': CERT_NONE
-}
-
 
 # Mailgun Configuration
 EMAIL_HOST = 'smtp.mailgun.org'

--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -16,6 +16,7 @@ import django_heroku
 
 from pathlib import Path
 from decouple import config, Csv
+from ssl import CERT_NONE
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -198,6 +199,13 @@ CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TIMEZONE = 'UTC'
+BROKER_USE_SSL = {
+    'ssl_cert_reqs': CERT_NONE
+}
+REDIS_BACKEND_USE_SSL = {
+    'ssl_cert_reqs': CERT_NONE
+}
+
 
 # Mailgun Configuration
 EMAIL_HOST = 'smtp.mailgun.org'


### PR DESCRIPTION
These new settings resolve the issue causing fast notifications to not be sent out, or at least resolves one of the issues. Testing is in the form of checking Heroku logs to make sure that the worker server comes online, where as it was crashing before. 