### PR TITLE
Mattash/enhancement optimize participants list

### DIFF
--- a/app.json
+++ b/app.json
@@ -39,7 +39,7 @@
                 "DEBUG": "True"
             },
             "scripts": {
-                "postdeploy": "python manage.py migrate && python manage.py seed"
+                "postdeploy": "python manage.py migrate && python manage.py createsuperuser --noinput --username admin --email admin@email.com && python manage.py seed"
             }
         },
         "test": {

--- a/app.json
+++ b/app.json
@@ -55,7 +55,7 @@
             ],
             "scripts": {
                 "test-setup": "python manage.py migrate",
-                "test": "true"
+                "test": "python manage.py test --keepdb"
             }
         }
     }

--- a/app.json
+++ b/app.json
@@ -51,7 +51,8 @@
             "addons": [
                 "heroku-postgresql:essential-0",
                 "heroku-redis:mini",
-                "mailgun:starter"
+                "mailgun:starter",
+                "heroku-postgresql:in-dyno"
             ],
             "scripts": {
                 "test-setup": "python manage.py migrate",

--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -211,9 +211,10 @@ AUTHENTICATION_BACKENDS = ["hub.auth.EmailBackend"]
 # Redirect to home URL after login (Default redirects to /accounts/profile/)
 LOGIN_REDIRECT_URL = '/hub/web/'
 
-# Activate Django-Heroku.
-import django_heroku
-django_heroku.settings(locals())
+if not config('CI', default=False, cast=bool):
+    # Activate Django-Heroku.
+    import django_heroku
+    django_heroku.settings(locals())
 
 # File Upload Settings
 FILE_UPLOAD_MAX_MEMORY_SIZE = 5242880  # 5MB - Django default

--- a/bahk/urls.py
+++ b/bahk/urls.py
@@ -62,11 +62,6 @@ urlpatterns += [
     path('api/s3-upload/', include('s3_file_field.urls')),
 ]
 
-# S3FileField URLs
-urlpatterns += [
-    path('api/s3-upload/', include('s3_file_field.urls')),
-]
-
 # for serving media files during development
 if not settings.IS_PRODUCTION:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/hub/apps.py
+++ b/hub/apps.py
@@ -4,3 +4,11 @@ from django.apps import AppConfig
 class HubConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'hub'
+
+    def ready(self):
+        """
+        Register signals when the app is ready.
+        This ensures our signal handlers are connected.
+        """
+        # Import signals to register them
+        import hub.signals

--- a/hub/models.py
+++ b/hub/models.py
@@ -111,6 +111,17 @@ class Fast(models.Model):
             self.year = self.days.first().date.year
             super().save(update_fields=["year"])
 
+        # Invalidate the cache for this church's fast list
+        from hub.views.fast import FastListView
+        FastListView().invalidate_cache(self.church_id)
+
+    def delete(self, *args, **kwargs):
+        church_id = self.church_id
+        super().delete(*args, **kwargs)
+        # Invalidate the cache after deletion
+        from hub.views.fast import FastListView
+        FastListView().invalidate_cache(church_id)
+
     class Meta:
         constraints = [
             constraints.UniqueConstraint(fields=["name", "church", "year"], name="unique_name_church_year"),

--- a/hub/signals.py
+++ b/hub/signals.py
@@ -1,0 +1,41 @@
+from django.db.models.signals import m2m_changed
+from django.dispatch import receiver
+from django.core.cache import cache
+from hub.models import Profile, Fast
+
+@receiver(m2m_changed, sender=Profile.fasts.through)
+def handle_fast_participant_change(sender, instance, action, **kwargs):
+    """
+    Signal handler that invalidates the FastListView cache when
+    participants join or leave fasts.
+    
+    This triggers on any change to the many-to-many relationship
+    between Profile and Fast models.
+    """
+    # Only proceed for these specific actions
+    if action in ('post_add', 'post_remove', 'post_clear'):
+        # Determine the church ID based on the instance type
+        church_id = None
+        
+        if isinstance(instance, Profile):
+            # This is a Profile instance, get its church ID
+            church_id = instance.church_id
+            print(f"Profile {instance.id} modified fasts, church_id: {church_id}")
+        else:
+            # This is a Fast instance, get its church ID
+            church_id = instance.church_id
+            print(f"Fast {instance.id} modified profiles, church_id: {church_id}")
+        
+        if church_id:
+            # Invalidate the participant count cache
+            cache.delete(f'church_{church_id}_participant_count')
+            print(f"Invalidated participant count cache for church {church_id}")
+            
+            # Also clear all cached querysets for this church
+            pattern = f'fast_list_qs:{church_id}:*'
+            # Note: If your cache backend doesn't support pattern matching, 
+            # this will need a different approach
+            keys = cache.keys(pattern) if hasattr(cache, 'keys') else []
+            if keys:
+                print(f"Clearing {len(keys)} cached querysets for church {church_id}")
+                cache.delete_many(keys)

--- a/hub/utils.py
+++ b/hub/utils.py
@@ -33,6 +33,10 @@ def invalidate_fast_participants_cache(fast_id):
         cache.delete_pattern(f"bahk:views.decorators.cache.cache_page.*fast.{fast_id}.participants.*")
         # Invalidate FastParticipantsView cache
         cache.delete_pattern(f"bahk:views.decorators.cache.cache_page.*{fast_id}/participants.*")
+        # Invalidate our new custom cache keys
+        cache.delete(f"bahk:fast_participants_view:{fast_id}")
+        cache.delete(f"bahk:fast_participants_simple_view:{fast_id}")
+        cache.delete(f"bahk:fast_participants_count:{fast_id}")
     else:
         # Fallback - less efficient
         cache.clear()

--- a/hub/views/devotionals.py
+++ b/hub/views/devotionals.py
@@ -50,6 +50,7 @@ class DevotionalByDateView(ChurchContextMixin, TimezoneMixin, generics.RetrieveA
 class DevotionalsByFastView(generics.ListAPIView):
     """
     API endpoint that provides a list of devotionals for a fast given its id.
+    Returns a maximum of 45 devotionals.
 
     URL Parameters:
         - fast_id: The ID of the fast for which to retrieve the participants.
@@ -63,7 +64,7 @@ class DevotionalsByFastView(generics.ListAPIView):
 
     def get_queryset(self):
         fast = Fast.objects.get(id=self.kwargs['fast_id'])
-        return Devotional.objects.filter(day__fast=fast)
+        return Devotional.objects.filter(day__fast=fast)[:45]  # Limit to 45 devotionals
 
 
 class DevotionalDetailView(generics.RetrieveAPIView):

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -16,10 +16,11 @@ from django.conf import settings
 from django.core.cache import cache
 from django.utils.encoding import force_str
 from django.shortcuts import get_object_or_404
-from django.db.models import Q
+from django.db.models import Q, Count, Min, Max, Sum
 from rest_framework.pagination import LimitOffsetPagination
 from ..utils import invalidate_fast_participants_cache
 from functools import wraps
+
 
 CACHE_TTL = getattr(settings, 'CACHE_MIDDLEWARE_SECONDS', 60 * 15)  # 15 minutes default
 
@@ -27,8 +28,6 @@ def get_cache_key(prefix, *args):
     """Generate a cache key with the given prefix and arguments."""
     return f"bahk:{prefix}:{'_'.join(force_str(arg) for arg in args)}"
 
-@method_decorator(cache_page(CACHE_TTL), name='dispatch')
-@method_decorator(vary_on_headers('Authorization'), name='dispatch')
 class FastListView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
     """
     API view to list all fasts for a specific church within a configurable date range.
@@ -60,6 +59,34 @@ class FastListView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
     permission_classes = [permissions.AllowAny]
     pagination_class = None
 
+    def get_church_participant_count(self, church_id):
+        """Get the total number of participants across all fasts for this church."""
+        count_key = f'church_{church_id}_participant_count'
+        count = cache.get(count_key)
+        
+        if count is None:
+            # Calculate the sum of participants across all fasts for this church
+            count = Fast.objects.filter(
+                church_id=church_id
+            ).annotate(
+                participant_count=Count('profiles', distinct=True)
+            ).aggregate(
+                total=Sum('participant_count')
+            )['total'] or 0
+            
+            # Cache this count for 10 minutes
+            cache.set(count_key, count, timeout=600)
+            
+        return count
+
+    def get_cache_key(self, church_id, start_date, end_date, tz):
+        """Generate a cache key that includes the participant count."""
+        # Get current participant count
+        participant_count = self.get_church_participant_count(church_id)
+        
+        # Include the count in the cache key
+        return f'fast_list_qs:{church_id}:{start_date}:{end_date}:{tz}:{participant_count}'
+
     def get_queryset(self):
         church = self.get_church()
         tz = self.get_timezone()
@@ -69,6 +96,7 @@ class FastListView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
         default_start = today - datetime.timedelta(days=180)
         default_end = today + datetime.timedelta(days=180)
 
+        # Parse date strings properly
         start_date = default_start
         end_date = default_end
 
@@ -87,8 +115,31 @@ class FastListView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
             except ValueError:
                 pass
 
-        # Optimize queryset with select_related and prefetch_related
-        return Fast.objects.filter(
+        # Generate cache key
+        cache_key = self.get_cache_key(
+            church.id,
+            start_date.isoformat(),
+            end_date.isoformat(),
+            str(tz)
+        )
+
+        # Try to get from cache
+        cached_queryset = cache.get(cache_key)
+        if cached_queryset is not None:
+            return cached_queryset
+
+        # If not in cache, generate queryset
+        queryset = Fast.objects.annotate(
+            participant_count=Count('profiles', distinct=True),
+            total_days=Count('days', distinct=True),
+            start_date=Min('days__date'),
+            end_date=Max('days__date'),
+            current_day_count=Count(
+                'days',
+                filter=Q(days__date__lte=today),
+                distinct=True
+            )
+        ).filter(
             church=church,
             days__date__gte=start_date,
             days__date__lte=end_date
@@ -98,6 +149,21 @@ class FastListView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
             'days',
             'profiles'
         ).distinct()
+
+        # Cache the queryset for 10 minutes
+        cache.set(cache_key, queryset, timeout=600)  # 10 minutes
+        return queryset
+
+    def invalidate_cache(self, church_id):
+        """Invalidate all cached lists for a given church."""
+        # Invalidate the participant count cache
+        cache.delete(f'church_{church_id}_participant_count')
+        
+        # Then find and delete any queryset caches
+        pattern = f'fast_list_qs:{church_id}:*'
+        keys = cache.keys(pattern)
+        if keys:
+            cache.delete_many(keys)
 
 
 @method_decorator(vary_on_headers('Authorization'), name='dispatch')
@@ -217,7 +283,17 @@ class FastByDateView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
             target_date = timezone.localdate(timezone=tz)
 
         # Optimize queryset with select_related and prefetch_related
-        queryset = Fast.objects.filter(
+        queryset = Fast.objects.annotate(
+            participant_count=Count('profiles', distinct=True),
+            total_days=Count('days', distinct=True),
+            start_date=Min('days__date'),
+            end_date=Max('days__date'),
+            current_day_count=Count(
+                'days',
+                filter=Q(days__date__lte=target_date),
+                distinct=True
+            )
+        ).filter(
             church=church,
             days__date=target_date
         ).select_related(

--- a/tests/test_fast_endpoints.py
+++ b/tests/test_fast_endpoints.py
@@ -1,0 +1,271 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient, APITestCase
+from rest_framework import status
+from hub.models import Fast, Church, Profile, Day
+from datetime import datetime, timedelta
+import time
+import json
+import pytz
+
+User = get_user_model()
+
+class FastEndpointTests(APITestCase):
+    """Test the core fast endpoints for functionality and performance."""
+    
+    def setUp(self):
+        """Set up test data needed for all test methods."""
+        # Create a test church (only has name field)
+        self.church = Church.objects.create(
+            name="Test Church"
+        )
+        
+        # Create test users
+        self.user1 = User.objects.create_user(
+            username="testuser1",
+            email="test1@example.com",
+            password="testpassword"
+        )
+        self.user2 = User.objects.create_user(
+            username="testuser2", 
+            email="test2@example.com", 
+            password="testpassword"
+        )
+        
+        # Create profiles for the users explicitly
+        self.profile1 = Profile.objects.create(
+            user=self.user1,
+            church=self.church
+        )
+        
+        self.profile2 = Profile.objects.create(
+            user=self.user2,
+            church=self.church
+        )
+        
+        # Create a test fast with days
+        today = datetime.now().date()
+        self.fast = Fast.objects.create(
+            name="Test Fast",
+            description="A test fast",
+            church=self.church
+        )
+        
+        # Create days for the fast (past, present, future)
+        # The Day model only has date, fast, and church fields
+        for i in range(-2, 3):  # 5 days from 2 days ago to 2 days from now
+            day_date = today + timedelta(days=i)
+            Day.objects.create(
+                fast=self.fast,
+                date=day_date,
+                church=self.church  # Add church reference
+            )
+        
+        # Create client for authenticated requests
+        self.client = APIClient()
+        
+        # URLs we'll test
+        self.fasts_list_url = reverse('fast-list')
+        self.fast_detail_url = reverse('fast-detail', kwargs={'pk': self.fast.id})
+        self.fast_by_date_url = reverse('fast-by-date')
+        self.fast_join_url = reverse('fast-join')
+        self.fast_leave_url = reverse('leave-fast')
+        self.fast_participants_url = reverse('fast-participants', kwargs={'fast_id': self.fast.id})
+        self.fast_stats_url = reverse('fast-stats')
+    
+    def test_fast_list_returns_200(self):
+        """Test that the fast listing endpoint returns 200 OK."""
+        # Add church_id as required parameter
+        url = f"{self.fasts_list_url}?church_id={self.church.id}"
+        
+        # Get response time for unauthenticated request
+        start_time = time.time()
+        response = self.client.get(url)
+        end_time = time.time()
+        
+        # Check response status
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Verify response structure
+        self.assertIsInstance(response.data, list)
+        self.assertTrue(len(response.data) > 0)
+        self.assertEqual(response.data[0]['name'], self.fast.name)
+        
+        # Check response time (should be under 300ms)
+        response_time = end_time - start_time
+        self.assertLess(response_time, 0.3, f"Fast list endpoint too slow: {response_time:.3f}s")
+        
+        # Log the performance for review
+        print(f"Fast list endpoint response time: {response_time:.3f}s")
+    
+    def test_fast_detail_returns_correct_data(self):
+        """Test that the fast detail endpoint returns correct data."""
+        start_time = time.time()
+        response = self.client.get(self.fast_detail_url)
+        end_time = time.time()
+        
+        # Check status
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Verify data content - adjust to match actual response structure
+        self.assertEqual(response.data['id'], self.fast.id)
+        self.assertEqual(response.data['name'], self.fast.name)
+        self.assertEqual(response.data['description'], self.fast.description)
+        # Check for expected fields based on the actual response
+        self.assertIn('start_date', response.data)
+        self.assertIn('end_date', response.data)
+        self.assertIn('total_number_of_days', response.data)
+        self.assertEqual(response.data['total_number_of_days'], 5)  # 5 days we created
+        
+        # Check response time (should be under 300ms)
+        response_time = end_time - start_time
+        self.assertLess(response_time, 0.3, f"Fast detail endpoint too slow: {response_time:.3f}s")
+        print(f"Fast detail endpoint response time: {response_time:.3f}s")
+    
+    def test_fast_by_date_returns_correct_data(self):
+        """Test that the fast-by-date endpoint returns appropriate fasts."""
+        today = datetime.now().date()
+        # Add church_id parameter which is required
+        url = f"{self.fast_by_date_url}?date={today.isoformat()}&church_id={self.church.id}"
+        
+        start_time = time.time()
+        response = self.client.get(url)
+        end_time = time.time()
+        
+        # Check status
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # The response is paginated with 'results' containing the list of fasts
+        self.assertIn('results', response.data)
+        self.assertIsInstance(response.data['results'], list)
+        self.assertTrue(len(response.data['results']) > 0)
+        
+        # Our test fast should be in the results list since it spans today
+        found = False
+        for fast in response.data['results']:
+            if fast['id'] == self.fast.id:
+                found = True
+                break
+        self.assertTrue(found, "Expected fast not found in response")
+        
+        # Check response time
+        response_time = end_time - start_time
+        self.assertLess(response_time, 0.3, f"Fast by date endpoint too slow: {response_time:.3f}s")
+        print(f"Fast by date endpoint response time: {response_time:.3f}s")
+    
+    def test_join_and_leave_fast(self):
+        """Test joining and leaving a fast."""
+        self.client.force_authenticate(user=self.user1)
+        
+        # Join the fast
+        join_data = {"fast_id": self.fast.id}
+        start_time = time.time()
+        join_response = self.client.put(self.fast_join_url, join_data)
+        join_time = time.time() - start_time
+        
+        # Check status and that the fast was joined
+        self.assertEqual(join_response.status_code, status.HTTP_200_OK)
+        self.profile1.refresh_from_db()
+        self.assertIn(self.fast, self.profile1.fasts.all())
+        self.assertLess(join_time, 0.5, f"Join fast endpoint too slow: {join_time:.3f}s")
+        
+        # Leave the fast
+        leave_data = {"fast_id": self.fast.id}
+        start_time = time.time()
+        leave_response = self.client.put(self.fast_leave_url, leave_data)
+        leave_time = time.time() - start_time
+        
+        # Check status and that the fast was left
+        self.assertEqual(leave_response.status_code, status.HTTP_200_OK)
+        self.profile1.refresh_from_db()
+        self.assertNotIn(self.fast, self.profile1.fasts.all())
+        self.assertLess(leave_time, 0.5, f"Leave fast endpoint too slow: {leave_time:.3f}s")
+        
+        print(f"Join fast endpoint response time: {join_time:.3f}s")
+        print(f"Leave fast endpoint response time: {leave_time:.3f}s")
+    
+    def test_fast_participants_endpoint(self):
+        """Test the fast participants endpoint."""
+        # First join the fast with user1
+        self.profile1.fasts.add(self.fast)
+        self.profile1.save()
+        
+        # Authenticate as user2
+        self.client.force_authenticate(user=self.user2)
+        
+        # Get participants
+        start_time = time.time()
+        response = self.client.get(self.fast_participants_url)
+        end_time = time.time()
+        
+        # Check status and data
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data, list)
+        self.assertEqual(len(response.data), 1)  # Should have 1 participant (user1)
+        
+        # Based on the observed response structure, check specific fields
+        participant = response.data[0]
+        self.assertIn('id', participant)
+        self.assertIn('user', participant)  # The username value is in the 'user' field
+        self.assertEqual(participant['id'], self.profile1.id)
+        
+        # Check response time
+        response_time = end_time - start_time
+        self.assertLess(response_time, 0.3, f"Fast participants endpoint too slow: {response_time:.3f}s")
+        print(f"Fast participants endpoint response time: {response_time:.3f}s")
+    
+    def test_fast_stats_endpoint(self):
+        """Test the fast stats endpoint."""
+        # First join the fast with user1
+        self.profile1.fasts.add(self.fast)
+        self.profile1.save()
+        
+        # Authenticate as user1
+        self.client.force_authenticate(user=self.user1)
+        
+        # Get stats
+        start_time = time.time()
+        response = self.client.get(self.fast_stats_url)
+        end_time = time.time()
+        
+        # Check status and data - adjust fields to match actual response
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Based on the error, the response structure is different
+        # The API returns 'joined_fasts' instead of 'fast_ids'
+        self.assertIn('joined_fasts', response.data)
+        self.assertIn('total_fasts', response.data)
+        self.assertIn('total_fast_days', response.data)  # Field name is different
+        self.assertEqual(response.data['total_fasts'], 1)
+        
+        # Check response time
+        response_time = end_time - start_time
+        self.assertLess(response_time, 0.3, f"Fast stats endpoint too slow: {response_time:.3f}s")
+        print(f"Fast stats endpoint response time: {response_time:.3f}s")
+    
+    def test_endpoints_under_load(self):
+        """Test endpoints performance under sequential requests."""
+        num_requests = 5
+        # Add required query parameters to URLs
+        endpoints = [
+            f"{self.fasts_list_url}?church_id={self.church.id}",
+            self.fast_detail_url,
+            f"{self.fast_by_date_url}?date={datetime.now().date().isoformat()}&church_id={self.church.id}"
+        ]
+        
+        print("\nEndpoint performance under load:")
+        
+        for endpoint in endpoints:
+            total_time = 0
+            for i in range(num_requests):
+                start_time = time.time()
+                response = self.client.get(endpoint)
+                request_time = time.time() - start_time
+                total_time += request_time
+                
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+            
+            avg_time = total_time / num_requests
+            print(f"Endpoint {endpoint}: avg response time over {num_requests} requests: {avg_time:.3f}s")
+            self.assertLess(avg_time, 0.3, f"Endpoint {endpoint} too slow under load: {avg_time:.3f}s") 

--- a/tests/test_participant_lists.py
+++ b/tests/test_participant_lists.py
@@ -1,0 +1,249 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient, APITestCase
+from rest_framework import status
+from hub.models import Fast, Church, Profile, Day
+from datetime import datetime, timedelta
+import time
+import json
+import pytz
+
+User = get_user_model()
+
+class FastParticipantListTests(APITestCase):
+    """Tests specifically focused on Fast participant list functionality."""
+
+    def setUp(self):
+        """Set up test data needed for all test methods."""
+        # Create a test church
+        self.church = Church.objects.create(
+            name="Test Church"
+        )
+        
+        # Create a test fast with days
+        today = datetime.now().date()
+        self.fast = Fast.objects.create(
+            name="Test Fast",
+            description="A test fast",
+            church=self.church
+        )
+        
+        # Create days for the fast (5 days spanning today)
+        for i in range(-2, 3):  # 5 days from 2 days ago to 2 days from now
+            day_date = today + timedelta(days=i)
+            Day.objects.create(
+                fast=self.fast,
+                date=day_date,
+                church=self.church
+            )
+        
+        # Create multiple users and profiles for testing pagination
+        self.users = []
+        self.profiles = []
+        
+        # Create 25 test users
+        for i in range(25):
+            user = User.objects.create_user(
+                username=f"testuser{i}",
+                email=f"test{i}@example.com",
+                password="testpassword"
+            )
+            self.users.append(user)
+            
+            profile = Profile.objects.create(
+                user=user,
+                church=self.church,
+                name=f"Test User {i}"  # Add a name to match the serializer
+            )
+            self.profiles.append(profile)
+        
+        # Make the first 20 users participants in the fast
+        for i in range(20):
+            self.profiles[i].fasts.add(self.fast)
+            self.profiles[i].save()
+        
+        # URL to test
+        self.regular_participants_url = reverse('fast-participants', kwargs={'fast_id': self.fast.id})
+        self.paginated_participants_url = reverse('fast-participants-paginated', kwargs={'fast_id': self.fast.id})
+    
+    def test_regular_participants_endpoint_requires_auth(self):
+        """Test that the regular participants endpoint requires authentication."""
+        # Create an unauthenticated client
+        client = APIClient()
+        
+        # Try to access the endpoint without authentication
+        response = client.get(self.regular_participants_url)
+        
+        # Should get 401 Unauthorized
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+    
+    def test_regular_participants_endpoint(self):
+        """Test that the regular participants endpoint works with authentication."""
+        # Create authenticated client
+        client = APIClient()
+        client.force_authenticate(user=self.users[0])
+        
+        start_time = time.time()
+        response = client.get(self.regular_participants_url)
+        end_time = time.time()
+        
+        # Check status
+        self.assertEqual(response.status_code, status.HTTP_200_OK, 
+                         f"Failed with response data: {response.data}")
+        
+        # Check data
+        self.assertIsInstance(response.data, list)
+        
+        # From looking at the serializer, we know that the ParticipantSerializer
+        # includes: id, name, profile_image, thumbnail, location, abbreviation, user
+        for participant in response.data:
+            self.assertIn('id', participant)
+            self.assertIn('name', participant)
+            self.assertIn('user', participant)
+            self.assertIn('abbreviation', participant)
+            
+            # Check abbreviation logic - if name is None, abbreviation will likely be 'u'
+            # (first letter of username or default value)
+            if participant['name']:
+                self.assertEqual(participant['abbreviation'], participant['name'][0])
+                
+            # The user field will be set even if name is None
+            self.assertIsNotNone(participant['user'])
+        
+        # Check performance
+        response_time = end_time - start_time
+        self.assertLess(response_time, 0.3, f"Regular participants endpoint too slow: {response_time:.3f}s")
+        print(f"Regular participants endpoint response time: {response_time:.3f}s")
+    
+    def test_regular_participants_limit(self):
+        """Test that the regular participants endpoint respects the limit parameter."""
+        # Create authenticated client
+        client = APIClient()
+        client.force_authenticate(user=self.users[0])
+        
+        # Based on the implementation it should respect a limit parameter
+        response = client.get(f"{self.regular_participants_url}?limit=5")
+        
+        # Should return only 5 participants
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+    
+    def test_participants_ordered_by_join_date(self):
+        """Test that participants are ordered by join date (simulated by user creation date)."""
+        # Create authenticated client
+        client = APIClient()
+        client.force_authenticate(user=self.users[0])
+        
+        # Our test setup adds users in order, so the first users should appear first
+        response = client.get(self.regular_participants_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Get the profile IDs in the order they appear in the response
+        participant_ids = [p['id'] for p in response.data]
+        
+        # Our test added profiles 0-19 to the fast in order
+        # The exact order may depend on the API implementation (might be ascending or descending)
+        # So we just check that the IDs of participants that joined are present
+        for i in range(min(len(participant_ids), 20)):
+            self.assertIn(self.profiles[i].id, participant_ids)
+    
+    def test_paginated_participants_endpoint(self):
+        """Test the paginated participants endpoint."""
+        # Create authenticated client
+        client = APIClient()
+        client.force_authenticate(user=self.users[0])
+        
+        start_time = time.time()
+        response = client.get(self.paginated_participants_url)
+        end_time = time.time()
+        
+        # Check status
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Check paginated structure
+        self.assertIn('count', response.data)
+        self.assertIn('results', response.data)
+        self.assertEqual(response.data['count'], 20)  # We added 20 participants
+        
+        # Check data in results
+        participants = response.data['results']
+        self.assertTrue(len(participants) > 0)
+        
+        # Verify response contains expected fields
+        participant = participants[0]
+        self.assertIn('id', participant)
+        self.assertIn('name', participant)
+        self.assertIn('user', participant)
+        self.assertIn('abbreviation', participant)
+        
+        # Check response time
+        response_time = end_time - start_time
+        self.assertLess(response_time, 0.3, f"Paginated participants endpoint too slow: {response_time:.3f}s")
+        print(f"Paginated participants endpoint response time: {response_time:.3f}s")
+    
+    def test_pagination_works_correctly(self):
+        """Test that pagination returns correct pages of results."""
+        # Create authenticated client
+        client = APIClient()
+        client.force_authenticate(user=self.users[0])
+        
+        # Get first page with 10 items
+        response = client.get(f"{self.paginated_participants_url}?limit=10")
+        
+        # Check status and count
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 20)  # Total should be 20
+        
+        # First page should have 10 results
+        first_page = response.data['results']
+        self.assertEqual(len(first_page), 10)
+        
+        # Get second page
+        response = client.get(f"{self.paginated_participants_url}?limit=10&offset=10")
+        
+        # Second page should also have 10 results
+        second_page = response.data['results']
+        self.assertEqual(len(second_page), 10)
+        
+        # Ensure first and second page items are different
+        first_page_ids = [p['id'] for p in first_page]
+        second_page_ids = [p['id'] for p in second_page]
+        
+        # No overlapping IDs between pages
+        self.assertEqual(len(set(first_page_ids).intersection(set(second_page_ids))), 0)
+    
+    def test_pagination_empty_result(self):
+        """Test pagination with offset beyond available results."""
+        # Create authenticated client
+        client = APIClient()
+        client.force_authenticate(user=self.users[0])
+        
+        response = client.get(f"{self.paginated_participants_url}?offset=50")
+        
+        # Should still return 200 but with empty results
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 20)  # Total should be 20
+        self.assertEqual(len(response.data['results']), 0)  # But no results for this page
+    
+    def test_performance_with_different_page_sizes(self):
+        """Test performance with different page sizes."""
+        # Create authenticated client
+        client = APIClient()
+        client.force_authenticate(user=self.users[0])
+        
+        page_sizes = [5, 10, 20]
+        
+        print("\nParticipant list performance with different page sizes:")
+        
+        for size in page_sizes:
+            start_time = time.time()
+            response = client.get(f"{self.paginated_participants_url}?limit={size}")
+            end_time = time.time()
+            
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(len(response.data['results']), min(size, 20))  # Can't get more results than exist
+            
+            response_time = end_time - start_time
+            print(f"Page size {size}: {response_time:.3f}s")
+            self.assertLess(response_time, 0.3, f"Slow response for page size {size}: {response_time:.3f}s") 


### PR DESCRIPTION
This pull request includes several significant updates to caching, serializers, and deployment configurations. The most important changes are grouped into improvements to caching, enhancements to serializers, and updates to deployment configurations.

### Improvements to Caching:

* [`hub/views/fast.py`](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R62-R89): Implemented caching for the participant count and queryset in `FastListView`, including methods for generating cache keys and invalidating caches. [[1]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R62-R89) [[2]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R99) [[3]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6L90-R142) [[4]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6R153-R167)
* [`hub/signals.py`](diffhunk://#diff-434c60b12831285b04d9bc90e90b23a4e4b49387667a9948ea0a2583053d9fedR1-R41): Added a signal handler to invalidate the cache when participants join or leave fasts.
* [`hub/utils.py`](diffhunk://#diff-5d35a4833faf54a70cb9e69cb7829f6cb0767b72b54a3fd92e484fd9042224d2R36-R39): Updated the cache invalidation logic to include new custom cache keys.

### Enhancements to Serializers:

* [`hub/serializers.py`](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9R186-R205): Optimized `FastSerializer` by caching the current date and using annotated values where possible to reduce redundant calculations and database queries. [[1]](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9R186-R205) [[2]](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9L215-L265) [[3]](diffhunk://#diff-34675984cc3ff1f16208a40a1233ccbedd040c499f99c8816959cfc4eb0d05d9L298-R311)

### Updates to Deployment Configurations:

* [`app.json`](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5L42-R42): Modified the `postdeploy` script to create a superuser and updated the test setup to run Django tests with the `--keepdb` flag. Added `heroku-postgresql:in-dyno` addon. [[1]](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5L42-R42) [[2]](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5L54-R59)

### Additional Changes:

* [`hub/apps.py`](diffhunk://#diff-c0508adc935957c74ed5614d6c66bf9240c4b9897b9f758823ab3c36afb35951R7-R14): Added a `ready` method to `HubConfig` to register signals when the app is ready.
* [`hub/models.py`](diffhunk://#diff-2e0cf63c3374e524fb024d4540dac9f4f555a8db27d993f35e84595c31495d0aR114-R124): Updated the `save` and `delete` methods to invalidate the cache for the fast list.
* [`bahk/settings.py`](diffhunk://#diff-3d7c9cff5931eeecbd6f03cd21ba54a22514e216bf6492fa57b0502e6b9d52d9R214): Conditional activation of Django-Heroku settings based on the `CI` environment variable.
* [`bahk/urls.py`](diffhunk://#diff-1b72401d874ccb1d5de01216a24019df04431d261fc59f6e476183616fe1bc02L65-L69): Removed redundant URL patterns for `s3_file_field`.
* [`hub/views/devotionals.py`](diffhunk://#diff-0d6d1af37746ffe24a93b0eb3f7e4faf961030f0c031d643970ee9acbf470afcR53): Limited the number of devotionals returned by `DevotionalsByFastView` to 45. [[1]](diffhunk://#diff-0d6d1af37746ffe24a93b0eb3f7e4faf961030f0c031d643970ee9acbf470afcR53) [[2]](diffhunk://#diff-0d6d1af37746ffe24a93b0eb3f7e4faf961030f0c031d643970ee9acbf470afcL66-R67)