### PR TITLE
Add section for generating static content in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ python manage.py createsuperuser
 ```
 Note the username, email, and password that you enter.
 
+### Running the website
+Generate the html/css/js static content with
+```
+python manage.py collectstatic
+```
+
 Now you're ready to run the app! In the terminal, enter
 ```
 python manage.py runserver


### PR DESCRIPTION
I had to run this command for the html to show up correctly at http://localhost:8000/hub/ and http://localhost:8000/hub/web

If this is a one-off issue, we don't have to add this and we can close the pr
