### PR TITLE
Bugfix/password reset endpoint

### DIFF
--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -245,3 +245,5 @@ else:
 CORS_ORIGIN_ALLOW_ALL = config('CORS_ORIGIN_ALLOW_ALL', default=False, cast=bool)
 CORS_ALLOWED_ORIGINS = config('CORS_ALLOWED_ORIGINS', default='', cast=Csv())
 
+# Frontend URL for password reset, if local development or production
+FRONTEND_URL = config('FRONTEND_URL', default='https://web.fastandpray.app')

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -13,12 +13,21 @@ class ProfileSerializer(serializers.ModelSerializer):
     user_id = serializers.IntegerField(source='user.id', read_only=True)
     username = serializers.CharField(source='user.username', read_only=True)
     email = serializers.EmailField(source='user.email', read_only=True)
-    thumbnail = serializers.URLField(source='profile_image_thumbnail.url', read_only=True)
+    thumbnail = serializers.SerializerMethodField()
+
+    def get_thumbnail(self, obj):
+        if obj.profile_image_thumbnail:
+            try:
+                return obj.profile_image_thumbnail.url
+            except:
+                return None
+        return None
 
     class Meta:
         model = models.Profile
-        fields = ['user_id','username','email','profile_image', 'thumbnail', 'location', 'church', 'receive_upcoming_fast_reminders']
-    
+        fields = ['user_id', 'username', 'email', 'profile_image', 'thumbnail', 
+                 'location', 'church', 'receive_upcoming_fast_reminders']
+
 class ProfileImageSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Profile

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -5,7 +5,7 @@ from rest_framework import routers
 from .views.profile import ProfileDetailView, ProfileImageUploadView
 from .views.fast import FastListView, FastDetailView, JoinFastView, FastByDateView, FastOnDate, FastOnDateWithoutUser, FastParticipantsView, LeaveFastView, FastStatsView
 from .views.day import FastDaysListView, UserDaysView
-from .views.user import UserViewSet, GroupViewSet, RegisterView
+from .views.user import UserViewSet, GroupViewSet, RegisterView, PasswordResetView, PasswordResetConfirmView
 from .views.church import ChurchListView, ChurchDetailView
 from .views.readings import GetDailyReadingsForDate
 from .views.web import home, test_email_view, add_fast_to_profile, remove_fast_from_profile, register, join_fasts, edit_profile, changelog
