### PR TITLE
Use authenticated user timezone when filtering devotional list

### DIFF
--- a/hub/views/devotionals.py
+++ b/hub/views/devotionals.py
@@ -119,7 +119,7 @@ class DevotionalDetailView(generics.RetrieveAPIView):
         return super().get(request, *args, **kwargs)
 
 
-class DevotionalListView(ChurchContextMixin, generics.ListAPIView):
+class DevotionalListView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
     """
     API endpoint that provides a list of devotionals for a given church.
 
@@ -195,13 +195,16 @@ class DevotionalListView(ChurchContextMixin, generics.ListAPIView):
         church = self.get_church()
         lang = self.request.query_params.get('lang') or get_language_from_request(self.request) or 'en'
         activate(lang)
+        local_today = timezone.localdate(timezone=self.get_timezone())
         qs = Devotional.objects.select_related("day", "video").filter(
             day__church=church,
+            day__date__lte=local_today,
             language_code=lang,
         )
         if not qs.exists():
             qs = Devotional.objects.select_related("day", "video").filter(
                 day__church=church,
+                day__date__lte=local_today,
                 language_code="en",
             )
 

--- a/hub/views/mixins.py
+++ b/hub/views/mixins.py
@@ -1,6 +1,6 @@
 from rest_framework.exceptions import ValidationError
 from ..models import Church
-from django.utils import timezone
+from django.core.exceptions import ObjectDoesNotExist
 import pytz
 
 
@@ -38,6 +38,12 @@ class TimezoneMixin:
 
     def get_timezone(self):
         tz_str = self.request.query_params.get('tz')
+        if not tz_str and self.request.user.is_authenticated:
+            try:
+                tz_str = self.request.user.profile.timezone
+            except ObjectDoesNotExist:
+                tz_str = None
+
         if tz_str:
             return pytz.timezone(tz_str)
         return pytz.UTC


### PR DESCRIPTION
### Motivation
- Devotional list previously used server/local date when excluding future-dated devotionals, which can surface items that are still “in the future” for the requesting user; other endpoints already consider timezone context. 
- Ensure the devotional list filters by the requester’s local date (including an authenticated user’s profile timezone) so results are consistent with the user’s locale.

### Description
- Updated `TimezoneMixin.get_timezone()` to fall back to an authenticated user’s profile timezone when the `tz` query parameter is not provided, with a safe `ObjectDoesNotExist` guard, and continue to default to `pytz.UTC` otherwise (`hub/views/mixins.py`).
- Made `DevotionalListView` inherit `TimezoneMixin` and compute a local cutoff with `local_today = timezone.localdate(timezone=self.get_timezone())`, and applied `day__date__lte=local_today` for both primary-language and English-fallback querysets (`hub/views/devotionals.py`).
- Added/updated tests in `hub/tests/test_devotional_list_api.py` to create an explicit `Profile` for the test user and to assert that an authenticated user’s profile timezone controls the local cutoff via a new `test_authenticated_user_profile_timezone_controls_local_cutoff` that uses `APIRequestFactory`, `force_authenticate`, and a mocked `timezone.now()`.

### Testing
- Ran `CI=true MAILGUN_DOMAIN=example.com MAILGUN_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy python manage.py test hub.tests.test_devotional_list_api --settings=tests.test_settings`, which executed the devotional list tests and completed successfully (7 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ea5cfcc483298ffa7ff2d7ae8cd6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query filtering semantics for a public list endpoint based on timezone resolution (query param vs user profile), which could affect which items users see around date boundaries.
> 
> **Overview**
> Devotional list filtering now uses the requester’s local date to exclude future-dated devotionals: `DevotionalListView` adds `TimezoneMixin`, computes `local_today` via `timezone.localdate(timezone=self.get_timezone())`, and applies `day__date__lte=local_today` (including the English fallback queryset).
> 
> `TimezoneMixin.get_timezone()` now falls back to an authenticated user’s `profile.timezone` when no `tz` query param is provided (with an `ObjectDoesNotExist` guard). Tests were expanded to create a user/profile with a timezone, verify the local cutoff via mocked `timezone.now()`, and assert future-dated devotionals are not returned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb0d9844423f894324d5d9217f26d9c24f781b0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->