### PR TITLE
Bugfix/avoid duplicate device token errors

### DIFF
--- a/notifications/tests.py
+++ b/notifications/tests.py
@@ -1,3 +1,210 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase, APIClient
+from rest_framework import status
+from unittest.mock import patch, MagicMock
+from .models import DeviceToken
+from .views import DeviceTokenCreateView, TestPushNotificationView
+import json
 
-# Create your tests here.
+class DeviceTokenTests(APITestCase):
+    def setUp(self):
+        # Create a test user
+        self.user = User.objects.create_user(
+            username='testuser',
+            email='test@example.com',
+            password='testpass123'
+        )
+        
+        # Set up the client
+        self.client = APIClient()
+        
+        # Define valid token data
+        self.valid_token_data = {
+            'token': 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxx]',
+            'device_type': 'ios',
+            'user': self.user.id
+        }
+        
+        # Define test URLs with the correct URL names
+        self.create_token_url = reverse('register-device-token')
+        self.test_push_url = reverse('test-push-notification')
+    
+    def test_create_token(self):
+        """Test creating a new device token"""
+        response = self.client.post(
+            self.create_token_url,
+            self.valid_token_data,
+            format='json'
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(DeviceToken.objects.count(), 1)
+        self.assertEqual(DeviceToken.objects.get().token, self.valid_token_data['token'])
+    
+    def test_update_existing_token(self):
+        """Test updating an existing token (upsert behavior)"""
+        # First create a token
+        DeviceToken.objects.create(
+            token=self.valid_token_data['token'],
+            device_type='android',  # Different from what we'll update to
+            user=self.user
+        )
+        
+        # Now try to create the same token but with different device_type
+        update_data = self.valid_token_data.copy()
+        update_data['device_type'] = 'ios'
+        
+        response = self.client.post(
+            self.create_token_url,
+            update_data,
+            format='json'
+        )
+        
+        # Should be a 200 OK response, not 201 Created
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Should still be only one token
+        self.assertEqual(DeviceToken.objects.count(), 1)
+        
+        # Device type should be updated
+        token = DeviceToken.objects.get()
+        self.assertEqual(token.device_type, 'ios')
+    
+    def test_create_token_invalid_data(self):
+        """Test creating a token with invalid data"""
+        invalid_data = {
+            'token': 'invalid-token-format',  # Should be in the format ExponentPushToken[xxx]
+            'device_type': 'ios',
+            'user': self.user.id
+        }
+        
+        response = self.client.post(
+            self.create_token_url,
+            invalid_data,
+            format='json'
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(DeviceToken.objects.count(), 0)
+    
+    def test_create_token_invalid_device_type(self):
+        """Test creating a token with invalid device type"""
+        invalid_type_data = self.valid_token_data.copy()
+        invalid_type_data['device_type'] = 'windows'  # Not in the valid choices
+        
+        response = self.client.post(
+            self.create_token_url,
+            invalid_type_data,
+            format='json'
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(DeviceToken.objects.count(), 0)
+
+
+class TestPushNotificationTests(APITestCase):
+    def setUp(self):
+        # Create a test user
+        self.user = User.objects.create_user(
+            username='testuser',
+            email='test@example.com',
+            password='testpass123'
+        )
+        
+        # Create a test token
+        self.token = DeviceToken.objects.create(
+            token='ExponentPushToken[xxxxxxxxxxxxxxxxxxxx]',
+            device_type='ios',
+            user=self.user,
+            is_active=True
+        )
+        
+        # Set up the client
+        self.client = APIClient()
+        
+        # Define test URL with the correct URL name
+        self.test_push_url = reverse('test-push-notification')
+    
+    @patch('notifications.views.send_push_notification')
+    def test_push_notification_success(self, mock_send_push):
+        """Test sending a push notification successfully"""
+        # Configure the mock to return a success response
+        mock_send_push.return_value = {
+            'success': True,
+            'sent': 1,
+            'failed': 0,
+            'invalid_tokens': [],
+            'errors': []
+        }
+        
+        data = {
+            'token': self.token.token,
+            'message': 'Test message'
+        }
+        
+        response = self.client.post(
+            self.test_push_url,
+            data,
+            format='json'
+        )
+        
+        # Verify the response and that the mock was called correctly
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['success'], True)
+        mock_send_push.assert_called_once_with(
+            message='Test message',
+            tokens=[self.token.token]
+        )
+    
+    @patch('notifications.views.send_push_notification')
+    def test_push_notification_no_token(self, mock_send_push):
+        """Test sending a push notification without a token"""
+        # The mock should not be called in this test
+        
+        data = {
+            'message': 'Test message'
+            # No token provided
+        }
+        
+        response = self.client.post(
+            self.test_push_url,
+            data,
+            format='json'
+        )
+        
+        # Verify the response and that the mock was not called
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['error'], 'Token is required')
+        mock_send_push.assert_not_called()
+    
+    @patch('notifications.views.send_push_notification')
+    def test_push_notification_default_message(self, mock_send_push):
+        """Test sending a push notification with default message"""
+        # Configure the mock to return a success response
+        mock_send_push.return_value = {
+            'success': True,
+            'sent': 1,
+            'failed': 0,
+            'invalid_tokens': [],
+            'errors': []
+        }
+        
+        data = {
+            'token': self.token.token
+            # No message provided, should use default
+        }
+        
+        response = self.client.post(
+            self.test_push_url,
+            data,
+            format='json'
+        )
+        
+        # Verify the response and that the mock was called with the default message
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_send_push.assert_called_once_with(
+            message='Test notification',  # Default message from the view
+            tokens=[self.token.token]
+        )

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -6,6 +6,7 @@ from .models import DeviceToken
 from .serializers import DeviceTokenSerializer
 from .utils import send_push_notification
 import logging
+from django.core.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -17,10 +18,32 @@ class DeviceTokenCreateView(generics.CreateAPIView):
 
     def create(self, request, *args, **kwargs):
         logger.info(f"Received request data: {request.data}")
-        return super().create(request, *args, **kwargs)
+        # Try to get existing token
+        try:
+            instance = DeviceToken.objects.get(token=request.data.get('token'))
+            serializer = self.get_serializer(instance, data=request.data)
+            serializer.is_valid(raise_exception=True)
+            self.perform_update(serializer)
+            return Response(serializer.data)
+        except DeviceToken.DoesNotExist:
+            # If it doesn't exist, create new one (with validation error handling)
+            serializer = self.get_serializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            try:
+                self.perform_create(serializer)
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            except ValidationError as e:
+                return Response(
+                    {'error': str(e)},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
 
     def perform_create(self, serializer):
-        logger.info(f"Saving device token with data: {serializer.validated_data}")
+        logger.info(f"Creating new device token with data: {serializer.validated_data}")
+        serializer.save()
+
+    def perform_update(self, serializer):
+        logger.info(f"Updating existing device token with data: {serializer.validated_data}")
         serializer.save()
 
 class TestPushNotificationView(APIView):

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -18,33 +18,65 @@ class DeviceTokenCreateView(generics.CreateAPIView):
 
     def create(self, request, *args, **kwargs):
         logger.info(f"Received request data: {request.data}")
-        # Try to get existing token
+        token_value = request.data.get('token')
+        
+        # Validate request has necessary data
+        if not token_value:
+            return Response(
+                {'error': 'Token is required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+            
+        # Check if token already exists
+        existing_token = None
         try:
-            instance = DeviceToken.objects.get(token=request.data.get('token'))
-            serializer = self.get_serializer(instance, data=request.data)
-            serializer.is_valid(raise_exception=True)
-            self.perform_update(serializer)
-            return Response(serializer.data)
+            existing_token = DeviceToken.objects.get(token=token_value)
         except DeviceToken.DoesNotExist:
-            # If it doesn't exist, create new one (with validation error handling)
-            serializer = self.get_serializer(data=request.data)
-            serializer.is_valid(raise_exception=True)
-            try:
-                self.perform_create(serializer)
-                return Response(serializer.data, status=status.HTTP_201_CREATED)
-            except ValidationError as e:
+            pass
+            
+        if existing_token:
+            # Handle token update case
+            
+            # Check if the user is authorized to update this token
+            if existing_token.user and existing_token.user.id != request.data.get('user'):
                 return Response(
-                    {'error': str(e)},
-                    status=status.HTTP_400_BAD_REQUEST
+                    {'error': 'Not authorized to update this device token'},
+                    status=status.HTTP_403_FORBIDDEN
                 )
-
-    def perform_create(self, serializer):
-        logger.info(f"Creating new device token with data: {serializer.validated_data}")
-        serializer.save()
-
-    def perform_update(self, serializer):
-        logger.info(f"Updating existing device token with data: {serializer.validated_data}")
-        serializer.save()
+                
+            serializer = self.get_serializer(existing_token, data=request.data)
+            operation = "update"
+        else:
+            # Handle token creation case
+            serializer = self.get_serializer(data=request.data)
+            operation = "create"
+            
+        # Validate the data through serializer
+        if not serializer.is_valid():
+            return Response(
+                serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+            
+        # Try to save the token
+        try:
+            if operation == "create":
+                logger.info(f"Creating new device token with data: {serializer.validated_data}")
+                serializer.save()
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            else:
+                logger.info(f"Updating existing device token with data: {serializer.validated_data}")
+                serializer.save()
+                return Response(serializer.data)
+        except ValidationError as e:
+            # Handle model-level validation errors
+            error_message = str(e)
+            if isinstance(e.message_dict, dict):
+                error_message = e.message_dict
+            return Response(
+                {'error': error_message},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
 class TestPushNotificationView(APIView):
     def post(self, request):


### PR DESCRIPTION
This pull request introduces comprehensive tests for the `DeviceToken` and `TestPushNotification` functionalities, along with improvements to the `DeviceTokenCreateView` to handle token creation and updates more robustly.

### New Tests for DeviceToken and Push Notifications:
* [`notifications/tests.py`](diffhunk://#diff-b9e8bb5a605dcfb1c42ccdf6e100dd6ba92a59b6a815256a485084a0106e7902R2-R246): Added a suite of tests for `DeviceToken` creation, updating, and validation, as well as tests for sending push notifications, ensuring proper handling of different scenarios.

### Improvements to DeviceTokenCreateView:
* [`notifications/views.py`](diffhunk://#diff-e6be1db0d83439038e771c63c36a18aabcb14b34d945f7b0abff80c93f6ab72aL20-R79): Enhanced `DeviceTokenCreateView` to handle both creation and updating of device tokens, including validation and authorization checks. Added logging for better traceability.

### Additional Imports:
* [`notifications/views.py`](diffhunk://#diff-e6be1db0d83439038e771c63c36a18aabcb14b34d945f7b0abff80c93f6ab72aR9): Added import for `ValidationError` to handle model-level validation errors in the view.