### PR TITLE
Refactor DevotionalSerializer to handle s3 links for media assets on production

### DIFF
--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -401,9 +401,9 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
 class DevotionalSerializer(serializers.ModelSerializer):
     title = serializers.CharField(source='video.title')
     description = serializers.CharField(source='video.description')
-    thumbnail = serializers.CharField(source='video.thumbnail')
-    thumbnail_small = serializers.CharField(source='video.thumbnail_small')
-    video = serializers.CharField(source='video.video')
+    thumbnail = serializers.SerializerMethodField()
+    thumbnail_small = serializers.SerializerMethodField()
+    video = serializers.SerializerMethodField()
     date = serializers.DateField(source='day.date')
     fast_id = serializers.IntegerField(source='day.fast.id')
     created_at = serializers.DateTimeField(source='video.created_at')
@@ -423,3 +423,21 @@ class DevotionalSerializer(serializers.ModelSerializer):
             'created_at',
             'updated_at',
         ]
+
+    def get_thumbnail(self, obj):
+        return obj.video.thumbnail.url if obj.video and obj.video.thumbnail else None
+
+    def get_thumbnail_small(self, obj):
+        if obj.video and obj.video.thumbnail:
+            # Try to get cached URL first
+            if obj.video.cached_thumbnail_url:
+                return obj.video.cached_thumbnail_url
+            # Fall back to generating URL
+            try:
+                return obj.video.thumbnail_small.url
+            except:
+                return None
+        return None
+
+    def get_video(self, obj):
+        return obj.video.video.url if obj.video and obj.video.video else None


### PR DESCRIPTION
This pull request includes changes to the `DevotionalSerializer` class in the `hub/serializers.py` file to improve the handling of video-related fields to return AWS uploaded asset urls on production.

Improvements to video-related field handling:

* [`hub/serializers.py`](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9L404-R406): Modified the `thumbnail`, `thumbnail_small`, and `video` fields to use `SerializerMethodField` instead of direct field mapping.
* [`hub/serializers.py`](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9R426-R443): Added `get_thumbnail`, `get_thumbnail_small`, and `get_video` methods to handle the retrieval of video URLs, including handling potential missing data and using cached URLs when available.