### PR TITLE
Add custom pagination for icon list endpoint

### DIFF
--- a/icons/views.py
+++ b/icons/views.py
@@ -6,6 +6,8 @@ from rest_framework.response import Response
 from django.db.models import Q
 from django.conf import settings
 
+from rest_framework.pagination import PageNumberPagination
+
 from icons.models import Icon
 from icons.serializers import IconSerializer
 from hub.services.llm_service import get_llm_service
@@ -13,21 +15,28 @@ from hub.services.llm_service import get_llm_service
 logger = logging.getLogger(__name__)
 
 
+class IconPagination(PageNumberPagination):
+    """Larger page size for icon grid browsing."""
+    page_size = 15
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+
+
 class IconListView(generics.ListAPIView):
     """
     API endpoint that allows icons to be viewed and filtered.
-    
+
     Permissions:
         - GET: Any user can view icons
-    
+
     Query Parameters:
         - church: Filter by church ID
         - tags: Filter by tag name (can be comma-separated)
         - search: Search in title
-    
+
     Returns:
         A paginated list of icons with their details.
-    
+
     Example Requests:
         GET /api/icons/
         GET /api/icons/?church=1
@@ -36,6 +45,7 @@ class IconListView(generics.ListAPIView):
     """
     serializer_class = IconSerializer
     permission_classes = [AllowAny]
+    pagination_class = IconPagination
     
     def get_queryset(self):
         """Get icons with optional filtering."""


### PR DESCRIPTION
## Summary
- Add `IconPagination` class with `page_size = 15` (5 rows in a 3-column grid) for the icon list endpoint
- Allow clients to override page size via `page_size` query param (max 100)
- Replaces the default page size of 10 which was too small for icon grid browsing

## Test plan
- [ ] `GET /api/icons/` returns 15 results per page by default
- [ ] `GET /api/icons/?page_size=30` respects the override
- [ ] Pagination `next`/`previous` links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts list pagination defaults and exposes an already-standard `page_size` override with a max cap; no auth or data mutation logic changes.
> 
> **Overview**
> Adds a custom DRF `IconPagination` for the icon list endpoint, increasing the default page size to 15 for grid browsing.
> 
> `IconListView` now uses this pagination and allows client overrides via `?page_size=` (capped at 100).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe1f89e91923c21ba40771f144a1277c36b39718. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->