@@ -20,10 +20,13 @@ router.register(r"groups", GroupViewSet)
 urlpatterns = [
     path("", include(router.urls)),
 
-    # User profile endpoints
+    # User & Profile endpoints
     path('register/', RegisterView.as_view(), name='auth_register'),
     path('profile/', ProfileDetailView.as_view(), name='profile-detail'),
-    path('profile/image-upload/', ProfileImageUploadView.as_view(), name='profile-image-upload'),   
+    path('profile/image-upload/', ProfileImageUploadView.as_view(), name='profile-image-upload'),
+    path('password/reset/', PasswordResetView.as_view(), name='password_reset'),
+    path('password/reset/confirm/', PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
+   
 
     # Fast endpoints
     path('fasts/', FastListView.as_view(), name='fast-list'),

--- a/hub/views/user.py
+++ b/hub/views/user.py
@@ -1,6 +1,14 @@
 from django.contrib.auth.models import User, Group
 from rest_framework import viewsets, permissions, generics
 from hub import serializers
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.encoding import force_bytes, force_str
+from django.core.mail import send_mail
+from django.conf import settings
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
 
 
 class UserViewSet(viewsets.ModelViewSet):
@@ -20,3 +28,72 @@ class RegisterView(generics.CreateAPIView):
     queryset = User.objects.all()
     permission_classes = [permissions.AllowAny]
     serializer_class = serializers.RegisterSerializer
+
+class PasswordResetView(APIView):
+    permission_classes = [permissions.AllowAny]
+    serializer_class = serializers.PasswordResetSerializer
+
+    def post(self, request):
+        serializer = self.serializer_class(data=request.data)
+        if serializer.is_valid():
+            email = serializer.validated_data['email']
+            try:
+                user = User.objects.get(email=email)
+                
+                # Generate password reset token
+                token = default_token_generator.make_token(user)
+                uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
+            
+                # Create reset link - frontend URL
+                reset_url = f"{settings.FRONTEND_URL}/reset-password/{uidb64}/{token}"
+
+                # Send email
+                send_mail(
+                    'Password Reset Request',
+                    f'Please click the following link to reset your password: {reset_url}',
+                    settings.DEFAULT_FROM_EMAIL,
+                    [email],
+                    fail_silently=False,
+                )
+            
+                return Response(
+                    {"detail": "Password reset email has been sent."},
+                    status=status.HTTP_200_OK
+                )
+            except User.DoesNotExist:
+                return Response(
+                    {"detail": "Email address not found."},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+class PasswordResetConfirmView(APIView):
+    permission_classes = [permissions.AllowAny]
+    serializer_class = serializers.PasswordResetConfirmSerializer
+
+    def post(self, request):
+        serializer = self.serializer_class(data=request.data)
+        if serializer.is_valid():
+            try:
+                uid = force_str(urlsafe_base64_decode(serializer.validated_data['uidb64']))
+                user = User.objects.get(pk=uid)
+                
+                if default_token_generator.check_token(user, serializer.validated_data['token']):
+                    user.set_password(serializer.validated_data['new_password'])
+                    user.save()
+                    return Response(
+                        {"detail": "Password has been reset successfully."},
+                        status=status.HTTP_200_OK
+                    )
+                return Response(
+                    {"detail": "Invalid token."},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+                
+            except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+                return Response(
+                    {"detail": "Invalid user ID."},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+                
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,0 +1,123 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.urls import reverse
+from django.core import mail
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.contrib.auth.tokens import default_token_generator
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from hub.serializers import PasswordResetSerializer, PasswordResetConfirmSerializer
+
+class PasswordResetTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser',
+            email='test@example.com',
+            password='oldpassword123'
+        )
+        self.password_reset_url = reverse('password_reset')
+        self.password_reset_confirm_url = reverse('password_reset_confirm')
+
+    def test_password_reset_serializer_valid_email(self):
+        serializer = PasswordResetSerializer(data={'email': 'test@example.com'})
+        self.assertTrue(serializer.is_valid())
+
+    def test_password_reset_serializer_invalid_email(self):
+        serializer = PasswordResetSerializer(data={'email': 'nonexistent@example.com'})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('email', serializer.errors)
+
+    def test_password_reset_confirm_serializer_passwords_match(self):
+        # Generate valid token and uidb64
+        token = default_token_generator.make_token(self.user)
+        uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
+        
+        data = {
+            'token': token,
+            'uidb64': uidb64,
+            'new_password': 'newpassword123',
+            'confirm_password': 'newpassword123'
+        }
+        serializer = PasswordResetConfirmSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+
+    def test_password_reset_confirm_serializer_passwords_dont_match(self):
+        token = default_token_generator.make_token(self.user)
+        uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
+        
+        data = {
+            'token': token,
+            'uidb64': uidb64,
+            'new_password': 'newpassword123',
+            'confirm_password': 'differentpassword123'
+        }
+        serializer = PasswordResetConfirmSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('non_field_errors', serializer.errors)
+
+    def test_password_reset_endpoint(self):
+        response = self.client.post(self.password_reset_url, {'email': 'test@example.com'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('test@example.com', mail.outbox[0].to)
+
+    def test_password_reset_endpoint_invalid_email(self):
+        response = self.client.post(self.password_reset_url, {'email': 'nonexistent@example.com'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertIn('email', response.data)
+
+    def test_password_reset_confirm_endpoint(self):
+        # Generate valid token and uidb64
+        token = default_token_generator.make_token(self.user)
+        uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
+        
+        data = {
+            'token': token,
+            'uidb64': uidb64,
+            'new_password': 'newpassword123',
+            'confirm_password': 'newpassword123'
+        }
+        
+        response = self.client.post(self.password_reset_confirm_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Verify the password was actually changed
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password('newpassword123'))
+
+    def test_password_reset_confirm_endpoint_invalid_token(self):
+        uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
+        
+        data = {
+            'token': 'invalid-token',
+            'uidb64': uidb64,
+            'new_password': 'newpassword123',
+            'confirm_password': 'newpassword123'
+        }
+        
+        response = self.client.post(self.password_reset_confirm_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        
+        # Verify the password was not changed
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password('oldpassword123'))
+
+    def test_password_reset_confirm_endpoint_invalid_uidb64(self):
+        token = default_token_generator.make_token(self.user)
+        
+        data = {
+            'token': token,
+            'uidb64': 'invalid-uidb64',
+            'new_password': 'newpassword123',
+            'confirm_password': 'newpassword123'
+        }
+        
+        response = self.client.post(self.password_reset_confirm_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        
+        # Verify the password was not changed
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password('oldpassword123')) 


### PR DESCRIPTION
I actually wrote a test for this one!
`python manage.py test tests.test_password_reset`

This pull request introduces a password reset feature to the application, along with various related improvements and tests. The changes include adding new serializers, views, and URL endpoints to support the password reset functionality. Additionally, tests have been added to ensure the feature works correctly.

### Password Reset Feature:

* **New Configuration:**
  - Added `FRONTEND_URL` configuration in `bahk/settings.py` to specify the frontend URL for password reset.

* **Serializers:**
  - Added `PasswordResetSerializer` and `PasswordResetConfirmSerializer` to handle password reset requests and confirmations in `hub/serializers.py`.

* **Views:**
  - Introduced `PasswordResetView` and `PasswordResetConfirmView` in `hub/views/user.py` to manage password reset and confirmation processes.

* **URL Endpoints:**
  - Added new URL patterns for password reset and confirmation in `hub/urls.py`.

* **Tests:**
  - Implemented tests for the password reset functionality in `tests/test_password_reset.py`.

### Other Improvements:

* **Profile Serializer:**
  - Updated the `ProfileSerializer` to use `SerializerMethodField` for the `thumbnail` field and added error handling for missing profile images in `hub/serializers.py`.