### PR TITLE
Add profile image URLs to prayer request requester data

### DIFF
--- a/docs/PRAYER_REQUESTS_API.md
+++ b/docs/PRAYER_REQUESTS_API.md
@@ -74,7 +74,9 @@ GET /api/prayer-requests/?mine=true&status=completed,deleted
     "requester": {
       "id": 5,
       "email": "john@example.com",
-      "full_name": "John Doe"
+      "full_name": "John Doe",
+      "profile_image_url": "https://s3.amazonaws.com/bucket/profile_images/5/profile.jpg",
+      "profile_image_thumbnail_url": "https://s3.amazonaws.com/bucket/cache/profile_thumbnails/5_thumb.jpg"
     },
     "created_at": "2025-11-18T15:30:00Z",
     "updated_at": "2025-11-18T15:32:00Z",
@@ -378,7 +380,9 @@ Commit to praying for a prayer request.
     "requester": {
       "id": 5,
       "email": "john@example.com",
-      "full_name": "John Doe"
+      "full_name": "John Doe",
+      "profile_image_url": "https://s3.amazonaws.com/bucket/profile_images/5/profile.jpg",
+      "profile_image_thumbnail_url": "https://s3.amazonaws.com/bucket/cache/profile_thumbnails/5_thumb.jpg"
     },
     "created_at": "2025-11-18T15:30:00Z",
     "updated_at": "2025-11-18T15:32:00Z",
@@ -458,7 +462,9 @@ Retrieve all prayer requests the current user has accepted.
     "requester": {
       "id": 5,
       "email": "john@example.com",
-      "full_name": "John Doe"
+      "full_name": "John Doe",
+      "profile_image_url": "https://s3.amazonaws.com/bucket/profile_images/5/profile.jpg",
+      "profile_image_thumbnail_url": "https://s3.amazonaws.com/bucket/cache/profile_thumbnails/5_thumb.jpg"
     },
     "created_at": "2025-11-18T15:30:00Z",
     "updated_at": "2025-11-18T15:32:00Z",
@@ -507,7 +513,9 @@ Log that you prayed for a request today.
     "requester": {
       "id": 5,
       "email": "john@example.com",
-      "full_name": "John Doe"
+      "full_name": "John Doe",
+      "profile_image_url": "https://s3.amazonaws.com/bucket/profile_images/5/profile.jpg",
+      "profile_image_thumbnail_url": "https://s3.amazonaws.com/bucket/cache/profile_thumbnails/5_thumb.jpg"
     },
     "created_at": "2025-11-18T15:30:00Z",
     "updated_at": "2025-11-18T15:32:00Z",
@@ -630,7 +638,7 @@ Send a thank you message to all who accepted your completed prayer request.
 | `reviewed` | boolean | Whether moderation is complete |
 | `status` | string | `pending_moderation`, `approved`, `rejected`, `completed`, `deleted`, `active` (special: approved and not expired) |
 | `moderation_severity` | string | Severity level from AI moderation: `low`, `medium`, `high`, `critical` (null if not yet moderated) |
-| `requester` | object | User who submitted (null if anonymous) |
+| `requester` | object | User who submitted (null if anonymous). Includes: `id`, `email`, `full_name`, `profile_image_url`, `profile_image_thumbnail_url` |
 | `created_at` | datetime | Creation timestamp |
 | `updated_at` | datetime | Last update timestamp |
 | `acceptance_count` | integer | Number of users who accepted |
@@ -971,6 +979,12 @@ curl -X GET https://api.example.com/api/prayer-requests/?mine=true&status=comple
    - Allow marking own requests as prayed
    - User's own requests automatically appear in `/accepted/` list
 
+9. **Display profile images for requester avatars**
+   - Use `requester.profile_image_thumbnail_url` for avatar display (100x100 optimized)
+   - Fallback to `requester.profile_image_url` for full-size image if needed
+   - Both fields will be `null` if user has no profile image
+   - Profile images respect anonymous setting - entire `requester` object is `null` for anonymous requests
+
 ---
 
 ## Support
@@ -984,6 +998,17 @@ For issues or questions:
 ---
 
 ## Changelog
