### PR TITLE
Add admin action to regenerate feast context with improvement instructions

### DIFF
--- a/hub/tasks/llm_tasks.py
+++ b/hub/tasks/llm_tasks.py
@@ -213,7 +213,7 @@ def _create_feast_context_with_translations(
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
 def generate_feast_context_task(
-    self, feast_id: int, force_regeneration: bool = False, language_code: str = None
+    self, feast_id: int, force_regeneration: bool = False, language_code: str = None, improvement_instructions: str = None
 ):
     """Generate and save AI context for a Feast instance in all available languages.
 
@@ -221,6 +221,7 @@ def generate_feast_context_task(
         feast_id: ID of the Feast to generate context for
         force_regeneration: If True, regenerate even if context exists
         language_code: DEPRECATED - Ignored. All languages are always generated.
+        improvement_instructions: Optional instructions to improve the generated content
     """
     if language_code is not None:
         logger.warning(
@@ -254,7 +255,7 @@ def generate_feast_context_task(
         generated_contexts = {}
         for lang in AVAILABLE_LANGUAGES:
             # Generate both text and short_text in a single call
-            context_dict = service.generate_feast_context(feast, llm_prompt, lang)
+            context_dict = service.generate_feast_context(feast, llm_prompt, lang, improvement_instructions)
             
             if context_dict and 'text' in context_dict and 'short_text' in context_dict:
                 generated_contexts[lang] = context_dict

--- a/hub/templates/admin/hub/feast/regenerate_context_instructions.html
+++ b/hub/templates/admin/hub/feast/regenerate_context_instructions.html
@@ -1,0 +1,76 @@
+{% extends "admin/base_site.html" %}
+
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; {% translate "Regenerate Context with Instructions" %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h1>{% translate "Regenerate Feast Context with Improvement Instructions" %}</h1>
+
+<p>You are about to regenerate AI context for the following {{ feasts|length }} feast(s):</p>
+
+<ul class="object-tools" style="list-style-type: disc; margin-left: 20px; margin-bottom: 20px;">
+{% for feast in feasts %}
+    <li style="margin: 5px 0;">
+        <strong>{{ feast.name }}</strong>
+        {% if feast.day %}
+            ({{ feast.day.date }})
+        {% endif %}
+    </li>
+{% endfor %}
+</ul>
+
+<form action="" method="post">
+    {% csrf_token %}
+    <input type="hidden" name="ids" value="{{ ids }}">
+
+    <fieldset class="module aligned">
+        <h2>{% translate "Improvement Instructions" %}</h2>
+        <div class="form-row">
+            <div>
+                <label for="improvement_instructions">
+                    {% translate "Instructions for improving the generated content:" %}
+                </label>
+                <p class="help">
+                    {% translate "These instructions will be appended to the LLM prompt to guide content generation." %}
+                </p>
+                <textarea
+                    id="improvement_instructions"
+                    name="improvement_instructions"
+                    rows="6"
+                    cols="80"
+                    style="width: 100%; max-width: 800px;"
+                    placeholder="Enter your improvement instructions here..."></textarea>
+            </div>
+        </div>
+
+        <div class="form-row" style="margin-top: 15px;">
+            <div>
+                <strong>{% translate "Example instructions:" %}</strong>
+                <ul style="list-style-type: disc; margin-left: 20px; margin-top: 10px; color: #666;">
+                    <li>Make it more concise and focused</li>
+                    <li>Focus on the historical significance and origins</li>
+                    <li>Emphasize the spiritual meaning for modern Christians</li>
+                    <li>Include more details about Armenian traditions</li>
+                    <li>Make the short_text more engaging and inviting</li>
+                    <li>Use simpler language suitable for new believers</li>
+                </ul>
+            </div>
+        </div>
+    </fieldset>
+
+    <div class="submit-row" style="margin-top: 20px;">
+        <input type="submit" value="{% translate 'Regenerate Context' %}" class="default">
+        <a href="{% url opts|admin_urlname:'changelist' %}" class="button cancel-link" style="margin-left: 10px;">
+            {% translate "Cancel" %}
+        </a>
+    </div>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add new admin action "Regenerate context with improvement instructions" for Feast model
- Allow admins to provide custom instructions that guide AI content generation (e.g., "make it more concise", "focus on historical significance")
- Instructions are appended to the LLM prompt and applied during regeneration

## Changes
- **LLM Service**: Add `improvement_instructions` parameter to `generate_feast_context()` in both `AnthropicService` and `OpenAIService`
- **Celery Task**: Update `generate_feast_context_task` to accept and pass through `improvement_instructions`
- **Admin**: Add action, URL, and view to `FeastAdmin` for the intermediate instructions page
- **Template**: Create `regenerate_context_instructions.html` with textarea and example instructions

## Test plan
- [ ] Go to Django admin > Hub > Feasts
- [ ] Select one or more feasts
- [ ] Choose "Regenerate context with improvement instructions" from actions dropdown
- [ ] Verify intermediate page shows selected feasts and textarea
- [ ] Enter instructions and submit
- [ ] Verify task is enqueued (check Celery logs or FeastContext updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an instruction-driven regeneration path for feast contexts.
> 
> - Adds FeastAdmin action, URL, and view with a new template (`regenerate_context_instructions.html`) to collect instructions and enqueue `generate_feast_context_task` with `improvement_instructions`
> - Extends LLM interface: `generate_feast_context(...)` now accepts `improvement_instructions`; implemented in `AnthropicService` and `OpenAIService` by appending to prompts
> - Updates Celery task `generate_feast_context_task` to accept and pass `improvement_instructions` while generating all languages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58b6c2d2935382a51ef56d22504450e5ce812121. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->