### PR TITLE
Fix Sentry noise: missing devotional is expected, not an error

### DIFF
--- a/hub/views/devotionals.py
+++ b/hub/views/devotionals.py
@@ -25,7 +25,8 @@ class DevotionalByDateView(ChurchContextMixin, TimezoneMixin, generics.RetrieveA
     """
     API endpoint that provides details of a single devotional.
 
-    If no devotional exists for the given date, returns null.
+    If no devotional exists for the given date, returns HTTP 200 with a null body.
+    Not every day has a devotional, so this is an expected, non-error response.
 
     Permissions:
         - GET: Any user can view devotional
@@ -40,7 +41,7 @@ class DevotionalByDateView(ChurchContextMixin, TimezoneMixin, generics.RetrieveA
         # Activate requested language
         lang = self.request.query_params.get('lang') or get_language_from_request(self.request) or 'en'
         activate(lang)
-        
+
         date_str = self.request.query_params.get('date')
         tz = self.get_timezone()
 
@@ -54,7 +55,7 @@ class DevotionalByDateView(ChurchContextMixin, TimezoneMixin, generics.RetrieveA
             # Default to the current date
             target_date = timezone.localdate(timezone=tz)
 
-        # Try requested language, then fallback to default 'en'
+        # Try requested language, then fallback to 'en', then any language for that date.
         try:
             return Devotional.objects.get(day__church=church, day__date=target_date, language_code=lang)
         except Devotional.DoesNotExist:
@@ -65,8 +66,16 @@ class DevotionalByDateView(ChurchContextMixin, TimezoneMixin, generics.RetrieveA
         try:
             return Devotional.objects.get(day__church=church, day__date=target_date)
         except Devotional.DoesNotExist:
-            logging.error(f"Devotional not found for {target_date} for church {church.name}")
+            # No devotional for this date — this is expected for some churches/days.
+            logging.debug(f"No devotional for {target_date} for church {church.name}")
             return None
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        if instance is None:
+            return Response(None)
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
 
 
 class DevotionalsByFastView(generics.ListAPIView):


### PR DESCRIPTION
## Summary

- The `/api/devotionals/by-date/` endpoint was calling `logging.error()` when no devotional existed for a given date/church combination. Sentry's logging integration captured every one of these as an alert — generating **5,295 events affecting 720 users** since March 2025 (Sentry issue `PYTHON-DJANGO-3`).
- Not every church has a devotional for every day. This is expected behaviour, not an error.
- Downgraded log level to `debug` so Sentry stops capturing it.
- Added an explicit `retrieve()` override to return `Response(None)` (JSON `null`) when no devotional is found, rather than relying on DRF serializing `None` as an ambiguous `{}`.

## What changed

| File | Change |
|------|--------|
| `hub/views/devotionals.py` | `logging.error` → `logging.debug`; added `retrieve()` override returning `null` explicitly |

## Frontend companion PR

surp-hovhannes/bahk_react_native — tightens `getDevotionalByDate` and `useDevotionalByDate` return types from `Devotional` to `Devotional | null` to match the now-documented contract. `DevotionalCard` already handles `null` gracefully with an early return — no UI changes needed.

## Test plan

- [x] Existing Django test suite passes (882 tests)
- [ ] Confirm Sentry issue `PYTHON-DJANGO-3` stops generating new events after deploy
- [ ] Verify `/api/devotionals/by-date/` returns `null` (not `{}`) for a date with no devotional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to the `DevotionalByDateView` read path: it downgrades logging severity and explicitly returns `null` for missing records, with minimal impact outside this endpoint.
> 
> **Overview**
> Stops treating “no devotional for date/church” as an error in `/api/devotionals/by-date/` by downgrading the log from `error` to `debug` and documenting that a missing devotional is an expected *HTTP 200 + JSON `null`* response.
> 
> Makes the response explicit by overriding `retrieve()` to return `Response(None)` when `get_object()` can’t find a devotional, and extends lookup fallback to try requested language, then `en`, then any language for that date.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72059686db1a026ec86e5a63cfb80126a961df50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->