### PR TITLE
Fix prayer request moderation LLM response parsing

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -555,6 +555,15 @@ class LLMPromptAdmin(admin.ModelAdmin):
         }),
         ('Important Notes', {
             'description': (
+                '<strong>For Prayer Requests:</strong> The prompt must include <code>{title}</code> and '
+                '<code>{description}</code> placeholders where the prayer request content will be inserted. '
+                'The prompt should instruct the LLM to return a JSON response with these fields: '
+                '<code>"approved"</code>, <code>"reason"</code>, <code>"concerns"</code>, <code>"severity"</code>, '
+                '<code>"requires_human_review"</code>, and <code>"suggested_action"</code>.<br><br>'
+                '<strong style="color: #c00;">Important:</strong> If your prompt includes a JSON example, '
+                'you must escape the curly braces by doubling them: use <code>{{</code> and <code>}}</code> '
+                'instead of <code>{</code> and <code>}</code>. Otherwise, Python\'s string formatting will '
+                'interpret them as placeholders and cause errors.<br><br>'
                 '<strong>For Feasts:</strong> The prompt must instruct the LLM to return a JSON response '
                 'with two fields: <code>"text"</code> (detailed explanation) and <code>"short_text"</code> '
                 '(2-sentence summary). Example instruction: "Return your response as JSON with two fields: '


### PR DESCRIPTION
## Summary
- Fix bug where LLM moderation was failing due to malformed responses
- Add validation that parsed LLM response is a dict with required `approved` key
- Use `role` field from LLMPrompt as system message for better prompt adherence
- Add admin documentation explaining prayer request prompt requirements

## Root Cause
The prayer request moderation was failing because:
1. The LLMPrompt was missing `{title}` and `{description}` placeholders, so the LLM never received the prayer request content
2. JSON examples in the prompt used unescaped `{` and `}` which Python's `.format()` interpreted as placeholders
3. No validation existed to catch when the LLM returned malformed responses

## Test plan
- [x] Verified moderation works with corrected LLMPrompt in database
- [x] All existing prayer request tests pass (34 tests)
- [x] LLMPrompt admin tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens prayer request moderation and admin guidance.
> 
> - Prayers: `_get_moderation_prompt_and_service` now returns `(model, system_role, prompt)`; Anthropic call includes optional `system`; added strict parsing/validation of LLM output (must be a dict with `approved`), with improved error handling
> - Admin: Adds “Important Notes” to `LLMPrompt` explaining required `{title}`/`{description}` placeholders, required JSON fields, and the need to escape `{`/`}` in JSON examples
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 948d5f0a208194b281af60180f3119b68debea81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->