### PR TITLE
feat: Update checklist usage tracking to allow optional fast_id 

### DIFF
--- a/events/migrations/0008_make_checklist_used_target_optional.py
+++ b/events/migrations/0008_make_checklist_used_target_optional.py
@@ -1,0 +1,45 @@
+# Generated for PR #229 analytics enhancements
+
+from django.db import migrations
+
+
+def update_checklist_used_event_type(apps, schema_editor):
+    """Update CHECKLIST_USED event type to not require target."""
+    EventType = apps.get_model('events', 'EventType')
+    
+    try:
+        checklist_event_type = EventType.objects.get(code='checklist_used')
+        checklist_event_type.requires_target = False
+        checklist_event_type.save()
+        print("✅ Updated CHECKLIST_USED event type to not require target")
+    except EventType.DoesNotExist:
+        # Event type doesn't exist yet, will be created correctly by init_event_types
+        print("ℹ️ CHECKLIST_USED event type doesn't exist yet - will be created correctly")
+        pass
+
+
+def reverse_update_checklist_used_event_type(apps, schema_editor):
+    """Reverse the update to CHECKLIST_USED event type."""
+    EventType = apps.get_model('events', 'EventType')
+    
+    try:
+        checklist_event_type = EventType.objects.get(code='checklist_used')
+        checklist_event_type.requires_target = True
+        checklist_event_type.save()
+        print("↩️ Reverted CHECKLIST_USED event type to require target")
+    except EventType.DoesNotExist:
+        pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0007_alter_useractivityfeed_activity_type_announcement'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            update_checklist_used_event_type,
+            reverse_update_checklist_used_event_type,
+        ),
+    ]

--- a/events/models.py
+++ b/events/models.py
@@ -166,7 +166,8 @@ class EventType(models.Model):
             cls.FAST_CREATED, cls.FAST_UPDATED, cls.ARTICLE_PUBLISHED, 
             cls.RECIPE_PUBLISHED, cls.VIDEO_PUBLISHED,
             # Engagement targets
-            cls.DEVOTIONAL_VIEWED, cls.CHECKLIST_USED,
+            cls.DEVOTIONAL_VIEWED,
+            # Note: CHECKLIST_USED removed - can be used without a specific fast
         ]
 
 


### PR DESCRIPTION
This pull request updates the tracking of the `CHECKLIST_USED` event to allow checklist interactions to be logged without requiring a specific fast as the target. This enables more flexible analytics by supporting both fast-specific and general checklist usage. The changes include a migration, model update, view logic modification, and expanded test coverage.

**Checklist event type logic and migration:**

* Added migration `0008_make_checklist_used_target_optional.py` to set `requires_target` to `False` for the `CHECKLIST_USED` event type, allowing events to be created without a target fast.
* Updated `_requires_target_for_code` in `events/models.py` to remove `CHECKLIST_USED` from the list of event types that require a target.

**Checklist tracking endpoint and data handling:**

* Modified `TrackChecklistUsedView.post` in `events/views.py` to make `fast_id` optional, support general checklist usage, and add a `context` field to distinguish between fast-specific and general events.

**Test coverage improvements:**

* Added `test_track_checklist_used_minimal_data` and updated related tests in `events/tests/test_engagement_endpoints.py` to verify checklist events can be tracked with minimal or no data, and that the new `context` field is set appropriately. [[1]](diffhunk://#diff-78c1a0a69352f0377a1e46b1636b71218b6d055344b0578403698b578ce8c98dR212-R240) [[2]](diffhunk://#diff-78c1a0a69352f0377a1e46b1636b71218b6d055344b0578403698b578ce8c98dR264-R292)…ction

- Modified the `TrackChecklistUsedView` to accept optional `fast_id` and `action` parameters, enabling more flexible checklist tracking.
- Updated the `EventType` model to reflect that the `CHECKLIST_USED` event type no longer requires a target.
- Added migration to adjust the `CHECKLIST_USED` event type settings.
- Enhanced tests to cover scenarios with minimal data input, ensuring robust event creation without mandatory parameters.

These changes improve the usability of the checklist tracking feature, allowing for broader engagement metrics.