### PR TITLE
[add] implement email template tests and enhance password reset email functionality

### DIFF
--- a/hub/tests/test_email_templates.py
+++ b/hub/tests/test_email_templates.py
@@ -1,0 +1,83 @@
+from django.test import TestCase, override_settings
+from django.contrib.auth.models import User
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.conf import settings
+from django.contrib.staticfiles.storage import StaticFilesStorage
+from django.core.files.storage import FileSystemStorage
+
+class TestStaticFilesStorage(FileSystemStorage):
+    """Mock storage that returns a dummy URL for static files."""
+    def url(self, name):
+        return f'http://testserver/static/{name}'
+
+@override_settings(
+    SITE_URL='http://testserver',
+    FRONTEND_URL='http://testserver',
+    EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+    EMAIL_HOST_USER='test@example.com',
+    STATICFILES_STORAGE='hub.tests.test_email_templates.TestStaticFilesStorage',
+    STATIC_URL='/static/'
+)
+class EmailTemplateTests(TestCase):
+    def setUp(self):
+        """Set up test data."""
+        # Create test user
+        self.user = User.objects.create_user(
+            username='testuser',
+            email='test@example.com',
+            password='testpass123'
+        )
+        
+        # Base context for all email templates
+        self.base_context = {
+            'user': self.user,
+            'site_url': settings.SITE_URL,
+        }
+
+    def test_password_reset_email_template_renders(self):
+        """Test that the password reset email template renders correctly."""
+        # Create reset URL
+        reset_url = f"{settings.FRONTEND_URL}/reset-password/test-uid/test-token"
+        
+        # Add reset URL to context
+        context = {
+            **self.base_context,
+            'reset_url': reset_url,
+        }
+        
+        # Render template
+        rendered = render_to_string('email/password_reset.html', context)
+        
+        # Check basic content
+        self.assertIn('Password Reset', rendered)
+        self.assertIn(self.user.username, rendered)
+        self.assertIn(reset_url, rendered)
+        self.assertIn('Reset Password', rendered)
+        
+        # Check branding elements
+        self.assertIn('Fast & Pray', rendered)
+        self.assertIn('fastandprayhelp@gmail.com', rendered)
+        self.assertIn('fastandpray.app', rendered)
+        
+        # Check images
+        self.assertIn('http://testserver/email_images/logo.png', rendered)
+        self.assertIn('http://testserver/email_images/logoicon.png', rendered)
+        
+        # Check security message
+        self.assertIn('This link will expire in 24 hours', rendered)
+        self.assertIn('If you didn\'t request this password reset', rendered)
+
+    def test_password_reset_email_template_with_missing_context(self):
+        """Test that the password reset email template handles missing context variables."""
+        # Render with minimal context
+        context = {
+            'site_url': settings.SITE_URL
+        }
+        
+        rendered = render_to_string('email/password_reset.html', context)
+        
+        # Template should still render without errors
+        self.assertIn('Password Reset', rendered)
+        self.assertIn('Fast & Pray', rendered)
+        self.assertNotIn('None', rendered)  # No undefined variables should be rendered 

--- a/templates/email/password_reset.html
+++ b/templates/email/password_reset.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Password Reset Request</title>
+    <style type="text/css">
+      @import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;500&display=swap');
+      
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #f3f3f3;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      table {
+        border-spacing: 0;
+        border-collapse: collapse;
+      }
+      td {
+        padding: 0;
+      }
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+      }
+      .header {
+        background-color: #390714;
+        padding: 36px 20px;
+        text-align: center;
+      }
+      .logo {
+        height: 38px;
+        max-height: 38px;
+      }
+      .logo-icon {
+        width: 58px;
+        height: 58px;
+      }
+      h1 {
+        color: #f7dbdb;
+        font-size: 35px;
+        margin: 5px 0 0;
+        font-weight: 500;
+        line-height: 1.2;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      .footer-title {
+        color: #d52d57;
+        font-size: 22px;
+        margin: 10px 0;
+        font-weight: 500;
+        line-height: 1.2;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      .content {
+        padding: 20px;
+        color: #000000;
+        font-size: 17px;
+        line-height: 1.5;
+        background-color: #ffffff;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      .footer {
+        background-color: #390714;
+        padding: 20px;
+        text-align: center;
+      }
+      .footer-links {
+        margin: 8px 0;
+      }
+      .footer-links a {
+        color: #f7dbdb;
+        text-decoration: none;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      p a {
+        color: #d52d57;
+        text-decoration: none;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      /* Button styles with fallback */
+      a.button {
+        display: block;
+        margin: 15px auto;
+        padding: 15px 30px;
+        background-color: #d52d57;
+        background-image: linear-gradient(#E54670, #B5244A);
+        color: white;
+        text-decoration: none !important;
+        text-transform: none;
+        border-radius: 40px;
+        font-size: 17px;
+        text-align: center;
+        min-width: 300px;
+        border: none;
+        cursor: pointer;
+        font-family: "Figtree", Arial, sans-serif;
+        mso-padding-alt: 15px 30px;
+        mso-text-raise: 0;
+      }
+      a.button:visited {
+        background-color: #d52d57;
+        background-image: linear-gradient(#E54670, #B5244A);
+      }
+      a.button:active {
+        background-color: #B5244A;
+        background-image: linear-gradient(#B5244A , #E54670);
+      }
+      a.button:hover {
+        background-color: #B5244A;
+        background-image: linear-gradient(#B5244A , #E54670);
+      }
+      /* Center alignment styles */
+      .centeredcontent {
+        text-align: center;
+        width: 100%;
+      }
+      .centeredcontent a.button {
+        display: inline-block;
+        margin: 10px auto;
+        text-align: center;
+      }
+      .spacer {
+        margin: 15px 0;
+      }
+    </style>
+  </head>
+  <body>
+    <table class="container" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td class="header">
+          <img src="{{ site_url }}/email_images/logo.png" alt="Fast & Pray Logo" class="logo" />
+          <h1>Password Reset</h1>
+        </td>
+      </tr>
+      <tr>
+        <td class="content">
+          <p>Hello {{ user.username }},</p>
+          <p>We received a request to reset your password. Click the button below to reset your password:</p>
+          <div class="centeredcontent">
+            <a href="{{ reset_url }}" class="button">Reset Password</a>
+          </div>
+          <p>If you didn't request this password reset, you can safely ignore this email.</p>
+          <p>This link will expire in 24 hours.</p>
+        </td>
+      </tr>
+      <tr>
+        <td class="footer">
+          <img src="{{ site_url }}/email_images/logoicon.png" alt="Fast & Pray Logo" class="logo-icon" />
+          <div class="footer-title">Fast & Pray</div>
+          <div class="footer-links">
+            <a href="mailto:fastandprayhelp@gmail.com">fastandprayhelp@gmail.com</a>
+          </div>
+          <div class="footer-links">
+            <a href="https://fastandpray.app">fastandpray.app</a>
+          </div>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html> 


### PR DESCRIPTION
This update introduces a new test suite for email templates, specifically focusing on the password reset email. The tests ensure that the email renders correctly with the appropriate context and handles missing context variables gracefully. Additionally, the password reset functionality in the user view has been updated to use the new email template. The FROM email was updated, which was causing the email to fail prior to this update.