### PR TITLE
Mattash/promo email bugfix

### DIFF
--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -455,4 +455,25 @@ class PromoEmailAdmin(admin.ModelAdmin):
             messages.success(request, f"Started sending '{promo.title}' to {promo.recipient_count()} recipients")
     send_now.short_description = "Send selected emails now"
     
-    actions = ['send_now']
+    def replicate_promo_emails(self, request, queryset):
+        """Action for replicating selected promo emails."""
+        for promo in queryset:
+            # Copy selected users list
+            users = list(promo.selected_users.all())
+            # Create a new PromoEmail draft with same properties
+            new_promo = PromoEmail.objects.create(
+                title=f"Copy of {promo.title}",
+                subject=promo.subject,
+                content_html=promo.content_html,
+                content_text=promo.content_text,
+                all_users=promo.all_users,
+                church_filter=promo.church_filter,
+                joined_fast=promo.joined_fast,
+                exclude_unsubscribed=promo.exclude_unsubscribed,
+            )
+            # Copy many-to-many selected users
+            new_promo.selected_users.set(users)
+        messages.success(request, f"Successfully replicated {queryset.count()} promo email(s).")
+    replicate_promo_emails.short_description = "Replicate selected promo emails"
+
+    actions = ['send_now', 'replicate_promo_emails']

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -102,7 +102,7 @@ def send_promo_email_task(self, promo_id, remaining_user_ids=None):
                     )
                     # Get remaining user IDs
                     remaining_user_ids = list(users.values_list('id', flat=True))[current_count:]
-                    if remaining_user_ids and not settings.CELERY_TASK_ALWAYS_EAGER:
+                    if remaining_user_ids and not getattr(settings, 'CELERY_TASK_ALWAYS_EAGER', False):
                         # Schedule the next batch automatically in non-eager mode
                         send_promo_email_task.apply_async(
                             args=[promo_id],


### PR DESCRIPTION
This pull request introduces a new admin action for replicating promotional emails, improves code robustness by using safer settings access, and adds a corresponding test to ensure the functionality works as expected. Below is a summary of the most important changes:

### New Feature: Promo Email Replication

* Added a new admin action `replicate_promo_emails` in `notifications/admin.py` to allow replication of selected promotional emails. This action creates a copy of the selected emails, including their properties and associated users. (`[notifications/admin.pyL458-R479](diffhunk://#diff-9224dd7ab04fa8adbc87ef425cfcf4797da15c50c170c5b060292074f4b10259L458-R479)`)

### Code Robustness

* Modified `notifications/tasks.py` to use `getattr` for accessing the `CELERY_TASK_ALWAYS_EAGER` setting, providing a default value of `False` for safer handling in case the setting is not defined. (`[notifications/tasks.pyL105-R105](diffhunk://#diff-e3ebb51888cfce5bc4b2fc128b7bd14f7cab4a7139b7a8bb5129dc419fe6b239L105-R105)`)

### Testing

* Added a new test `test_admin_replicate_action_replicates_selected_promos` in `notifications/tests/test_promo_email_admin.py` to verify that the `replicate_promo_emails` action correctly creates copies of selected promo emails with identical attributes and associated users. (`[notifications/tests/test_promo_email_admin.pyR305-R333](diffhunk://#diff-1003260418ec27ec45c538436ab855e6caa05eb877344a06ea63ec960542c68aR305-R333)`)