### PR TITLE
Update email notifications to use Mailgun API

### DIFF
--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -374,24 +374,28 @@ SESSION_CACHE_ALIAS = 'default'
 # Cache middleware settings
 CACHE_MIDDLEWARE_ALIAS = 'default'
 
-# Mailgun Configuration
-EMAIL_HOST = 'smtp.mailgun.org'
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-EMAIL_HOST_USER = 'postmaster@' + config('MAILGUN_DOMAIN')
-EMAIL_HOST_PASSWORD = config('MAILGUN_API_KEY')
+# Mailgun API Configuration (via Django Anymail)
+# Note: We're using the API, not SMTP, so SMTP settings are not needed
+ANYMAIL = {
+    "MAILGUN_API_KEY": config('MAILGUN_API_KEY'),
+    "MAILGUN_SENDER_DOMAIN": config('MAILGUN_DOMAIN'),
+    "MAILGUN_API_URL": "https://api.mailgun.net/v3",  # US servers (default)
+    # For EU servers, uncomment the line below:
+    # "MAILGUN_API_URL": "https://api.eu.mailgun.net/v3",
+}
+
+# Use Mailgun API backend (not SMTP)
+EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
+
+# Email settings
+DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='fastandprayhelp@gmail.com')
+# For backward compatibility with existing code that references EMAIL_HOST_USER
+EMAIL_HOST_USER = DEFAULT_FROM_EMAIL
 EMAIL_TEST_ADDRESS = config('EMAIL_TEST_ADDRESS', default='test@test.com')
 
 # Email rate limiting
 EMAIL_RATE_LIMIT = config('EMAIL_RATE_LIMIT', default=100, cast=int)  # emails per hour
 EMAIL_RATE_LIMIT_WINDOW = 3600 if not DEBUG else 60  # 1 hour in seconds; 1 minute in seconds for debugging
-
-ANYMAIL = {
-    "MAILGUN_API_KEY": config('MAILGUN_API_KEY'),
-    "MAILGUN_SENDER_DOMAIN": config('MAILGUN_DOMAIN')  
-}
-EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend" 
-DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='fastandprayhelp@gmail.com')
 
 # OPEN AI SETTINGS
 OPENAI_API_KEY = config('OPENAI_API_KEY')

