### PR TITLE
Make fast reminder task logs visible

### DIFF
--- a/hub/utils.py
+++ b/hub/utils.py
@@ -16,6 +16,7 @@ from hub.models import Church, Day, Fast, Profile
 from hub.serializers import FastSerializer
 
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 PARSER_REGEX = r"^([A-za-z1-4\'\. ]+) ([0-9]+\.)?([0-9]+)\-?([0-9]+\.)?([0-9]+)?$"


### PR DESCRIPTION
resolves #91

I plan to make a file that initializes a `logger` variable so we can consistently use the same logging configuration across all files


### how to test
- [x] apply the below diff (to be able to run the file directly)
```diff
diff --git a/hub/utils.py b/hub/utils.py
index abb691b..2c3c8de 100644
--- a/hub/utils.py
+++ b/hub/utils.py
@@ -11,16 +11,17 @@ from django.db.models import OuterRef, Subquery, Q
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
 
-import bahk.settings as settings
-from hub.models import Church, Day, Fast, Profile
-from hub.serializers import FastSerializer
+# import bahk.settings as settings
+# from hub.models import Church, Day, Fast, Profile
+# from hub.serializers import FastSerializer
 
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.info("yeah")
 
-PARSER_REGEX = r"^([A-za-z1-4\'\. ]+) ([0-9]+\.)?([0-9]+)\-?([0-9]+\.)?([0-9]+)?$"
-SUPPORTED_CHURCHES = Church.objects.filter(name=settings.DEFAULT_CHURCH_NAME)
+# PARSER_REGEX = r"^([A-za-z1-4\'\. ]+) ([0-9]+\.)?([0-9]+)\-?([0-9]+\.)?([0-9]+)?$"
+# SUPPORTED_CHURCHES = Church.objects.filter(name=settings.DEFAULT_CHURCH_NAME)
 
 def scrape_readings(date_obj, church, date_format="%Y%m%d", max_num_readings=40):
     """Scrapes readings from sacredtradition.am""" 

```
- [x] ensure that the log line now appears when running the file directly
```
evan@whatever ~/bahk $ python hub/utils.py 
INFO:__main__:yeah
```
