### PR TITLE
[feature] log in with email instead of username

### DIFF
--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -162,8 +162,8 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 10
 }
 
-# path to backend for authenticating users by email (instead of username)
-AUTHENTICATION_BACKENDS = ["hub.auth.EmailBackend"]
+# path to backend for authenticating users by email or username (instead of only username)
+AUTHENTICATION_BACKENDS = ["hub.auth.EmailOrUsernameBackend"]
 
 # Redirect to home URL after login (Default redirects to /accounts/profile/)
 LOGIN_REDIRECT_URL = '/hub/web/'

--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -162,6 +162,9 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 10
 }
 
+# path to backend for authenticating users by email (instead of username)
+AUTHENTICATION_BACKENDS = ["hub.auth.EmailBackend"]
+
 # Redirect to home URL after login (Default redirects to /accounts/profile/)
 LOGIN_REDIRECT_URL = '/hub/web/'
 

--- a/hub/auth.py
+++ b/hub/auth.py
@@ -1,0 +1,21 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
+
+
+class EmailBackend(ModelBackend):
+    """Solution to log in with email instead of username.
+    
+    Copied from:
+    https://stackoverflow.com/questions/37332190/django-login-with-email
+    """
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        UserModel = get_user_model()
+        try:
+            # the "username" field is now treated as an email
+            user = UserModel.objects.get(email=username)
+        except UserModel.DoesNotExist:
+            return None
+        else:
+            if user.check_password(password):
+                return user
+        return None

--- a/hub/auth.py
+++ b/hub/auth.py
@@ -1,21 +1,29 @@
+"""Backend for authentication."""
+import logging
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
+from django.db.models import Q
 
 
-class EmailBackend(ModelBackend):
+class EmailOrUsernameBackend(ModelBackend):
     """Solution to log in with email instead of username.
     
-    Copied from:
+    Adapted from:
     https://stackoverflow.com/questions/37332190/django-login-with-email
     """
     def authenticate(self, request, username=None, password=None, **kwargs):
         UserModel = get_user_model()
-        try:
-            # the "username" field is now treated as an email
-            user = UserModel.objects.get(email=username)
-        except UserModel.DoesNotExist:
+        # the "username" field can now also be treated as an email
+        possible_user = UserModel.objects.filter(Q(email=username) | Q(username=username))
+        if not possible_user.exists():
             return None
-        else:
-            if user.check_password(password):
-                return user
-        return None
+        if possible_user.count() > 1:
+            logging.error("Multiple users found with the email/username %s. Fix database before proceeding.", username)
+            return None
+
+        user = possible_user.first()
+        if not user.check_password(password):
+            return None
+        
+        return user

--- a/hub/models.py
+++ b/hub/models.py
@@ -1,6 +1,4 @@
 """Models for bahk hub."""
-import datetime
-
 from django.contrib.auth.models import User
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models


### PR DESCRIPTION
**Feature**

Custom email backend to log in users with their email instead of their username.

Essentially treats username as an email.

**Test**
Try to log in as a user with their email. Log out. Then try to log in with their username. Both should work.