### PR TITLE
Fix gunicorn OOM kills and cron timeout from sacredtradition.am hangs

### DIFF
--- a/hub/utils.py
+++ b/hub/utils.py
@@ -96,16 +96,14 @@ def scrape_readings(date_obj, church, date_format="%Y%m%d", max_num_readings=40)
         url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM=1103&iL={language_code}&ymd={date_str}"
         try:
             response = urllib.request.urlopen(url, timeout=10)
+            if response.status != 200:
+                logging.error("Could not access readings from url %s. Failed with status %r", url, response.status)
+                return []
+            data = response.read()
+            html_content = data.decode("utf-8")
         except (urllib.error.URLError, OSError):
             logging.error("Invalid url %s", url)
             return []
-
-        if response.status != 200:
-            logging.error("Could not access readings from url %s. Failed with status %r", url, response.status)
-            return []
-
-        data = response.read()
-        html_content = data.decode("utf-8")
 
         book_start = html_content.find("<b>")
 
@@ -418,16 +416,14 @@ def scrape_feast(date_obj, church, date_format="%Y%m%d"):
         
         try:
             response = urllib.request.urlopen(req, timeout=10)
+            if response.status != 200:
+                logging.error("Could not access feast from url %s. Failed with status %r", url, response.status)
+                return None
+            data = response.read()
+            html_content = data.decode("utf-8")
         except (urllib.error.URLError, OSError):
             logging.error("Invalid url %s", url)
             return None
-
-        if response.status != 200:
-            logging.error("Could not access feast from url %s. Failed with status %r", url, response.status)
-            return None
-
-        data = response.read()
-        html_content = data.decode("utf-8")
 
         # Look for elements with class="dname" or class=dname (with or without quotes)
         # Match various HTML tags with class dname

--- a/hub/utils.py
+++ b/hub/utils.py
@@ -102,7 +102,7 @@ def scrape_readings(date_obj, church, date_format="%Y%m%d", max_num_readings=40)
             data = response.read()
             html_content = data.decode("utf-8")
         except (urllib.error.URLError, OSError):
-            logging.error("Invalid url %s", url)
+            logging.error("Failed to fetch %s", url)
             return []
 
         book_start = html_content.find("<b>")
@@ -422,7 +422,7 @@ def scrape_feast(date_obj, church, date_format="%Y%m%d"):
             data = response.read()
             html_content = data.decode("utf-8")
         except (urllib.error.URLError, OSError):
-            logging.error("Invalid url %s", url)
+            logging.error("Failed to fetch %s", url)
             return None
 
         # Look for elements with class="dname" or class=dname (with or without quotes)

