### PR TITLE
Tag screen views with source and filter app analytics

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -483,9 +483,14 @@ class EventAdmin(admin.ModelAdmin):
             event_type__category='analytics'
         ).exclude(user__is_staff=True)
 
+        screen_view_qs = base_qs.filter(
+            event_type__code=EventType.SCREEN_VIEW,
+            data__source='app_ui'
+        )
+
         # Totals
         total_app_opens = base_qs.filter(event_type__code=EventType.APP_OPEN).count()
-        total_screen_views = base_qs.filter(event_type__code=EventType.SCREEN_VIEW).count()
+        total_screen_views = screen_view_qs.count()
         active_users = base_qs.exclude(user__isnull=True).values('user').distinct().count()
 
         # Events over time (analytics)
@@ -508,7 +513,7 @@ class EventAdmin(admin.ModelAdmin):
 
         # Most viewed screens
         top_screens = list(
-            base_qs.filter(event_type__code=EventType.SCREEN_VIEW, data__has_key='screen')
+            screen_view_qs.filter(data__has_key='screen')
             .values('data__screen').annotate(count=Count('id')).order_by('-count')[:15]
         )
 
@@ -590,13 +595,18 @@ class EventAdmin(admin.ModelAdmin):
 
         # Other metrics
         total_app_opens = base_qs.filter(event_type__code=EventType.APP_OPEN).count()
-        total_screen_views = base_qs.filter(event_type__code=EventType.SCREEN_VIEW).count()
+        screen_view_qs = base_qs.filter(
+            event_type__code=EventType.SCREEN_VIEW,
+            data__source='app_ui'
+        )
+
+        total_screen_views = screen_view_qs.count()
         active_users = base_qs.exclude(user__isnull=True).values('user').distinct().count()
         avg_session_duration = base_qs.filter(event_type__code=EventType.SESSION_END, data__has_key='duration_seconds')\
             .aggregate(avg=Avg(Cast('data__duration_seconds', FloatField())))['avg'] or 0
 
         top_screens = list(
-            base_qs.filter(event_type__code=EventType.SCREEN_VIEW, data__has_key='screen')
+            screen_view_qs.filter(data__has_key='screen')
             .values('data__screen').annotate(count=Count('id')).order_by('-count')[:15]
         )
 

--- a/events/migrations/0010_add_screen_view_source.py
+++ b/events/migrations/0010_add_screen_view_source.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+
+def set_screen_view_source(apps, schema_editor):
+    Event = apps.get_model('events', 'Event')
+    EventType = apps.get_model('events', 'EventType')
+
+    try:
+        screen_view_type = EventType.objects.get(code='screen_view')
+    except EventType.DoesNotExist:
+        return
+
+    screen_views = Event.objects.filter(event_type=screen_view_type)
+
+    for event in screen_views.iterator():
+        data = event.data or {}
+        if data.get('source'):
+            continue
+
+        path = data.get('path', '') or ''
+        source = 'api' if str(path).startswith('/api/') else 'app_ui'
+        data['source'] = source
+        Event.objects.filter(pk=event.pk).update(data=data)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0009_announcement_i18n_event_i18n_useractivityfeed_i18n'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_screen_view_source, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- Tag screen view analytics events with an app_ui or api source based on request path or header
- Filter app analytics dashboard metrics to app_ui screen views and backfill existing events with sources
- Expand middleware and admin dashboard tests to cover API tagging and filtered screen analytics

## Testing
- python manage.py test events.tests.test_middleware events.tests.test_admin_dashboards *(fails: MAILGUN_DOMAIN not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bea13a4b8832996e52cbf5048a613)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tag SCREEN_VIEW events with `source` (api/app_ui) and filter App Analytics to `app_ui` screen views; add backfill migration and tests.
> 
> - **Analytics middleware (`events/middleware.py`)**:
>   - Add `source` to SCREEN_VIEW events, set via path or `X-API-Request` header (`api` vs `app_ui`).
>   - Introduce `_is_api_request` helper; include `source` in event `data`.
> - **Admin dashboards (`events/admin.py`)**:
>   - App Analytics: compute `total_screen_views` and `top_screens` from `SCREEN_VIEW` events where `data__source='app_ui'`.
>   - Reuse `screen_view_qs` for totals and rankings.
> - **Data migration (`events/migrations/0010_add_screen_view_source.py`)**:
>   - Backfill `data['source']` for existing SCREEN_VIEW events (`api` if `path` starts with `/api/`, else `app_ui`).
> - **Tests**:
>   - Update dashboard and middleware tests to assert `source` tagging, app_ui-only screen metrics, and API header behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6df0e52d945a5c6f0c97acffeb432111e8ec991. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->