### PR TITLE
ParticipantSerializer to include name and abbreviation fields

### DIFF
--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -288,6 +288,13 @@ class DaySerializer(serializers.ModelSerializer):
 class ParticipantSerializer(serializers.ModelSerializer):
     thumbnail = serializers.SerializerMethodField()
     abbreviation = serializers.SerializerMethodField()
+    user = serializers.SerializerMethodField()
+
+    def get_user(self, obj):
+        # user is returning name while frontend is transitioning to api change.
+        # this will be removed after frontend update is fully deployed.
+        return obj.name
+
     def get_abbreviation(self, obj):
         if obj.name:
             return obj.name[0]
@@ -301,7 +308,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Profile
-        fields = ['id', 'name', 'profile_image', 'thumbnail', 'location', 'abbreviation']
+        fields = ['id', 'name', 'profile_image', 'thumbnail', 'location', 'abbreviation', 'user']
 
 class PasswordResetSerializer(serializers.Serializer):
     email = serializers.EmailField()

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -287,6 +287,12 @@ class DaySerializer(serializers.ModelSerializer):
 
 class ParticipantSerializer(serializers.ModelSerializer):
     thumbnail = serializers.SerializerMethodField()
+    abbreviation = serializers.SerializerMethodField()
+    def get_abbreviation(self, obj):
+        if obj.name:
+            return obj.name[0]
+        else:
+            return obj.user.email[0]
 
     def get_thumbnail(self, obj):
         if obj.profile_image_thumbnail:
@@ -295,9 +301,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Profile
-        fields = ['id', 'user', 'profile_image', 'thumbnail', 'location'] 
-
-    user = serializers.CharField(source='user.email')  # If you want to include the email instead of the user object
+        fields = ['id', 'name', 'profile_image', 'thumbnail', 'location', 'abbreviation']
 
 class PasswordResetSerializer(serializers.Serializer):
     email = serializers.EmailField()

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -233,6 +233,7 @@ class FastParticipantsView(views.APIView):
     
     URL Parameters:
         - fast_id: The ID of the fast for which to retrieve the participants.
+        - limit: Optional. A number to limit the number of participants to return. Defaults to 6.
 
     Returns:
         - A list of participant profiles for the specified fast.
@@ -246,8 +247,18 @@ class FastParticipantsView(views.APIView):
         if not current_fast:
             return response.Response({"detail": "Fast not found."}, status=404)
 
-        # Retrieve up to 6 participants for the specified fast
-        other_participants = current_fast.profiles.all()[:NUMBER_PARTICIPANTS_TO_SHOW_WEB]
+        # Get the limit parameter from query params, defaulting to NUMBER_PARTICIPANTS_TO_SHOW_WEB
+        # This controls how many participants to return in the response
+        limit = request.query_params.get('limit', NUMBER_PARTICIPANTS_TO_SHOW_WEB)
+
+        # Convert the limit parameter to an integer, defaulting to NUMBER_PARTICIPANTS_TO_SHOW_WEB if invalid
+        try:
+            limit = int(limit)
+        except (ValueError, TypeError):
+            limit = NUMBER_PARTICIPANTS_TO_SHOW_WEB
+
+        # Get all profiles (participants) associated with this fast, limited by the limit parameter
+        other_participants = current_fast.profiles.all()[:limit]            
 
         # Serialize the participant data
         serialized_participants = ParticipantSerializer(other_participants, many=True, context={'request': request})


### PR DESCRIPTION
This pull request includes changes to the `hub/serializers.py` file to enhance the `ParticipantSerializer` by adding a new field and updating the Meta class fields.

Must be published after associated [app PR goes live](https://github.com/surp-hovhannes/bahk_react_native/pull/73)

Enhancements to `ParticipantSerializer`:

* Added a new method `get_abbreviation` to generate an abbreviation based on the participant's name or email.
* Updated the `Meta` class to include the new `abbreviation` field in the list of serialized fields.