### PR TITLE
bugfix/handle single verse readings and prevent infinite loop

### DIFF
--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -116,35 +116,40 @@ class GetDailyReadingsForDate(generics.GenericAPIView):
             i1 = book_start + len("<b>")
             i2 = html_content.find("</b>")
             reading_str = html_content[i1:i2]
+            # advance to next section of web text to prevent infinite loop
+            html_content = html_content[i2 + 1:]
+            book_start = html_content.find("<b>")
     
-            parser_regex = r"^([A-za-z\'\. ]+) ([0-9]+)\.([0-9]+)\-([0-9]+\.)?([0-9]+)$"
+            parser_regex = r"^([A-za-z\'\. ]+) ([0-9]+)\.([0-9]+)(\-)?([0-9]+\.)?([0-9]+)?$"
             groups = re.search(parser_regex, reading_str)
 
             # skip reading if does not match parser regex
             if groups is None:
                 logging.error("Could not parse reading %s at %s with regex %s", reading_str, url, parser_regex)
-                html_content = html_content[i2 + 1:]
-                book_start = html_content.find("<b>")
                 continue
 
-            book = groups.group(1)
-            start_chapter = groups.group(2)
-            start_verse = groups.group(3)
-            end_chapter = groups.group(4).strip(".") if groups.group(4) else start_chapter  # rm decimal from group
-            end_verse = groups.group(5)
+            try:
+                # parse groups
+                book = groups.group(1)
+                start_chapter = groups.group(2)
+                start_verse = groups.group(3)
+                end_chapter = groups.group(5).strip(".") if groups.group(5) is not None else start_chapter  # rm decimal
+                end_verse = groups.group(6) if groups.group(6) is not None else start_verse
     
-            # Instead of building the old dictionary format, create a reading object
-            reading = {
-                "book": book,
-                "startChapter": int(start_chapter),  # Convert to integers
-                "startVerse": int(start_verse), 
-                "endChapter": int(end_chapter),
-                "endVerse": int(end_verse)
-            }
-            formatted_readings.append(reading)
+                # Instead of building the old dictionary format, create a reading object
+                reading = {
+                    "book": book,
+                    "startChapter": int(start_chapter),  # Convert to integers
+                    "startVerse": int(start_verse), 
+                    "endChapter": int(end_chapter), 
+                    "endVerse": int(end_verse) 
+                }
+            except Exception as e:
+                logging.error("Could not parse reading with text %s with regex %s from %s. Skipping.", 
+                              reading_str, parser_regex, url)
+                continue
 
-            html_content = html_content[i2 + len("</b>"):]
-            book_start = html_content.find("<b>")
+            formatted_readings.append(reading)
 
         # Create the final response format
         response_data = {

--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -120,7 +120,7 @@ class GetDailyReadingsForDate(generics.GenericAPIView):
             html_content = html_content[i2 + 1:]
             book_start = html_content.find("<b>")
     
-            parser_regex = r"^([A-za-z\'\. ]+) ([0-9]+)\.([0-9]+)(\-)?([0-9]+\.)?([0-9]+)?$"
+            parser_regex = r"^([A-za-z\'\. ]+) ([0-9]+)\.([0-9]+)\-?([0-9]+\.)?([0-9]+)?$"
             groups = re.search(parser_regex, reading_str)
 
             # skip reading if does not match parser regex
@@ -133,8 +133,8 @@ class GetDailyReadingsForDate(generics.GenericAPIView):
                 book = groups.group(1)
                 start_chapter = groups.group(2)
                 start_verse = groups.group(3)
-                end_chapter = groups.group(5).strip(".") if groups.group(5) is not None else start_chapter  # rm decimal
-                end_verse = groups.group(6) if groups.group(6) is not None else start_verse
+                end_chapter = groups.group(4).strip(".") if groups.group(4) is not None else start_chapter  # rm decimal
+                end_verse = groups.group(5) if groups.group(5) is not None else start_verse
     
                 # Instead of building the old dictionary format, create a reading object
                 reading = {


### PR DESCRIPTION
**Bugfixes**
- Single-verse readings were failing to be parsed because the regex expected a `"-"`: now, make that an optional group
- To prevent infinite loop, advance through html content immediately
- add try-except around group parsing just in case

**Testing**
Get the readings for 2024-11-25 and check that they are parsed properly (this day includes each type of reading: single-chapter, single-verse, and spanning chapters)

You can do this by running the server locally
```
python manage.py runserver
```
And retrieving the endpoint at `http://localhost:8000/hub/readings/?date=2024-11-25`