### PR TITLE
Bugfix/fast by date tz

### DIFF
--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -146,7 +146,8 @@ class FastByDateView(ChurchContextMixin, generics.ListAPIView):
             return timezone.utc
 
     def get_queryset(self):
-        # Retrieve the date from query parameters, default to today
+        church = self.get_church()
+        
         date_str = self.request.query_params.get('date')
         tz = self.get_timezone()
 
@@ -158,9 +159,8 @@ class FastByDateView(ChurchContextMixin, generics.ListAPIView):
                 raise ValidationError("Invalid date format. Expected format: yyyy-mm-dd.")
         else:
             # Default to the current date
-            target_date = timezone.localdate()
+            target_date = timezone.localdate(timezone=tz)
 
-        church = self.get_church()
         return Fast.objects.filter(church=church, days__date=target_date)
 
 

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ValidationError
 import datetime
 from rest_framework import views, response, status
 import logging
+import pytz
 
 
 class FastListView(ChurchContextMixin, generics.ListAPIView):
@@ -28,6 +29,7 @@ class FastListView(ChurchContextMixin, generics.ListAPIView):
     Query Parameters:
         - start_date: Optional. Start date in YYYY-MM-DD format. Defaults to 6 months ago.
         - end_date: Optional. End date in YYYY-MM-DD format. Defaults to 6 months in future.
+        - tz: Optional. Timezone offset from UTC in the IANA format (e.g., America/New_York).
     
     Returns:
         - A list of fasts filtered by:
@@ -39,9 +41,22 @@ class FastListView(ChurchContextMixin, generics.ListAPIView):
     permission_classes = [permissions.AllowAny]
     pagination_class = None
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['tz'] = self.get_timezone()
+        return context
+
+    def get_timezone(self):
+        tz_str = self.request.query_params.get('tz')
+        if tz_str:
+            return pytz.timezone(tz_str)
+        else:
+            return timezone.utc
+
     def get_queryset(self):
         church = self.get_church()
-        today = timezone.now().date()
+        tz = self.get_timezone()
+        today = timezone.localdate(timezone=tz)
         
         # Default date range (±6 months)
         default_start = today - datetime.timedelta(days=180)
@@ -109,6 +124,8 @@ class FastByDateView(ChurchContextMixin, generics.ListAPIView):
 
     Query Parameters:
         - date: Optional. A string representing the date in `yyyy-mm-dd` format.
+        - tz: Optional. A string representing the timezone offset from UTC in the IANA format (e.g., America/New_York).
+        - church_id: Optional. A string representing the church id. Required if unauthenticated.
 
     Returns:
         - A list of fasts filtered by the church and date context.
@@ -116,18 +133,32 @@ class FastByDateView(ChurchContextMixin, generics.ListAPIView):
     serializer_class = FastSerializer
     permission_classes = [permissions.AllowAny]  # Allow any user to access this view
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['tz'] = self.get_timezone()
+        return context
+
+    def get_timezone(self):
+        tz_str = self.request.query_params.get('tz')
+        if tz_str:
+            return pytz.timezone(tz_str)
+        else:
+            return timezone.utc
+
     def get_queryset(self):
         # Retrieve the date from query parameters, default to today
         date_str = self.request.query_params.get('date')
+        tz = self.get_timezone()
+
         if date_str:
             try:
                 # Parse the date string (expected format: yyyy-mm-dd)
-                target_date = timezone.datetime.strptime(date_str, "%Y-%m-%d").date()
+                target_date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
             except ValueError:
                 raise ValidationError("Invalid date format. Expected format: yyyy-mm-dd.")
         else:
             # Default to the current date
-            target_date = timezone.now().date()
+            target_date = timezone.localdate()
 
         church = self.get_church()
         return Fast.objects.filter(church=church, days__date=target_date)


### PR DESCRIPTION
API requests were off when users in other timezones are ahead (or presumably behind) in date. This defaults to UTC for all requests to /api/fasts and api/fasts/by-date and user can define ?tz= according IANA of their local. The JS app will do this for them.

This pull request includes changes to the `hub/serializers.py` and `hub/views/fast.py` files to improve timezone handling and ensure accurate date calculations. The most important changes include importing the `timezone` module, updating date calculations to use the provided timezone, and adding a new query parameter for timezone.

Improvements to timezone handling:

* [`hub/serializers.py`](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9R14): Imported `timezone` module and updated various methods (`get_countdown`, `get_days_to_feast`, `get_has_passed`, `get_next_fast_date`, `get_current_day_number`) to use `timezone.localdate` with the provided timezone context to ensure accurate date calculations. [[1]](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9R14) [[2]](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9R146-R148) [[3]](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9L156-R166) [[4]](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9R183-R192) [[5]](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9L197-L210)

Enhancements to views for timezone support:

* [`hub/views/fast.py`](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R11): Imported `pytz` module and added a new query parameter `tz` for timezone offset in `FastListView` and `FastByDateView` classes. Updated `get_serializer_context` and `get_queryset` methods to use the provided timezone for date calculations. [[1]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R11) [[2]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R32) [[3]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R44-R59) [[4]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R127-L132)