### PR TITLE
Fix PrayerRequest thumbnail cache AttributeError in activity feed

### DIFF
--- a/events/serializers.py
+++ b/events/serializers.py
@@ -202,17 +202,16 @@ class UserActivityFeedSerializer(serializers.ModelSerializer, ThumbnailCacheMixi
         
         target = obj.target
         
-        # Handle Fast thumbnails
-        if hasattr(target, 'image') and target.image:
+        # Handle Fast thumbnails (image field with image_thumbnail spec)
+        if hasattr(target, 'image_thumbnail') and hasattr(target, 'image') and target.image:
             try:
                 # Use cached thumbnail URL if available
                 cached_url = self.update_thumbnail_cache(target, 'image', 'image_thumbnail')
                 if cached_url:
                     return cached_url
-                
+
                 # Fall back to direct thumbnail URL
-                if hasattr(target, 'image_thumbnail'):
-                    return target.image_thumbnail.url
+                return target.image_thumbnail.url
             except Exception:
                 pass
         


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'PrayerRequest' object has no attribute 'image_thumbnail'` logged to Sentry during activity feed serialization
- The thumbnail handler for Fast objects incorrectly matched PrayerRequest (which has `image` but uses `thumbnail` not `image_thumbnail` as its spec name)
- Added `hasattr(target, 'image_thumbnail')` guard so PrayerRequest falls through to the correct `thumbnail` handler block

## Test plan
- [ ] Verify activity feed loads without Sentry errors when PrayerRequest events are present
- [ ] Verify Fast thumbnails still resolve correctly in the activity feed
- [ ] Confirm no new `image_thumbnail` AttributeErrors in Sentry after deploy

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized serializer change that only adds an attribute guard; low risk aside from potentially changing which thumbnail branch is used for some models.
> 
> **Overview**
> Fixes activity-feed thumbnail serialization by tightening the “Fast thumbnail” detection in `UserActivityFeedSerializer.get_target_thumbnail`.
> 
> The serializer now requires `image_thumbnail` to exist before attempting cache updates or returning `target.image_thumbnail.url`, preventing `AttributeError` for targets that have an `image` field but no `image_thumbnail` spec (e.g., PrayerRequest) so they fall through to other thumbnail handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb54437a527f8984f7deeab4620b39671e02ac17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->