+
+### v1.2.0 (2025-11-25)
+- **Profile Image Support**
+  - Added `profile_image_url` and `profile_image_thumbnail_url` to requester data
+  - Thumbnail URL (100x100) optimized for avatar display
+  - Full image URL available for larger displays
+  - Both fields return `null` if user has no profile image
+  - Respects anonymous request setting
+- **Test Coverage**
+  - Added 3 integration tests for profile image serialization
+  - Tests cover: image URLs present, null when no image, hidden for anonymous requests
 
 ### v1.1.0 (2025-11-26)
 - **Enhanced Moderation System**


### PR DESCRIPTION
## Summary

Enhance the `RequesterSerializer` to include profile image and thumbnail URLs for display as avatars in the frontend. This allows the mobile app to show user profile pictures alongside prayer requests.

## Changes

### Backend (`prayers/serializers.py`)
- ✅ Add `profile_image_url` field to `RequesterSerializer` for full-size image
- ✅ Add `profile_image_thumbnail_url` field for 100x100 optimized avatar display
- ✅ Use cached thumbnail URLs from Profile model for performance
- ✅ Handle missing images gracefully (returns `null`)
- ✅ Respect anonymous request privacy (entire requester object is `null`)

### Tests (`tests/test_prayer_requests.py`)
- ✅ `test_requester_includes_profile_image_urls` - Verify URLs present when user has image
- ✅ `test_requester_profile_image_null_when_no_image` - Verify null when no image
- ✅ `test_anonymous_request_hides_requester_including_profile_image` - Verify anonymous privacy
- ✅ All 22 prayer request tests passing

### Documentation (`docs/PRAYER_REQUESTS_API.md`)
- ✅ Update API response examples with new fields
- ✅ Add best practice (#9) for displaying profile images
- ✅ Update data models table with field descriptions
- ✅ Add changelog entry (v1.2.0)

## Technical Details

**Field Behavior:**
- `profile_image_url`: Returns full-size original image URL from `Profile.profile_image`
- `profile_image_thumbnail_url`: Returns 100x100 JPEG thumbnail (ResizeToFill, 60% quality)
- Both fields return `null` if user has no profile image
- Thumbnail uses cached URL when available, generates on-the-fly as fallback

**Performance:**
- Leverages existing `Profile.cached_thumbnail_url` infrastructure
- Avoids S3 API calls by using cached thumbnails
- Graceful error handling for missing files

**Privacy:**
- Respects anonymous prayer requests
- When `is_anonymous: true`, entire `requester` object is `null` (including images)
- Staff and request owner can still see requester data

## API Response Example

```json
{
  "id": 1,
  "title": "Pray for my father's surgery",
  "requester": {
    "id": 5,
    "email": "john@example.com",
    "full_name": "John Doe",
    "profile_image_url": "https://s3.amazonaws.com/bucket/profile_images/5/profile.jpg",
    "profile_image_thumbnail_url": "https://s3.amazonaws.com/bucket/cache/profile_thumbnails/5_thumb.jpg"
  },
  ...
}
```

## Frontend Usage

```javascript
// Use thumbnail for avatar display
const avatarUrl = requester?.profile_image_thumbnail_url || defaultAvatar;

// Use full image for larger displays or modals
const fullImageUrl = requester?.profile_image_url;
```

## Test Results

```
Ran 22 tests in 3.894s

OK
```

All prayer request tests passing, including 3 new tests for profile image functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose `profile_image_url` and `profile_image_thumbnail_url` in `requester` data, with tests and docs updates.
> 
> - **Backend (`prayers/serializers.py`)**:
>   - Extend `RequesterSerializer` with `profile_image_url` and `profile_image_thumbnail_url` (uses cached thumbnail when available; falls back safely; returns `null` if absent).
>   - Preserve anonymity: `requester` is `null` on anonymous requests (non-owner/non-staff).
> - **Tests (`tests/test_prayer_requests.py`)**:
>   - Add 3 integration tests covering: image URLs present, `null` when no image, hidden when anonymous.
> - **Docs (`docs/PRAYER_REQUESTS_API.md`)**:
>   - Update response examples to include new requester image fields across endpoints.
>   - Update data model table and add best practice for displaying requester avatars.
>   - Add changelog entry `v1.2.0` describing profile image support and tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 261e1d7a1ca32fd58289748b7d85b76d31350bcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->