### PR TITLE
draft of simple endpoint to scrape sacredtradition.am for today's readings

### DIFF
--- a/hub/urls.py
+++ b/hub/urls.py
@@ -7,7 +7,7 @@ from .views.fast import FastListView, FastDetailView, JoinFastView, FastByDateVi
 from .views.day import FastDaysListView, UserDaysView
 from .views.user import UserViewSet, GroupViewSet, RegisterView
 from .views.church import ChurchListView, ChurchDetailView
-from .views.readings import GetDailyReadingsForToday
+from .views.readings import GetDailyReadingsForDate
 from .views.web import home, test_email_view, add_fast_to_profile, remove_fast_from_profile, register, join_fasts, edit_profile, changelog
 
 router = routers.DefaultRouter()
@@ -57,7 +57,7 @@ urlpatterns = [
     path('changelog/web/', changelog, name='changelog'),
 
     # Readings endpoints
-    path("readings/", GetDailyReadingsForToday.as_view(), name="daily-readings-today"),
+    path("readings/", GetDailyReadingsForDate.as_view(), name="daily-readings-today"),
 
 
     # Misc endpoints

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -7,7 +7,7 @@ from .views.fast import FastListView, FastDetailView, JoinFastView, FastByDateVi
 from .views.day import FastDaysListView, UserDaysView
 from .views.user import UserViewSet, GroupViewSet, RegisterView
 from .views.church import ChurchListView, ChurchDetailView
-from .views.readings import get_daily_readings_for_today
+from .views.readings import GetDailyReadingsForToday
 from .views.web import home, test_email_view, add_fast_to_profile, remove_fast_from_profile, register, join_fasts, edit_profile, changelog
 
 router = routers.DefaultRouter()
@@ -57,7 +57,7 @@ urlpatterns = [
     path('changelog/web/', changelog, name='changelog'),
 
     # Readings endpoints
-    path("readings/", get_daily_readings_for_today, name="daily-readings-today"),
+    path("readings/", GetDailyReadingsForToday.as_view(), name="daily-readings-today"),
 
 
     # Misc endpoints

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -57,7 +57,7 @@ urlpatterns = [
     path('changelog/web/', changelog, name='changelog'),
 
     # Readings endpoints
-    path("readings/", GetDailyReadingsForDate.as_view(), name="daily-readings-today"),
+    path("readings/", GetDailyReadingsForDate.as_view(), name="daily-readings"),
 
 
     # Misc endpoints

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -7,6 +7,7 @@ from .views.fast import FastListView, FastDetailView, JoinFastView, FastByDateVi
 from .views.day import FastDaysListView, UserDaysView
 from .views.user import UserViewSet, GroupViewSet, RegisterView
 from .views.church import ChurchListView, ChurchDetailView
+from .views.readings import get_daily_readings_for_today
 from .views.web import home, test_email_view, add_fast_to_profile, remove_fast_from_profile, register, join_fasts, edit_profile, changelog
 
 router = routers.DefaultRouter()
@@ -54,6 +55,9 @@ urlpatterns = [
     path("join_fasts/web/", join_fasts, name="join_fasts"),
     path("edit_profile/web/", edit_profile, name="edit_profile"),
     path('changelog/web/', changelog, name='changelog'),
+
+    # Readings endpoints
+    path("readings/", get_daily_readings_for_today, name="daily-readings-today"),
 
 
     # Misc endpoints

--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -14,7 +14,7 @@ import urllib.request
 from django.http import JsonResponse
 
 
-class GetDailyReadingsForToday(generics.GenericAPIView):
+class GetDailyReadingsForDate(generics.GenericAPIView):
     """
     API view to retrieve daily scripture readings by scraping sacredtradition.am.
 

--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -1,0 +1,42 @@
+"""Views for returning data pertaining to daily readings.
+
+Currently based on the Daily Worship app's website, sacredtradition.am
+"""
+from datetime import datetime
+import re
+
+import urllib.request
+
+from django.http import JsonResponse
+
+
+def get_daily_readings_for_today(*_args, **_kwargs):
+    """Based on https://www.geeksforgeeks.org/python-web-scraping-tutorial/"""
+    today_str = datetime.strftime(datetime.today().date(), "%Y%m%d")
+
+    url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM1103&iL=2&ymd={today_str}"
+    response = urllib.request.urlopen(url)
+    data = response.read()
+    html_content = data.decode("utf-8")
+
+    readings = {}
+    book_start = html_content.find("<b>")
+    
+    while book_start != -1:
+        i1 = book_start + len("<b>")
+        i2 = html_content.find("</b>")
+        reading_str = html_content[i1:i2]
+    
+        groups = re.search("^([A-za-z\'\. ]+) ([0-9]+)\.([0-9]+)\-([0-9]+)$", reading_str)
+    
+        book = groups.group(1)
+        chapter = groups.group(2)
+        verse_start = groups.group(3)
+        verse_end = groups.group(4)
+    
+        readings[book] = {chapter: [verse_start, verse_end]}
+    
+        html_content = html_content[i2 + 1:]
+        book_start = html_content.find("<b>")
+
+    return JsonResponse(readings)

--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -26,27 +26,30 @@ class GetDailyReadingsForDate(generics.GenericAPIView):
         - AllowAny: No authentication required
 
     Query Parameters:
-        - date (str): Optional. The date to get the readings for in the format YYYYMMDD.
+        - date (str): Optional. The date to get the readings for in the format YYYY-MM-DD.
 
     Returns:
         - A JSON response with the following structure:
         {
-            "<book_name>": {
-                "<chapter_number>": [
-                    "<start_verse>",
-                    "<end_verse>"
-                ]
-            },
-            ...
+            "<date>": {
+                "<book_name>": {
+                    "<chapter_number>": [
+                        "<start_verse>",
+                        "<end_verse>"
+                    ]
+                }
+            }
         }
 
     Example Response:
         {
-            "Matthew": {
-                "5": ["1", "12"]
-            },
-            "Isaiah": {
-                "55": ["1", "13"]
+            "2024-03-11": {
+                "Matthew": {
+                    "5": ["1", "12"]
+                },
+                "Isaiah": {
+                    "55": ["1", "13"]
+                }
             }
         }
     """
@@ -55,22 +58,30 @@ class GetDailyReadingsForDate(generics.GenericAPIView):
         return f"daily_readings_{date}"
 
     def get(self, request, *args, **kwargs):
+        # Format for API response (YYYY-MM-DD)
+        response_date_format = "%Y-%m-%d"
+        # Format required by sacredtradition.am (YYYYMMDD)
+        scraper_date_format = "%Y%m%d"
+
         if date_str := self.request.query_params.get('date'):
             try:
-                date = datetime.strftime(datetime.strptime(date_str, "%Y-%m-%d").date(), "%Y%m%d")
+                date_obj = datetime.strptime(date_str, response_date_format).date()
             except ValueError:
-                raise ValidationError("Invalid date format. Expected format: yyyy-mm-dd.")
+                raise ValidationError("Invalid date format. Expected format: YYYY-MM-DD")
         else:
-            date = datetime.strftime(datetime.today().date(), "%Y%m%d")
+            date_obj = datetime.today().date()
+
+        response_date = date_obj.strftime(response_date_format)
+        scraper_date = date_obj.strftime(scraper_date_format)
 
         # Try to get from cache first
-        cache_key = self.get_cache_key(date)
+        cache_key = self.get_cache_key(response_date)
         cached_readings = cache.get(cache_key)
         if cached_readings:
-            return Response(cached_readings)
+            return Response({response_date: cached_readings})
 
         # If not in cache, fetch and store
-        url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM1103&iL=2&ymd={date}"
+        url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM1103&iL=2&ymd={scraper_date}"
         response = urllib.request.urlopen(url)
         data = response.read()
         html_content = data.decode("utf-8")
@@ -98,4 +109,4 @@ class GetDailyReadingsForDate(generics.GenericAPIView):
         # Cache the results for 24 hours (86400 seconds)
         cache.set(cache_key, readings, 86400)
         
-        return Response(readings)
+        return Response({response_date: readings})

--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -11,7 +11,21 @@ from django.http import JsonResponse
 
 
 def get_daily_readings_for_today(*_args, **_kwargs):
-    """Based on https://www.geeksforgeeks.org/python-web-scraping-tutorial/"""
+    """Scrapes daily readings from sacredtradition.am.
+
+    Returns:
+        JSON of daily readings::
+
+        {
+            <book>: {
+                <chapter>:
+                    [<start-verse>, <end-verse>]
+                }
+            },
+            ...
+        }
+
+    Based on https://www.geeksforgeeks.org/python-web-scraping-tutorial/"""
     today_str = datetime.strftime(datetime.today().date(), "%Y%m%d")
 
     url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM1103&iL=2&ymd={today_str}"

--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -5,52 +5,85 @@ Currently based on the Daily Worship app's website, sacredtradition.am
 from datetime import datetime
 import re
 
+from rest_framework.exceptions import ValidationError
+from rest_framework import generics
+from rest_framework.response import Response
+
 import urllib.request
 
 from django.http import JsonResponse
 
 
-def get_daily_readings_for_today(*_args, **_kwargs):
-    """Scrapes daily readings from sacredtradition.am.
+class GetDailyReadingsForToday(generics.GenericAPIView):
+    """
+    API view to retrieve daily scripture readings by scraping sacredtradition.am.
+
+    This view scrapes the Daily Worship app's website to get the daily readings
+    for the current date. It parses the HTML content to extract book names,
+    chapters, and verse ranges. Including the optional paramater 'date', it
+    will return the readings for that date instead of today's date.
+
+    Permissions:
+        - AllowAny: No authentication required
+
+    Query Parameters:
+        - date (str): Optional. The date to get the readings for in the format YYYYMMDD.
 
     Returns:
-        JSON of daily readings::
-
+        - A JSON response with the following structure:
         {
-            <book>: {
-                <chapter>:
-                    [<start-verse>, <end-verse>]
-                }
+            "<book_name>": {
+                "<chapter_number>": [
+                    "<start_verse>",
+                    "<end_verse>"
+                ]
             },
             ...
         }
 
-    Based on https://www.geeksforgeeks.org/python-web-scraping-tutorial/"""
-    today_str = datetime.strftime(datetime.today().date(), "%Y%m%d")
+    Example Response:
+        {
+            "Matthew": {
+                "5": ["1", "12"]
+            },
+            "Isaiah": {
+                "55": ["1", "13"]
+            }
+        }
+    """
 
-    url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM1103&iL=2&ymd={today_str}"
-    response = urllib.request.urlopen(url)
-    data = response.read()
-    html_content = data.decode("utf-8")
+    def get(self, request, *args, **kwargs):
+        if date_str := self.request.query_params.get('date'):
+            try:
+                date = datetime.strftime(datetime.strptime(date_str, "%Y-%m-%d").date(), "%Y%m%d")
+            except ValueError:
+                raise ValidationError("Invalid date format. Expected format: yyyy-mm-dd.")
+        else:
+            date = datetime.strftime(datetime.today().date(), "%Y%m%d")
 
-    readings = {}
-    book_start = html_content.find("<b>")
-    
-    while book_start != -1:
-        i1 = book_start + len("<b>")
-        i2 = html_content.find("</b>")
-        reading_str = html_content[i1:i2]
-    
-        groups = re.search("^([A-za-z\'\. ]+) ([0-9]+)\.([0-9]+)\-([0-9]+)$", reading_str)
-    
-        book = groups.group(1)
-        chapter = groups.group(2)
-        verse_start = groups.group(3)
-        verse_end = groups.group(4)
-    
-        readings[book] = {chapter: [verse_start, verse_end]}
-    
-        html_content = html_content[i2 + 1:]
+        url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM1103&iL=2&ymd={date}"
+        response = urllib.request.urlopen(url)
+        data = response.read()
+        html_content = data.decode("utf-8")
+
+        readings = {}
         book_start = html_content.find("<b>")
+        
+        while book_start != -1:
+            i1 = book_start + len("<b>")
+            i2 = html_content.find("</b>")
+            reading_str = html_content[i1:i2]
+    
+            groups = re.search("^([A-za-z\'\. ]+) ([0-9]+)\.([0-9]+)\-([0-9]+)$", reading_str)
 
-    return JsonResponse(readings)
+            book = groups.group(1)
+            chapter = groups.group(2)
+            verse_start = groups.group(3)
+            verse_end = groups.group(4)
+    
+            readings[book] = {chapter: [verse_start, verse_end]}
+    
+            html_content = html_content[i2 + 1:]
+            book_start = html_content.find("<b>")
+
+        return Response(readings)


### PR DESCRIPTION
Assuming sacredtradition.am doesn't change their webpage, we can scrape the daily readings. Here, we add an endpoint to get today's daily readings in a JSON.

Still a draft designed to get us thinking about how we might display or use the readings in the frontend.

**Testing**
Run locally and curl endpoint `/hub/readings/`, e.g.,
```
curl http://localhost:8000/hub/readings/
```