### PR TITLE
Bugfix/add missing link for st james on catena

### DIFF
--- a/hub/constants.py
+++ b/hub/constants.py
@@ -88,6 +88,7 @@ CATENA_ABBREV_FOR_BOOK = {
     "St. Paul's Epistle to the Hebrews": "heb",
     "James": "jas",
     "St. James' Epistle General": "jas",
+    "St. James General Epistle": "jas",
     "1 Peter": "1pt",
     "St. Peter's First Epistle General": "1pt",
     "2 Peter": "2pt",

--- a/hub/constants.py
+++ b/hub/constants.py
@@ -2,6 +2,7 @@
 NUMBER_PARTICIPANTS_TO_SHOW_WEB = 6  # number of participant thumbnails to show on fast card on web version
 DATE_FORMAT_STRING = "%m/%d/%Y"  # format string for dates (month, day, year)
 
+CATENA_HOME_PAGE_URL = "https://catenabible.com/"
 CATENA_ABBREV_FOR_BOOK = {
     # Old Testament
     "Genesis": "gn",

--- a/hub/models.py
+++ b/hub/models.py
@@ -1,4 +1,6 @@
 """Models for bahk hub."""
+import logging
+
 from django.contrib.auth.models import User
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
@@ -7,7 +9,7 @@ from imagekit.models import ImageSpecField
 from imagekit.processors import ResizeToFill
 from imagekit.processors import Transpose
 
-from hub.constants import CATENA_ABBREV_FOR_BOOK
+from hub.constants import CATENA_ABBREV_FOR_BOOK, CATENA_HOME_PAGE_URL
 import bahk.settings as settings
 
 
@@ -126,9 +128,12 @@ class Reading(models.Model):
 
     def create_url(self):
         """Creates URL to read the reading."""
-        book_abbrev = CATENA_ABBREV_FOR_BOOK[self.book]
+        book_abbrev = CATENA_ABBREV_FOR_BOOK.get(self.book)
+        if book_abbrev is None:
+            logging.error("Missing Catena URL abbreviation for %s. Returning home page", self.book)
+            return CATENA_HOME_PAGE_URL
         verse_ref = "" if self.start_verse <= 2 else f"#{book_abbrev}{self.start_chapter:03d}{self.start_verse - 2:03d}"
-        return f"https://catenabible.com/{book_abbrev}/{self.start_chapter:d}/{verse_ref}"
+        return f"{CATENA_HOME_PAGE_URL}{book_abbrev}/{self.start_chapter:d}/{verse_ref}"
 
 
     def __str__(self):


### PR DESCRIPTION
**Bug**

On December 28, 2024, readings could not be fetched because of an unforeseen name for the book of James, which caused creation of the Catena URL to fail, failing the fetching of the rest of the readings.

**Fix**

This name has been added to the list and a backup has been added to avoid this in the future.

Tested locally by andylitalo.

Resolves issue https://github.com/surp-hovhannes/bahk/issues/113