### PR TITLE
moves tz to mixin. applies mixin to views

### DIFF
--- a/hub/views/mixins.py
+++ b/hub/views/mixins.py
@@ -1,5 +1,7 @@
 from rest_framework.exceptions import ValidationError
 from ..models import Church
+from django.utils import timezone
+import pytz
 
 
 class ChurchContextMixin:
@@ -23,3 +25,19 @@ class ChurchContextMixin:
                 raise ValidationError("Church with the provided ID does not exist.")
 
         return church
+
+class TimezoneMixin:
+    """
+    Mixin to handle timezone context for serializers.
+    Expects 'tz' query parameter in IANA format (e.g., 'America/New_York').
+    """
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['tz'] = self.get_timezone()
+        return context
+
+    def get_timezone(self):
+        tz_str = self.request.query_params.get('tz')
+        if tz_str:
+            return pytz.timezone(tz_str)
+        return timezone.utc

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -40,28 +40,38 @@ def send_push_notification(message, data=None, users=None, notification_type=Non
             tokens_queryset = tokens_queryset.filter(user__in=users)
 
         # Filter based on user preferences if notification_type is provided
-        if notification_type == 'upcoming_fast':
-            tokens_queryset = tokens_queryset.filter(
-                user__profile__receive_upcoming_fast_push_notifications=True
-            )
-        elif notification_type == 'ongoing_fast':
-            tokens_queryset = tokens_queryset.filter(
-                user__profile__receive_ongoing_fast_push_notifications=True
-            )
-        elif notification_type == 'daily_fast':
-            tokens_queryset = tokens_queryset.filter(
-                user__profile__receive_daily_fast_push_notifications=True
-            )
-        elif notification_type == 'weekly_fast':
-            tokens_queryset = tokens_queryset.filter(
-                user__profile__include_weekly_fasts_in_notifications=True
-            )
-
-        if notification_type != 'weekly_fast' and not data.get('weekly_fast', False):
-            tokens_queryset = tokens_queryset.exclude(
-                Q(user__profile__fasts__name__icontains='friday') |
-                Q(user__profile__fasts__name__icontains='wednesday')
-            )
+        if notification_type:
+            if notification_type == 'upcoming_fast':
+                tokens_queryset = tokens_queryset.filter(
+                    user__profile__receive_upcoming_fast_push_notifications=True
+                )
+                if not data.get('weekly_fast', False):
+                    tokens_queryset = tokens_queryset.exclude(
+                        Q(user__profile__fasts__name__icontains='friday') |
+                        Q(user__profile__fasts__name__icontains='wednesday')
+                    )
+            elif notification_type == 'ongoing_fast':
+                tokens_queryset = tokens_queryset.filter(
+                    user__profile__receive_ongoing_fast_push_notifications=True
+                )
+                if not data.get('weekly_fast', False):
+                    tokens_queryset = tokens_queryset.exclude(
+                        Q(user__profile__fasts__name__icontains='friday') |
+                        Q(user__profile__fasts__name__icontains='wednesday')
+                    )
+            elif notification_type == 'daily_fast':
+                tokens_queryset = tokens_queryset.filter(
+                    user__profile__receive_daily_fast_push_notifications=True
+                )
+                if not data.get('weekly_fast', False):
+                    tokens_queryset = tokens_queryset.exclude(
+                        Q(user__profile__fasts__name__icontains='friday') |
+                        Q(user__profile__fasts__name__icontains='wednesday')
+                    )
+            elif notification_type == 'weekly_fast':
+                tokens_queryset = tokens_queryset.filter(
+                    user__profile__include_weekly_fasts_in_notifications=True
+                )
 
         tokens = list(tokens_queryset.values_list('token', flat=True))
 

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -40,38 +40,28 @@ def send_push_notification(message, data=None, users=None, notification_type=Non
             tokens_queryset = tokens_queryset.filter(user__in=users)
 
         # Filter based on user preferences if notification_type is provided
-        if notification_type:
-            if notification_type == 'upcoming_fast':
-                tokens_queryset = tokens_queryset.filter(
-                    user__profile__receive_upcoming_fast_push_notifications=True
-                )
-                if not data.get('weekly_fast', False):
-                    tokens_queryset = tokens_queryset.exclude(
-                        Q(user__profile__fasts__name__icontains='friday') |
-                        Q(user__profile__fasts__name__icontains='wednesday')
-                    )
-            elif notification_type == 'ongoing_fast':
-                tokens_queryset = tokens_queryset.filter(
-                    user__profile__receive_ongoing_fast_push_notifications=True
-                )
-                if not data.get('weekly_fast', False):
-                    tokens_queryset = tokens_queryset.exclude(
-                        Q(user__profile__fasts__name__icontains='friday') |
-                        Q(user__profile__fasts__name__icontains='wednesday')
-                    )
-            elif notification_type == 'daily_fast':
-                tokens_queryset = tokens_queryset.filter(
-                    user__profile__receive_daily_fast_push_notifications=True
-                )
-                if not data.get('weekly_fast', False):
-                    tokens_queryset = tokens_queryset.exclude(
-                        Q(user__profile__fasts__name__icontains='friday') |
-                        Q(user__profile__fasts__name__icontains='wednesday')
-                    )
-            elif notification_type == 'weekly_fast':
-                tokens_queryset = tokens_queryset.filter(
-                    user__profile__include_weekly_fasts_in_notifications=True
-                )
+        if notification_type == 'upcoming_fast':
+            tokens_queryset = tokens_queryset.filter(
+                user__profile__receive_upcoming_fast_push_notifications=True
+            )
+        elif notification_type == 'ongoing_fast':
+            tokens_queryset = tokens_queryset.filter(
+                user__profile__receive_ongoing_fast_push_notifications=True
+            )
+        elif notification_type == 'daily_fast':
+            tokens_queryset = tokens_queryset.filter(
+                user__profile__receive_daily_fast_push_notifications=True
+            )
+        elif notification_type == 'weekly_fast':
+            tokens_queryset = tokens_queryset.filter(
+                user__profile__include_weekly_fasts_in_notifications=True
+            )
+
+        if notification_type != 'weekly_fast' and not data.get('weekly_fast', False):
+            tokens_queryset = tokens_queryset.exclude(
+                Q(user__profile__fasts__name__icontains='friday') |
+                Q(user__profile__fasts__name__icontains='wednesday')
+            )
 
         tokens = list(tokens_queryset.values_list('token', flat=True))
 


### PR DESCRIPTION
Fixes #96 

This pull request includes changes to enhance timezone handling in views and improve the filtering logic for push notifications in the `notifications/utils.py` file. The most important changes include adding a new `TimezoneMixin` and updating the views to use this mixin, as well as refining the filtering of push notifications based on user preferences.

Enhancements to timezone handling:

* [`hub/views/fast.py`](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6L5-R5): Added `TimezoneMixin` to the `FastListView`, `FastDetailView`, and `FastByDateView` classes to provide timezone context for serializers. Removed redundant methods for getting timezone from these views. [[1]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6L5-R5) [[2]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6L14-R14) [[3]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R24) [[4]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6L44-L55) [[5]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6L91-R105) [[6]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R114) [[7]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6L136-L147)
* [`hub/views/mixins.py`](diffhunk://#diff-d6597cf1a5b23f3c2bad241de198a529552283fd756f77d16e25e51961063c3bR3-R4): Introduced the `TimezoneMixin` class to handle timezone context for serializers, expecting a 'tz' query parameter in IANA format. [[1]](diffhunk://#diff-d6597cf1a5b23f3c2bad241de198a529552283fd756f77d16e25e51961063c3bR3-R4) [[2]](diffhunk://#diff-d6597cf1a5b23f3c2bad241de198a529552283fd756f77d16e25e51961063c3bR28-R43)

Improvements to push notification filtering:

* [`notifications/utils.py`](diffhunk://#diff-c300da093d8bb0cb0420b1781d72d9c37f9593ce7dba9b58660e8dd4df98f19dR43-R74): Enhanced the filtering logic for push notifications to consider user preferences more accurately. Added checks for `notification_type` and refined exclusion conditions for weekly fasts.