--- a/hub/utils.py
+++ b/hub/utils.py
@@ -95,8 +95,8 @@ def scrape_readings(date_obj, church, date_format="%Y%m%d", max_num_readings=40)
         """
         url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM=1103&iL={language_code}&ymd={date_str}"
         try:
-            response = urllib.request.urlopen(url)
-        except urllib.error.URLError:
+            response = urllib.request.urlopen(url, timeout=10)
+        except (urllib.error.URLError, OSError):
             logging.error("Invalid url %s", url)
             return []
 
@@ -417,8 +417,8 @@ def scrape_feast(date_obj, church, date_format="%Y%m%d"):
         req = urllib.request.Request(url, headers={'User-agent': 'Mozilla/5.0'})
         
         try:
-            response = urllib.request.urlopen(req)
-        except urllib.error.URLError:
+            response = urllib.request.urlopen(req, timeout=10)
+        except (urllib.error.URLError, OSError):
             logging.error("Invalid url %s", url)
             return None
 

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -772,7 +772,7 @@ def send_inactive_fast_member_nudge_task():
             continue
 
         cache_keys = {uid: _REENGAGEMENT_CACHE_KEY.format(user_id=uid) for uid in inactive_joined}
-        cached = cache.get_many(cache_keys.values())
+        cached = cache.get_many(list(cache_keys.values()))
         eligible_ids = [uid for uid, key in cache_keys.items() if key not in cached]
 
         if not eligible_ids:

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -761,23 +761,30 @@ def send_inactive_fast_member_nudge_task():
 
     total_sent = 0
     for fast in active_fasts:
-        inactive_joined = User.objects.filter(
-            profile__fasts=fast,
-            is_active=True,
-        ).exclude(id__in=recently_active_ids)
+        inactive_joined = list(
+            User.objects.filter(
+                profile__fasts=fast,
+                is_active=True,
+            ).exclude(id__in=recently_active_ids).values_list('id', flat=True)
+        )
 
-        for user in inactive_joined:
-            cache_key = _REENGAGEMENT_CACHE_KEY.format(user_id=user.id)
-            if cache.get(cache_key):
-                continue
+        if not inactive_joined:
+            continue
 
-            send_push_notification_to_users_task.delay(
-                message=INACTIVE_FAST_MEMBER_MESSAGE.format(fast_name=fast.name),
-                data={'screen': f'fast/{fast.id}'},
-                user_ids=[user.id],
-            )
-            cache.set(cache_key, True, timeout=_REENGAGEMENT_TTL)
-            total_sent += 1
+        cache_keys = {uid: _REENGAGEMENT_CACHE_KEY.format(user_id=uid) for uid in inactive_joined}
+        cached = cache.get_many(cache_keys.values())
+        eligible_ids = [uid for uid, key in cache_keys.items() if key not in cached]
+
+        if not eligible_ids:
+            continue
+
+        send_push_notification_to_users_task.delay(
+            message=INACTIVE_FAST_MEMBER_MESSAGE.format(fast_name=fast.name),
+            data={'screen': f'fast/{fast.id}'},
+            user_ids=eligible_ids,
+        )
+        cache.set_many({cache_keys[uid]: True for uid in eligible_ids}, timeout=_REENGAGEMENT_TTL)
+        total_sent += len(eligible_ids)
 
     logger.info(f'Push Notification: Inactive fast member nudge sent to {total_sent} users')
 


### PR DESCRIPTION
## Summary
- Add 10s timeout + broaden exception handling on `urlopen` calls in `hub/utils.py` for both readings and feast scraping — prevents Gunicorn workers from hanging indefinitely on slow SSL connections to `sacredtradition.am`, which was causing OOM worker kills and `SystemExit` errors on `/api/readings/` and `/api/feasts/`
- Batch Redis cache lookups (`get_many`/`set_many`) and consolidate Celery dispatches to one per fast in `send_inactive_fast_member_nudge_task` — reduces serial per-user Redis round trips that were contributing to cron monitor timeouts

## Sentry issues addressed
- PYTHON-DJANGO-PJ — `Worker SIGKILL / OOM` (22 occurrences, escalating)
- PYTHON-DJANGO-PG — `SystemExit: 1` on `/api/feasts/` (13 occurrences)
- PYTHON-DJANGO-PR — `SystemExit: 1` on `/api/readings/`
- PYTHON-DJANGO-PQ — Cron timeout: `send-inactive-fast-member-nudge-daily`

## Test plan
- [ ] Run `tests.unit.hub` and `tests.unit.notifications` — all 28 pass
- [ ] Verify `/api/readings/` and `/api/feasts/` return gracefully when `sacredtradition.am` is slow or unreachable
- [ ] Monitor Sentry after deploy to confirm OOM kills stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production scraping/network I/O and notification fanout; failures could suppress readings/feasts or send nudges to an incorrect set of users if the cache-key batching logic is wrong, but changes are localized and add safeguards (timeouts/early returns).
> 
> **Overview**
> Prevents backend hangs when scraping `sacredtradition.am` by adding a 10s `urlopen` timeout, checking non-200 responses early, and broadening error handling to include `OSError` for both readings and feast scraping in `hub/utils.py`.
> 
> Reduces cron/Celery overhead in `send_inactive_fast_member_nudge_task` by switching from per-user cache checks and per-user notification dispatch to batched `cache.get_many`/`set_many` and a single `send_push_notification_to_users_task` call per fast for all eligible inactive users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8253246f154341f9e1f27404314dfaa4885fe7fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->