### PR TITLE
prayer request activity feed items should include profile name, not email/username

### DIFF
--- a/prayers/views.py
+++ b/prayers/views.py
@@ -228,6 +228,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
 from events.models import Event, EventType, UserActivityFeed, UserMilestone
+from hub.utils import get_user_profile_safe
 from prayers.models import PrayerRequest, PrayerRequestAcceptance, PrayerRequestPrayerLog
 from prayers.serializers import (
     PrayerRequestSerializer,
@@ -466,8 +467,9 @@ class PrayerRequestViewSet(viewsets.ModelViewSet):
         # Create activity feed item for requester
         if not prayer_request.is_anonymous:
             # Get display name from profile, fallback to "User {first_letter}" for privacy
-            if hasattr(request.user, 'profile') and request.user.profile and request.user.profile.name:
-                acceptor_name = request.user.profile.name
+            profile = get_user_profile_safe(request.user)
+            if profile and profile.name:
+                acceptor_name = profile.name
             else:
                 # Privacy-safe fallback: "User D" instead of showing email
                 first_letter = request.user.email[0].upper() if request.user.email else 'U'
@@ -613,8 +615,9 @@ class PrayerRequestViewSet(viewsets.ModelViewSet):
 
         # Create activity feed items for all who accepted (excluding requester)
         # Get display name from profile, fallback to "User {first_letter}" for privacy
-        if hasattr(request.user, 'profile') and request.user.profile and request.user.profile.name:
-            sender_name = request.user.profile.name
+        profile = get_user_profile_safe(request.user)
+        if profile and profile.name:
+            sender_name = profile.name
         else:
             # Privacy-safe fallback: "User D" instead of showing email
             first_letter = request.user.email[0].upper() if request.user.email else 'U'


### PR DESCRIPTION
Fixes #276

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates activity feed copy to prefer profile display names and avoid exposing emails.
> 
> - For `prayer_request_accepted` and `prayer_request_thanks`, titles now use `get_user_profile_safe(request.user).name` when present
> - Privacy-safe fallback to `User {first_letter}` instead of email/username
> - Adds import for `get_user_profile_safe`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88120532d3a2af82fcf26e8555d9190f7394530f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->