### PR TITLE
fix: Update day creation logic in seed command to ensure non-overlapping dates for fasts

### DIFF
--- a/hub/management/commands/seed.py
+++ b/hub/management/commands/seed.py
@@ -126,18 +126,24 @@ class Command(BaseCommand):
             ),
         ]
 
-        # Create Days for each Fast
+        # Create Days for each Fast with non-overlapping dates
         all_days = []
+        day_offset = 0  # Track the starting day offset for each fast
+        
         for n, fast in enumerate(fasts):
             fast_days = []
-            for i in range((n + 1) * 7):  # Different durations for each fast
+            num_days = (n + 1) * 7  # Different durations for each fast (7, 14, 21)
+            
+            for i in range(num_days):
                 day = models.Day.objects.create(
-                    date=date.today() + timedelta(days=i), 
+                    date=date.today() + timedelta(days=day_offset + i), 
                     fast=fast, 
                     church=fast.church
                 )
                 fast_days.append(day)
                 all_days.append(day)
+            
+            day_offset += num_days  # Move offset forward for next fast
             fast.save(update_fields=["year"])  # saving fast with day(s) updates the year field
 
         # Create Users and Profiles


### PR DESCRIPTION
This commit modifies the day creation logic in the seed command to ensure that each fast has non-overlapping dates. A day offset is introduced to track the starting date for each fast, allowing for distinct date ranges based on the fast's duration. This change enhances the accuracy of the generated data and maintains the integrity of the fast scheduling process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `hub/management/commands/seed.py` to create `Day` records with non-overlapping date ranges per `Fast` using a running day offset and per-fast duration.
> 
> - **Seed Data (`hub/management/commands/seed.py`)**:
>   - **Day creation for `Fast`**:
>     - Introduces `day_offset` to stagger `Day.date` across fasts.
>     - Uses `num_days = (n + 1) * 7` and `date = today + timedelta(day_offset + i)`.
>     - Advances `day_offset` after each fast to maintain distinct ranges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50a59a26dda5dd2589ef2780017fed742d1ed357. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->