### PR TITLE
Bugfix/issue 77 handle webscrape failure

### DIFF
--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -83,7 +83,16 @@ class GetDailyReadingsForDate(generics.GenericAPIView):
 
         # If not in cache, fetch and store
         url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM1103&iL=2&ymd={scraper_date}"
-        response = urllib.request.urlopen(url)
+        try:
+            response = urllib.request.urlopen(url)
+        except urllib.error.URLError:
+            logging.error("Invalid url %s", url)
+            return Response({})
+
+        if response.status != 200:
+            logging.error("Could not access readings from url %s. Failed with status %r", url, response.status)
+            return Response({})
+
         data = response.read()
         html_content = data.decode("utf-8")
 


### PR DESCRIPTION
**Bugfix**
- Handles readings with different chapters for starting and ending verse
- Handles invalid URL, non-200 HTTP response, and failed regex parsing of HTML

Note: the readings view now returns the chapter and verses as a list of chapter-verse pairs instead of a dictionary, i.e., Matthew 24:1-25:3 would be returned as
```
{
  "Matthew": [
    ("24", "1"),
    ("25", "3")
  ]
}
```