### PR TITLE
fix: add correct name of the book of Jude

### DIFF
--- a/hub/constants.py
+++ b/hub/constants.py
@@ -102,5 +102,6 @@ CATENA_ABBREV_FOR_BOOK = {
     "3 John": "3jn",
     "St. John's Third Epistle General": "3jn",
     "Jude": "jude",
+    "St. Jude's General Epistle": "jude",
     "Revelation": "rv"
 }


### PR DESCRIPTION
**Bug**

Mapped the book named "Jude" to the URL segment, but book was actually named "St Jude's General Epistle." This was not noticed before because this is the first day of the year when we read from Jude.

**Fix**

Added the correct name as the key to map to URL segment for the catena url.

**Testing**

My local environment is buggy, so I haven't tested yet.