### PR TITLE
feat: Add language support to FastDetailView and enhance FastSerializer context

### DIFF
--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -202,6 +202,7 @@ class FastDetailView(TimezoneMixin, generics.RetrieveAPIView):
 
     Query Parameters:
         - tz: Optional. Timezone offset from UTC in the IANA format (e.g., America/New_York).
+        - lang: Optional. Language code for translations (e.g., en, hy). Defaults to 'en'.
     
     Returns:
         - Details of the requested fast.
@@ -219,11 +220,15 @@ class FastDetailView(TimezoneMixin, generics.RetrieveAPIView):
     def retrieve(self, request, *args, **kwargs):
         # Generate cache key using the fast ID, auth status, and timezone
         is_authenticated = request.user.is_authenticated
+        lang = request.query_params.get('lang') or 'en'
+        # Include user id when authenticated to prevent per-user fields (e.g., joined) from leaking
+        auth_segment = f"user:{request.user.id}" if is_authenticated else 'anon'
         cache_key = get_cache_key(
             'fast_detail',
             self.kwargs['pk'],
-            'auth' if is_authenticated else 'anon',
-            self.get_timezone().zone
+            auth_segment,
+            self.get_timezone().zone,
+            lang
         )
         
         # Try to get serialized data from cache
@@ -598,10 +603,10 @@ class FastOnDate(views.APIView):
     def get(self, request):
         if request.user.is_authenticated:
             fast = _get_fast_for_user_on_date(request)
-            return response.Response(FastSerializer(fast).data)
+            return response.Response(FastSerializer(fast, context={'request': request}).data)
         else:
             fast = _get_fast_on_date(request)
-            return response.Response(FastSerializer(fast).data)
+            return response.Response(FastSerializer(fast, context={'request': request}).data)
 
 
 class FastOnDateWithoutUser(views.APIView):
@@ -613,7 +618,7 @@ class FastOnDateWithoutUser(views.APIView):
 
     def get(self, request):
         fast = _get_fast_on_date(request)
-        return response.Response(FastSerializer(fast).data)
+        return response.Response(FastSerializer(fast, context={'request': request}).data)
     
 
 def _get_fast_for_user_on_date(request):


### PR DESCRIPTION
This pull request enhances support for language-specific responses and improves serializer context handling in the fast-related API views. The most important changes are grouped below:

Language support and caching improvements:

* Documents new `lang` query parameter for the `FastDetailView` API, allowing clients to specify the desired language for translations.
* Updated cache key generation in `FastDetailView` to include the `lang` parameter and use a more precise `auth_segment` for authenticated users, preventing data leakage of user-specific fields.

Serializer context consistency:

* Updated all usages of `FastSerializer` in `FastOnDate` and `FastOnDateWithoutUser` views to include the `request` in the serializer context, ensuring correct handling of request-specific logic. [[1]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6L601-R609) [[2]](diffhunk://#diff-0157cebd445ad9d3373f134bdf54140354b6c8fe96e48ce8b6e7593466d258a6L616-R621)- Introduced an optional 'lang' query parameter in FastDetailView for language code, defaulting to 'en'.
- Updated FastSerializer calls in FastOnDate and FastOnDateWithoutUser views to include request context for improved multilingual support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `lang` support and per-user cache segmentation to `FastDetailView`, and ensures `FastSerializer` receives `request` context in date-based views.
> 
> - **Backend/API**:
>   - **`hub/views/fast.py`**:
>     - **`FastDetailView`**:
>       - Documents new `lang` query param.
>       - Cache key now includes per-user `auth_segment` (user id when authenticated), timezone, and `lang`.
>     - **Date-based views**:
>       - `FastOnDate` and `FastOnDateWithoutUser` now instantiate `FastSerializer` with `context={'request': request}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fceb7529c6e28ec0b7446fe10b6dec6c0d405c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->