--- a/docs/MAILGUN_API_SETUP.md
+++ b/docs/MAILGUN_API_SETUP.md
@@ -1,0 +1,138 @@
+# Mailgun API Integration
+
+This document explains how the application has been configured to use Mailgun API for sending emails instead of SMTP.
+
+## Overview
+
+The application now uses **Mailgun API** via the `django-anymail` library for all email sending, including:
+- User notifications
+- Fast reminders  
+- Promotional emails
+- Password reset emails
+- All other system emails
+
+## Configuration
+
+### Required Environment Variables
+
+Make sure you have these environment variables set:
+
+```bash
+# Mailgun API configuration
+MAILGUN_API_KEY=your-mailgun-api-key-here
+MAILGUN_DOMAIN=your-mailgun-domain.com
+
+# Email settings
+DEFAULT_FROM_EMAIL=your-from-email@your-domain.com
+EMAIL_TEST_ADDRESS=test@example.com  # For testing
+```
+
+### Django Settings
+
+The following settings are configured in `bahk/settings.py`:
+
+```python
+# Mailgun API Configuration (via Django Anymail)
+ANYMAIL = {
+    "MAILGUN_API_KEY": config('MAILGUN_API_KEY'),
+    "MAILGUN_SENDER_DOMAIN": config('MAILGUN_DOMAIN'),
+    "MAILGUN_API_URL": "https://api.mailgun.net/v3",  # US servers
+}
+
+# Use Mailgun API backend (not SMTP)
+EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
+
+# Email settings
+DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL')
+EMAIL_HOST_USER = DEFAULT_FROM_EMAIL  # For backward compatibility
+```
+
+## Testing the Integration
+
+### Method 1: Management Command (Recommended)
+
+Use the custom management command to test the Mailgun API integration:
+
+```bash
+# Basic test
+python manage.py test_mailgun_api
+
+# Test with custom email address
+python manage.py test_mailgun_api --email your-email@example.com
+
+# Verbose output with configuration details
+python manage.py test_mailgun_api --verbose
+```
+
+### Method 2: Python Shell
+
+You can also test directly in the Django shell:
+
+```python
+python manage.py shell
+
+# In the shell:
+from hub.utils import test_mailgun_api
+result = test_mailgun_api()
+print(result)
+```
+
+### Method 3: Celery Task
+
+Test via Celery task:
+
+```python
+from hub.tasks.email_tasks import test_mailgun_api_task
+result = test_mailgun_api_task.delay()
+print(result.get())
+```
+
+## Key Benefits of API vs SMTP
+
+1. **Better Reliability**: API calls are more reliable than SMTP connections
+2. **Enhanced Features**: Access to advanced Mailgun features like:
+   - Email tracking and analytics
+   - Bounce and complaint handling
+   - Email validation
+   - Scheduled sending
+3. **Better Error Handling**: More detailed error messages and status codes
+4. **No Connection Issues**: No need to worry about SMTP connection timeouts or authentication issues
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Invalid API Key**: Make sure your `MAILGUN_API_KEY` environment variable is set correctly
+2. **Domain Not Verified**: Ensure your domain is verified in your Mailgun dashboard
+3. **Wrong Region**: If using EU servers, update the API URL in settings:
+   ```python
+   "MAILGUN_API_URL": "https://api.eu.mailgun.net/v3"
+   ```
+
+### Checking Configuration
+
+Run the test command with verbose output to see your current configuration:
+
+```bash
+python manage.py test_mailgun_api --verbose
+```
+
+### Logs
+
+Check the application logs for detailed error messages if emails fail to send. The enhanced test function provides comprehensive logging.
+
+## Migration Notes
+
+- **SMTP Settings Removed**: The old SMTP settings (`EMAIL_HOST`, `EMAIL_PORT`, etc.) have been removed from the configuration
+- **Backward Compatibility**: `EMAIL_HOST_USER` is still available for backward compatibility but now points to `DEFAULT_FROM_EMAIL`
+- **All Email Types**: Both promotional emails and system notifications now use the API
+- **Testing**: All existing tests continue to work as they use the locmem backend during testing
+
+## Next Steps
+
+1. Test the integration using the management command
+2. Monitor email delivery in your Mailgun dashboard
+3. Consider setting up webhooks for bounce/complaint handling
+4. Review and update any custom email templates if needed
+
+For more information about Mailgun API features, see the [Mailgun documentation](https://documentation.mailgun.com/) and [Django Anymail documentation](https://anymail.readthedocs.io/).

--- a/hub/management/commands/test_mailgun_api.py
+++ b/hub/management/commands/test_mailgun_api.py
@@ -1,0 +1,107 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from hub.utils import test_mailgun_api
+import json
+
+
+class Command(BaseCommand):
+    help = 'Test Mailgun API integration via Django Anymail'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--email',
+            type=str,
+            help='Email address to send test email to (overrides EMAIL_TEST_ADDRESS setting)',
+        )
+        parser.add_argument(
+            '--verbose',
+            action='store_true',
+            help='Show detailed configuration information',
+        )
+
+    def handle(self, *args, **options):
+        self.stdout.write('=' * 60)
+        self.stdout.write('Testing Mailgun API Integration')
+        self.stdout.write('=' * 60)
+
+        # Show configuration if verbose mode
+        if options['verbose']:
+            self.stdout.write('\nCurrent Email Configuration:')
+            self.stdout.write(f'  EMAIL_BACKEND: {settings.EMAIL_BACKEND}')
+            self.stdout.write(f'  DEFAULT_FROM_EMAIL: {settings.DEFAULT_FROM_EMAIL}')
+            
+            anymail_config = getattr(settings, 'ANYMAIL', {})
+            self.stdout.write(f'  ANYMAIL Configuration:')
+            for key, value in anymail_config.items():
+                if 'API_KEY' in key:
+                    # Mask API key for security
+                    masked_value = f'{value[:8]}{"*" * (len(value) - 8)}' if len(value) > 8 else '***'
+                    self.stdout.write(f'    {key}: {masked_value}')
+                else:
+                    self.stdout.write(f'    {key}: {value}')
+
+        # Override test email address if provided
+        if options['email']:
+            original_test_address = settings.EMAIL_TEST_ADDRESS
+            settings.EMAIL_TEST_ADDRESS = options['email']
+            self.stdout.write(f'\nUsing custom test email: {options["email"]}')
+        else:
+            self.stdout.write(f'\nUsing default test email: {settings.EMAIL_TEST_ADDRESS}')
+
+        self.stdout.write('\nSending test email...')
+
+        # Call the test function
+        result = test_mailgun_api()
+
+        # Restore original test address if it was overridden
+        if options['email']:
+            settings.EMAIL_TEST_ADDRESS = original_test_address
+
+        # Display results
+        if result['success']:
+            self.stdout.write(
+                self.style.SUCCESS(f'\n✅ {result["message"]}')
+            )
+            self.stdout.write(f'   Backend: {result["backend"]}')
+            self.stdout.write(f'   From: {result["from_email"]}')
+            self.stdout.write(f'   To: {result["to_email"]}')
+            if result.get('result'):
+                self.stdout.write(f'   Send Result: {result["result"]}')
+        else:
+            self.stdout.write(
+                self.style.ERROR(f'\n❌ Test failed: {result["error"]}')
+            )
+            self.stdout.write(f'   Backend: {result["backend"]}')
+            
+            if options['verbose'] and result.get('anymail_config'):
+                self.stdout.write('   Anymail Config:')
+                for key, value in result['anymail_config'].items():
+                    if 'API_KEY' in key:
+                        masked_value = f'{value[:8]}{"*" * (len(value) - 8)}' if len(value) > 8 else '***'
+                        self.stdout.write(f'     {key}: {masked_value}')
+                    else:
+                        self.stdout.write(f'     {key}: {value}')
+
+        self.stdout.write('\n' + '=' * 60)
+
+        # Provide helpful next steps
+        if result['success']:
+            self.stdout.write(
+                self.style.SUCCESS('✅ Mailgun API integration is working correctly!')
+            )
+            self.stdout.write('\nNext steps:')
+            self.stdout.write('  • Check your email inbox for the test message')
+            self.stdout.write('  • Your promotional emails will now be sent via Mailgun API')
+            self.stdout.write('  • All notification emails are using the API instead of SMTP')
+        else:
+            self.stdout.write(
+                self.style.ERROR('❌ Mailgun API integration needs attention')
+            )
+            self.stdout.write('\nTroubleshooting:')
+            self.stdout.write('  • Verify your MAILGUN_API_KEY environment variable')
+            self.stdout.write('  • Verify your MAILGUN_DOMAIN environment variable')
+            self.stdout.write('  • Check that your domain is verified in Mailgun')
+            self.stdout.write('  • Ensure django-anymail is properly installed')
+            self.stdout.write('  • Run with --verbose for more configuration details')
+
+        self.stdout.write('')

