### PR TITLE
Feature/email for username backend

### DIFF
--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -172,8 +172,8 @@ SIMPLE_JWT = {
     'REFRESH_TOKEN_LIFETIME': datetime.timedelta(days=100*365)  # set to expire in 100 years (~forever)
 }
 
-# path to backend for authenticating users by email or username (instead of only username)
-AUTHENTICATION_BACKENDS = ["hub.auth.EmailOrUsernameBackend"]
+# path to backend for authenticating users by email
+AUTHENTICATION_BACKENDS = ["hub.auth.EmailBackend"]
 
 # Redirect to home URL after login (Default redirects to /accounts/profile/)
 LOGIN_REDIRECT_URL = '/hub/web/'

--- a/hub/auth.py
+++ b/hub/auth.py
@@ -3,23 +3,24 @@ import logging
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
-from django.db.models import Q
 
 
-class EmailOrUsernameBackend(ModelBackend):
+class EmailBackend(ModelBackend):
     """Solution to log in with email instead of username.
     
     Adapted from:
     https://stackoverflow.com/questions/37332190/django-login-with-email
     """
     def authenticate(self, request, username=None, password=None, **kwargs):
+        """A bit of a hack: the kwarg is username, but we expect it to be the email."""
+        email = username
         UserModel = get_user_model()
         # the "username" field can now also be treated as an email
-        possible_user = UserModel.objects.filter(Q(email=username) | Q(username=username))
+        possible_user = UserModel.objects.filter(email=email)
         if not possible_user.exists():
             return None
         if possible_user.count() > 1:
-            logging.error("Multiple users found with the email/username %s. Fix database before proceeding.", username)
+            logging.error("Multiple users found with the email %s. Fix database before proceeding.", email)
             return None
 
         user = possible_user.first()

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -82,7 +82,7 @@ class CustomUserCreationForm(UserCreationForm):
     
     class Meta:
         model = User
