### PR TITLE
refactor: Remove post-save signal for devotional availability tracking

### DIFF
--- a/events/signals.py
+++ b/events/signals.py
@@ -538,26 +538,9 @@ def create_activity_feed_item(sender, instance, created, **kwargs):
             logger.error(f"Error propagating system event {instance.id} to participants: {e}")
 
 
-@receiver(post_save, sender='hub.Devotional')
-def track_devotional_availability_on_save(sender, instance, created, **kwargs):
-    """
-    Track devotional availability when a devotional is created or updated.
-    Only triggers for devotionals with dates today or in the future.
-    """
-    try:
-        from django.utils import timezone
-        from .tasks import track_devotional_availability_task
-        
-        today = timezone.now().date()
-        
-        # Only track if the devotional's date is today or in the future
-        if instance.day and instance.day.date >= today:
-            # Schedule the task asynchronously to avoid blocking the save operation
-            track_devotional_availability_task.delay(instance.day.fast.id, instance.id)
-            logger.info(f"Scheduled devotional availability tracking for {instance.day.fast.name} - {instance.video.title if instance.video else 'Devotional'}")
-            
-    except Exception as e:
-        logger.error(f"Error scheduling devotional availability tracking: {e}")
+# Removed post-save signal for devotional availability tracking
+# Now using only the daily scheduled task (check_devotional_availability_task) 
+# which runs at 7 AM and creates events for devotionals with today's date
 
 
 def track_article_published(article):

--- a/events/tasks.py
+++ b/events/tasks.py
@@ -494,6 +494,10 @@ def track_devotional_availability_task(self, fast_id, devotional_id):
     """
     Track when a specific devotional becomes available asynchronously.
     
+    NOTE: This task is primarily for manual/testing purposes.
+    The main devotional availability tracking is handled by the daily
+    check_devotional_availability_task which runs at 7 AM.
+    
     Args:
         fast_id: ID of the Fast
         devotional_id: ID of the Devotional


### PR DESCRIPTION
- Eliminated the `track_devotional_availability_on_save` signal to streamline the process.
- Now relying solely on the daily `check_devotional_availability_task` that runs at 7 AM for tracking devotional availability.
- Updated documentation in `track_devotional_availability_task` to clarify its purpose and usage.