--- a/hub/tasks/email_tasks.py
+++ b/hub/tasks/email_tasks.py
@@ -2,13 +2,18 @@
 Email-related tasks for the hub app.
 """
 from celery import shared_task
-from hub.utils import test_email, send_fast_reminders
+from hub.utils import test_email, test_mailgun_api, send_fast_reminders
 import sentry_sdk
 
 @shared_task
 def test_email_task():
     """Send a test email to verify that the email configuration is working."""
     test_email()
+
+@shared_task
+def test_mailgun_api_task():
+    """Send a test email specifically for testing Mailgun API integration."""
+    return test_mailgun_api()
 
 @shared_task(name='hub.tasks.send_fast_reminder_task')
 @sentry_sdk.monitor(monitor_slug='daily-fast-notifications')

--- a/hub/utils.py
+++ b/hub/utils.py
@@ -192,3 +192,105 @@ def test_email():
     except Exception as e:
         logger.error(f'Failed to send email: {e}')
         raise e
+
+
+def test_mailgun_api():
+    """
+    Enhanced test function specifically for testing Mailgun API integration.
+    Uses EmailMultiAlternatives to test both text and HTML content.
+    Returns detailed information about the email sending process.
+    """
+    try:
+        from django.core.mail import EmailMultiAlternatives
+        
+        # Create a test email with both HTML and text content
+        subject = 'Mailgun API Test Email'
+        text_content = '''
+        This is a test email sent via Mailgun API through Django Anymail.
+        
+        If you receive this email, your Mailgun API integration is working correctly!
+        
+        Email Backend: {backend}
+        From Email: {from_email}
+        Test Address: {test_address}
+        
+        Best regards,
+        Fast & Pray Team
+        '''.format(
+            backend=settings.EMAIL_BACKEND,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            test_address=settings.EMAIL_TEST_ADDRESS
+        )
+        
+        html_content = '''
+        <html>
+        <body>
+            <h2>Mailgun API Test Email</h2>
+            <p>This is a test email sent via <strong>Mailgun API</strong> through Django Anymail.</p>
+            <p>If you receive this email, your Mailgun API integration is working correctly!</p>
+            
+            <h3>Configuration Details:</h3>
+            <ul>
+                <li><strong>Email Backend:</strong> {backend}</li>
+                <li><strong>From Email:</strong> {from_email}</li>
+                <li><strong>Test Address:</strong> {test_address}</li>
+            </ul>
+            
+            <p>Best regards,<br>
+            <strong>Fast &amp; Pray Team</strong></p>
+        </body>
+        </html>
+        '''.format(
+            backend=settings.EMAIL_BACKEND,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            test_address=settings.EMAIL_TEST_ADDRESS
+        )
+        
+        from_email = f"Fast and Pray <{settings.DEFAULT_FROM_EMAIL}>"
+        
+        # Create the email message
+        email = EmailMultiAlternatives(
+            subject=subject,
+            body=text_content,
+            from_email=from_email,
+            to=[settings.EMAIL_TEST_ADDRESS]
+        )
+        
+        # Add HTML alternative
+        email.attach_alternative(html_content, "text/html")
+        
+        # Send the email and capture any response from Anymail
+        result = email.send()
+        
+        logger.info(f'Mailgun API test email sent successfully to {settings.EMAIL_TEST_ADDRESS}')
+        logger.info(f'Email backend: {settings.EMAIL_BACKEND}')
+        logger.info(f'Send result: {result}')
+        
+        # Try to get Anymail status information if available
+        anymail_status = getattr(email, 'anymail_status', None)
+        if anymail_status:
+            logger.info(f'Anymail status: {anymail_status}')
+            logger.info(f'Message ID: {getattr(anymail_status, "message_id", "N/A")}')
+            logger.info(f'Status: {getattr(anymail_status, "status", "N/A")}')
+        
+        return {
+            'success': True,
+            'message': 'Test email sent successfully via Mailgun API',
+            'backend': settings.EMAIL_BACKEND,
+            'from_email': from_email,
+            'to_email': settings.EMAIL_TEST_ADDRESS,
+            'result': result
+        }
+        
+    except Exception as e:
+        error_msg = f'Failed to send test email via Mailgun API: {str(e)}'
+        logger.error(error_msg)
+        logger.error(f'Email backend: {settings.EMAIL_BACKEND}')
+        logger.error(f'Anymail configuration: {getattr(settings, "ANYMAIL", {})}')
+        
+        return {
+            'success': False,
+            'error': error_msg,
+            'backend': settings.EMAIL_BACKEND,
+            'anymail_config': getattr(settings, 'ANYMAIL', {})
+        }

--- a/notifications/tests/test_settings.py
+++ b/notifications/tests/test_settings.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
+from decouple import config
 
 # Test settings
 SITE_URL = 'http://testserver'
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
-EMAIL_HOST_USER = 'test@example.com' 
+EMAIL_HOST_USER = config('EMAIL_TEST_ADDRESS', default='test@test.com')


### PR DESCRIPTION
Email notifications were updated to use Mailgun API instead of SMTP.

*   In `bahk/settings.py`, redundant SMTP configurations (`EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USE_TLS`) were removed. The `EMAIL_BACKEND` was set to `anymail.backends.mailgun.EmailBackend`, and `ANYMAIL` settings were updated to include `MAILGUN_API_URL`. `EMAIL_HOST_USER` was re-added for backward compatibility, pointing to `DEFAULT_FROM_EMAIL`.
*   An enhanced test function, `test_mailgun_api()`, was added to `hub/utils.py` to verify Mailgun API integration, including HTML content and detailed status reporting.
*   A new Celery task, `test_mailgun_api_task`, was created in `hub/tasks/email_tasks.py` to leverage this test function.
*   A Django management command, `test_mailgun_api`, was introduced in `hub/management/commands/test_mailgun_api.py` for easy command-line testing with options for custom emails and verbose output.
*   Comprehensive documentation for the Mailgun API setup, `docs/MAILGUN_API_SETUP.md`, was created, detailing configuration, testing, benefits, and troubleshooting.

This ensures all email types, including promotional and system notifications, now utilize the Mailgun API for improved reliability and features.