-        fields = ["username", "email", "password1", "password2"]
+        fields = ["email", "password1", "password2"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/hub/management/commands/seed.py
+++ b/hub/management/commands/seed.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
     def _create_users(self, emails, church, fasts=None):
         users = []
         profiles = []
-        for email in zip(emails):
+        for email in emails:
             user = models.User.objects.create_user(username=email, email=email, password=PASSWORD)
             users.append(user)
             profile = models.Profile.objects.create(user=user, church=church)

--- a/hub/management/commands/seed.py
+++ b/hub/management/commands/seed.py
@@ -7,11 +7,8 @@ from django.db import transaction
 import hub.models as models
 
 
-USERNAMES1 = ["user1a", "user1b"]
 EMAILS1 = ["user1a@email.com", "user1b@email.com"]
-USERNAMES2 = ["user2"]
 EMAILS2 = ["user2@email.com"]
-USERNAMES3 = ["user3"]
 EMAILS3 = ["user3@email.com"]
 PASSWORD = "default123"
 
@@ -64,16 +61,16 @@ class Command(BaseCommand):
                 day = models.Day.objects.create(date=date.today() + timedelta(days=i), fast=fast, church=fast.church)
                 fast.save(update_fields=["year"])  # saving fast with day(s) updates the year field
 
-        self._create_users(USERNAMES1, EMAILS1, churches[0], [fasts[0]])
-        self._create_users(USERNAMES2, EMAILS2, churches[1], [fasts[1]])
-        self._create_users(USERNAMES3, EMAILS3, churches[2])
+        self._create_users(EMAILS1, churches[0], fasts=[fasts[0]])
+        self._create_users(EMAILS2, churches[1], fasts=[fasts[1]])
+        self._create_users(EMAILS3, churches[2])
 
     @transaction.atomic        
-    def _create_users(self, usernames, emails, church, fasts=None):
+    def _create_users(self, emails, church, fasts=None):
         users = []
         profiles = []
-        for username, email in zip(usernames, emails):
-            user = models.User.objects.create_user(username=username, email=email, password=PASSWORD)
+        for email in zip(emails):
+            user = models.User.objects.create_user(username=email, email=email, password=PASSWORD)
             users.append(user)
             profile = models.Profile.objects.create(user=user, church=church)
             profiles.append(profile)

--- a/hub/models.py
+++ b/hub/models.py
@@ -93,7 +93,7 @@ class Profile(models.Model):
     include_weekly_fasts_in_notifications = models.BooleanField(default=False)
 
     def __str__(self):
-        return self.user.username
+        return self.user.email
 
 
 class Day(models.Model):

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -17,7 +17,6 @@ from hub import models
 
 class ProfileSerializer(serializers.ModelSerializer):
     user_id = serializers.IntegerField(source='user.id', read_only=True)
-    username = serializers.CharField(source='user.username', read_only=True)
     email = serializers.EmailField(source='user.email', read_only=True)
     thumbnail = serializers.SerializerMethodField()
 
@@ -31,7 +30,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Profile
-        fields = ['user_id', 'username', 'email', 'profile_image', 'thumbnail', 
+        fields = ['user_id', 'email', 'profile_image', 'thumbnail', 
                  'location', 'church', 'receive_upcoming_fast_reminders', 
                  'receive_upcoming_fast_push_notifications', 
                  'receive_ongoing_fast_push_notifications',
@@ -48,7 +47,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = User
-        fields = ["url", "username", "email", "groups", "profile"]
+        fields = ["url", "email", "groups", "profile"]
 
 class GroupSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
@@ -67,7 +66,7 @@ class RegisterSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('username', 'password', 'password2', 'email', 'church')
+        fields = ('password', 'password2', 'email', 'church')
 
     def validate(self, attrs):
         if attrs['password'] != attrs['password2']:
@@ -77,7 +76,7 @@ class RegisterSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         church = validated_data.pop('profile')['church']
         user = User.objects.create(
-            username=validated_data['username'],
+            username=validated_data['email'],
             email=validated_data['email'],
         )
         user.set_password(validated_data['password'])
@@ -270,7 +269,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
         model = models.Profile
         fields = ['id', 'user', 'profile_image', 'thumbnail', 'location'] 
 
-    user = serializers.CharField(source='user.username')  # If you want to include the username instead of the user object
+    user = serializers.CharField(source='user.email')  # If you want to include the email instead of the user object
 
 class PasswordResetSerializer(serializers.Serializer):
     email = serializers.EmailField()

--- a/hub/templates/registration/login.html
+++ b/hub/templates/registration/login.html
@@ -4,7 +4,7 @@
 <div class="row w-100 p-3 mx-3 mb-3 rounded-bottom shadow bg-light text-dark">
 
   {% if form.errors %}
-    <p>Your username and password didn't match. Please try again.</p>
+    <p>Your email and password didn't match. Please try again.</p>
   {% endif %}
 
   {% if next %}
@@ -20,7 +20,7 @@
     {% csrf_token %}
     <div class="form-group row pb-3">
       <div class="col-sm-10">
-        <input type="text" name="{{ form.username.name }}" id="{{ form.username.id_for_label }}" class="form-control" placeholder="{{ form.username.label }}" value="{{ form.username.value|default_if_none:'' }}">
+        <input type="text" name="{{ form.email.name }}" id="{{ form.email.id_for_label }}" class="form-control" placeholder="{{ form.email.label }}" value="{{ form.email.value|default_if_none:'' }}">
       </div>
     </div>
     <div class="form-group row pb-3 ">

--- a/hub/templates/registration/login.html
+++ b/hub/templates/registration/login.html
@@ -20,7 +20,7 @@
     {% csrf_token %}
     <div class="form-group row pb-3">
       <div class="col-sm-10">
-        <input type="text" name="{{ form.email.name }}" id="{{ form.email.id_for_label }}" class="form-control" placeholder="{{ form.email.label }}" value="{{ form.email.value|default_if_none:'' }}">
+        <input type="text" name="{{ form.username.name }}" id="{{ form.username.id_for_label }}" class="form-control" placeholder="Email" value="{{ form.username.value|default_if_none:'' }}">
       </div>
     </div>
     <div class="form-group row pb-3 ">

--- a/hub/templates/registration/register.html
+++ b/hub/templates/registration/register.html
@@ -12,8 +12,8 @@
       <form class="register-form" method="POST" action="">
         {% csrf_token %}
         <h2 class="register-title">REGISTER</h3>
-        <h4>{{form.username.label}}</h4>
-        {{form.username}}
+        <h4>{{form.email.label}}</h4>
+        {{form.email}}
         <h4>{{form.email.label}}</h4>
         {{form.email}}
         <h4>{{form.password1.label}}</h4>

--- a/hub/views/web.py
+++ b/hub/views/web.py
@@ -97,14 +97,14 @@ def register(request):
     if request.method == 'POST':
         form = CustomUserCreationForm(request.POST)
         if form.is_valid():
-            username = form.cleaned_data["username"]
+            email = form.cleaned_data["email"]
             church_name = form.cleaned_data["church"]
             form.save()
-            Profile.objects.get_or_create(user=User.objects.get(username=username), 
+            Profile.objects.get_or_create(user=User.objects.get(email=email), 
                                           church=Church.objects.get(name=church_name))
 
             password = form.cleaned_data["password1"]
-            user = authenticate(request, username=username, password=password)
+            user = authenticate(request, username=email, password=password)
             if user is not None:
                 login(request, user)
                 

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -13,7 +13,7 @@ from hub.serializers import PasswordResetSerializer, PasswordResetConfirmSeriali
 class PasswordResetTests(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user(
-            username='testuser',
+            username='test@example.com',
             email='test@example.com',
             password='oldpassword123'
         )


### PR DESCRIPTION
**Feature**

Obsoletes use of "username", replacing with email where it cannot be completely removed (such as in the `User` class).

Should only be deployed with [companion PR for frontend](https://github.com/surp-hovhannes/bahk_react_native/pull/54).

To test,
```
python -m pip install -r requirements.txt
python manage.py seed
python manage.py runserver <local-machine-ip-address>:8000
```

You may need to change `settings.py` so `ALLOWED_HOSTS` includes your machine's IP address.

Then, in the `bahk_react_native` repo, with the companion branch `feature/email-for-username-frontend` active, change `API_HOST = 'http://<ip-address>:8000'` in `constant/constants.js` and run
```
npx expo start
```
Check that you can register a new user and login as an existing user (e.g., `email: user1a@email.com`,  `password: default123`).