### PR TITLE
Fix duplicate fast missing translatable content

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -311,6 +311,21 @@ class FastAdmin(admin.ModelAdmin):
                 duplicate_fast.image = old_fast.image
                 duplicate_fast.image_thumbnail = old_fast.image_thumbnail
 
+                # Copy translated fields (django-modeltrans stores in _en, _hy suffixes)
+                # This ensures all language versions are preserved
+                duplicate_fast.name_en = old_fast.name_en
+                duplicate_fast.name_hy = old_fast.name_hy
+                duplicate_fast.description_en = old_fast.description_en
+                duplicate_fast.description_hy = old_fast.description_hy
+                duplicate_fast.culmination_feast_en = old_fast.culmination_feast_en
+                duplicate_fast.culmination_feast_hy = old_fast.culmination_feast_hy
+                duplicate_fast.culmination_feast_salutation_en = old_fast.culmination_feast_salutation_en
+                duplicate_fast.culmination_feast_salutation_hy = old_fast.culmination_feast_salutation_hy
+                duplicate_fast.culmination_feast_message_en = old_fast.culmination_feast_message_en
+                duplicate_fast.culmination_feast_message_hy = old_fast.culmination_feast_message_hy
+                duplicate_fast.culmination_feast_message_attribution_en = old_fast.culmination_feast_message_attribution_en
+                duplicate_fast.culmination_feast_message_attribution_hy = old_fast.culmination_feast_message_attribution_hy
+
                 # days
                 dates = [
                     data["first_day"] + datetime.timedelta(days=num_days)
@@ -332,6 +347,9 @@ class FastAdmin(admin.ModelAdmin):
                     "name": old_fast.name,
                     "church": old_fast.church,
                     "culmination_feast": old_fast.culmination_feast,
+                    "culmination_feast_salutation": old_fast.culmination_feast_salutation,
+                    "culmination_feast_message": old_fast.culmination_feast_message,
+                    "culmination_feast_message_attribution": old_fast.culmination_feast_message_attribution,
                     "description": old_fast.description,
                     "url": old_fast.url,
                 }


### PR DESCRIPTION
When duplicating a fast, the translatable fields (name, description, culmination_feast, culmination_feast_salutation, culmination_feast_message, culmination_feast_message_attribution) were not being copied in both languages (English and Armenian). This meant that duplicated fasts would lose their Armenian translations.

Changes:
- Updated duplicate_fast_with_new_dates in hub/admin.py to copy all translatable field values (both _en and _hy suffixes)
- Added missing culmination feast fields to form initial data
- Added comprehensive test to verify translation copying works correctly

This ensures that when a fast is duplicated for a new year, all content in both supported languages is preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure duplicating a `Fast` copies all translated (_en/_hy) fields and pre-fills missing culmination fields; add test to verify.
> 
> - **Admin (hub)**:
>   - `hub/admin.py`: Update `duplicate_fast_with_new_dates` to copy all translatable `Fast` fields (`name_*`, `description_*`, `culmination_feast_*`, `culmination_feast_salutation_*`, `culmination_feast_message_*`, `culmination_feast_message_attribution_*`) across `_en`/`_hy`.
>   - Pre-fill form `initial` with `culmination_feast_salutation`, `culmination_feast_message`, and `culmination_feast_message_attribution`.
> - **Tests**:
>   - `tests/test_multilingual.py`: Add `test_fast_duplication_copies_translations` to assert English/Armenian values are preserved on duplication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0509a5c45e5af3c257744ab6c49d9d09df7d0ca0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->