### PR TITLE
Overwrote changes for St. Kirakos and his mother. Changing back

### DIFF
--- a/data/feasts.json
+++ b/data/feasts.json
@@ -167,7 +167,7 @@
   {
     "month": "January",
     "day": "21",
-    "name": "Commemoration of St. Kirakos and his mother Judithah",
+    "name": "Commemoration of St. Cyricus and his mother Julitta",
     "description": "Judithah was a God-loving and pious woman. She had a three-year-old son, whose name was Kirakos. When persecutions against the Christians began, she left for Tarson. But she did not live a quiet and peaceful life there as the persecutions were being continued in Tarson, too. The saint woman was imprisoned and subjected to torments. Little Kirakos, seeing his mother’s sufferings cried, but despite the judge’s kindness and warm attitude, he was strengthened by his faith towards Christ and all the time repeated his mother’s words: “I am Christian and I worship Jesus Christ”. The baby tried by all means to get free from the judge’s hands and to go to his mother. He struck the judge in the hand and the annoyed judge threw the baby down the stairs. Knocking his head against a stone, the baby died. His mother rendered glory to God that her son was martyred, but did not betray Our Savior Jesus Christ. She was subjected to indescribable torments and finally was beheaded. This event took place in 305 AD The Armenian Church has dedicated a church hymn to St. Kirakos.",
     "upcoming_dates": [
       "2026-01-21"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates data to correct the Jan 21 feast entry name.
> 
> - Changes `name` for January 21 in `data/feasts.json` from `Commemoration of St. Kirakos and his mother Judithah` to `Commemoration of St. Cyricus and his mother Julitta`
> - No code or logic changes; data-only adjustment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c37a6906c5f9e0f2e78ab65c1371ceb31b83092d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->