### PR TITLE
[bugfix] ensure seed church pk starts with 1

### DIFF
--- a/hub/management/commands/seed.py
+++ b/hub/management/commands/seed.py
@@ -35,9 +35,9 @@ class Command(BaseCommand):
 
     def populate_db(self):
         churches = [
-            models.Church.objects.create(name="Armenian Apostolic Church"),
-            models.Church.objects.create(name="Church2"),
-            models.Church.objects.create(name="Church3"),
+            models.Church.objects.create(name="Armenian Apostolic Church", pk=1),
+            models.Church.objects.create(name="Church2", pk=2),
+            models.Church.objects.create(name="Church3", pk=3),
         ]
 
         fasts = [


### PR DESCRIPTION
**Bug**

When seeding database after having already created a database, might skip `pk=1` when creating churches. This is necessary to fetch churches when not logged in (defaults to fetching church with `pk=1`).

**Fix**

Hard-coded `pk`s for seed churches (1,2,3).

Tested.