### PR TITLE
Prayer nudge timing logic

### DIFF
--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -831,11 +831,13 @@ def send_prayer_acceptance_nudge_task():
 
     # Acceptances for active requests where the user hasn't prayed recently.
     # Exclude auto-acceptances (counts_for_milestones=False means requester's own).
+    # Only consider acceptances that are at least 2 days old to respect the grace period.
     overdue = (
         PrayerRequestAcceptance.objects.filter(
             prayer_request__in=active_requests,
             counts_for_milestones=True,
             user__is_active=True,
+            accepted_at__date__lte=two_days_ago,
         )
         .annotate(recently_prayed=Exists(recent_prayer))
         .filter(recently_prayed=False)


### PR DESCRIPTION
Prevent premature prayer nudges by filtering accepted requests to be at least 2 days old.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small query filter change that only reduces/defers notifications; main risk is timezone/date boundary behavior of `accepted_at__date` filtering.
> 
> **Overview**
> Adds a **2-day grace period** to `send_prayer_acceptance_nudge_task` by filtering overdue acceptances to those with `accepted_at__date <= two_days_ago`, preventing prayer nudges from being sent immediately after a user accepts a request.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93a4fc0a9d4689a16fa32781a9031202c4ffa1e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->