### PR TITLE
[bugfix] Handles creating fast with dates if dates exist

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -135,11 +135,11 @@ class FastAdmin(admin.ModelAdmin):
                 fast = form.save()
                 data = form.cleaned_data
 
-                # days
+                # create days for fast
                 dates = [data["first_day"] + datetime.timedelta(days=num_days) 
                          for num_days in range(data["length_of_fast"])]
-                days = [Day.objects.get_or_create(date=date)[0] for date in dates]
-                fast.days.set(days)
+                for date in dates:
+                    Day.objects.create(date=date, fast=fast, church=data["church"])
 
                 # go back to fast admin page
                 obj_url = reverse(f"admin:{self.opts.app_label}_{self.opts.model_name}_changelist")

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -65,14 +65,13 @@ class CreateFastWithDatesAdminForm(forms.ModelForm):
             raise ValidationError(
                 f"Last day ({last_day}) must be before culmination feast ({culmination_feast_date})"
             )
-
         # also checks that does not overlap with other fasts from the same church
-        days = Day.objects.filter(date__range=[first_day, last_day])
         church_name = self.cleaned_data["church"].name
-        names_of_churches_with_overlapping_fasts = sum([[f.church.name for f in day.fasts.all()] for day in days], [])
-        if church_name in names_of_churches_with_overlapping_fasts:
-            raise ValidationError("Fast overlaps with another fast from the same church (not permitted).")
-        
+        days = Day.objects.filter(date__range=[first_day, last_day], church__name=church_name)
+        if any(day.fast is not None for day in days):
+            raise ValidationError(f"Fast overlaps with another fast from the {church_name} (not permitted).")
+
+
         return last_day
 
 


### PR DESCRIPTION
**Bug**

Previously, creating fast with dates was treating days as having a many-to-many relationship with fasts, which was causing uncaught errors and leading to cryptic Server 500 errors. These expressions should have been updated when the `Day` model was updated to have foreign key relationships with `Fast`.

**Fix**

Check for overlapping days of fast using foreign key relationship
Create link between day and fast upon creation of day by setting the fast as its foreign key.

**Testing**

1. Create a fast with dates (go to admin > `Fasts` > `CREATE FAST WITH DATES` in the upper right)
2. Create another fast with dates with a new name but same church and overlapping at least 1 day with the fast you just created. You should get a validation error indicating that there is an overlap with an existing fast from that church. Check that `Fasts` page to make sure that the fast was not created without the dates (this was happening before).
3. Adjust the dates so they do not overlap with a fast from your current church, but they do overlap with a fast from another church. The fast should be created successfully.