### PR TITLE
Add start_day_number to Fast to support Day 0 fasts

### DIFF
--- a/hub/migrations/0048_add_start_day_number_to_fast.py
+++ b/hub/migrations/0048_add_start_day_number_to_fast.py
@@ -12,8 +12,8 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='fast',
-            name='start_day_number',
-            field=models.PositiveIntegerField(default=1, help_text="The day number assigned to the first day of the fast (e.g., 0 if the fast has a 'Day 0')"),
+            name='has_day_zero',
+            field=models.BooleanField(default=False, help_text='If True, the fast starts counting from Day 0 instead of Day 1'),
         ),
         migrations.AlterField(
             model_name='devotional',

--- a/hub/models.py
+++ b/hub/models.py
@@ -69,9 +69,9 @@ class Fast(models.Model):
         blank=True,
         help_text="Attribution or author of the culmination feast message"
     )
-    start_day_number = models.PositiveIntegerField(
-        default=1,
-        help_text="The day number assigned to the first day of the fast (e.g., 0 if the fast has a 'Day 0')",
+    has_day_zero = models.BooleanField(
+        default=False,
+        help_text="If True, the fast starts counting from Day 0 instead of Day 1",
     )
 
     # auto-saved to be the year of the first day of the fast


### PR DESCRIPTION
## Summary

- Adds a `start_day_number` field (default=1) to the `Fast` model
- Updates `get_current_day_number` in the serializer to apply `start_day_number - 1` as an offset on both the annotation and fallback computation paths
- Fixes the off-by-one error in `current_day_number` for fasts that begin with a "Day 0" devotional (e.g., Fast 112 / Great Lent 2026)

**Backward compatible:** all existing fasts default to `start_day_number=1`, which produces identical behavior to before.

To fix an affected fast, set `start_day_number=0` via the admin.

## Test plan

- [x] Existing hub unit tests pass
- [ ] Verify fast 112 returns `current_day_number=6` after setting `start_day_number=0` in admin
- [ ] Confirm other fasts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: simple additive model field plus a small arithmetic adjustment in a serializer; existing fasts keep identical behavior due to the default value.
> 
> **Overview**
> Adds a `start_day_number` field to `Fast` (via migration) so a fast can start at day 0 (or other non-1 numbering) while defaulting to 1 for existing data.
> 
> Updates `FastSerializer.get_current_day_number` to apply a `(start_day_number - 1)` offset to both the annotated `current_day_count` path and the fallback computed count, fixing off-by-one day numbering for “Day 0” fasts. The migration also updates `Devotional.order` field metadata/help text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11ebda5b50918f83095d598a26998bdf3fe7dad3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->