### PR TITLE
fix: use select_related and only() on Feast queryset to reduce memory

### DIFF
--- a/.github/workflows/django_ci.yml
+++ b/.github/workflows/django_ci.yml
@@ -108,7 +108,7 @@ jobs:
       run: |
         # Run Django tests, --noinput avoids interactive prompts
         # Exclude performance and slow tests for faster CI runs
-        python manage.py test --noinput --parallel --exclude-tag=performance --exclude-tag=slow --settings=tests.test_settings
+        python manage.py test --noinput --exclude-tag=performance --exclude-tag=slow --settings=tests.test_settings
 
     # Example Deployment step (conditional on push to main branch and specific Python version)
     # - name: Deploy to Hosting Provider (e.g., Heroku)

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -50,7 +50,7 @@ class GetFeastForDate(generics.GenericAPIView):
 
     def get_queryset(self):
         return Feast.objects.select_related('icon', 'day').only(
-            'id', 'name', 'name_en', 'name_hy', 'designation',
+            'id', 'name', 'i18n', 'name_en', 'name_hy', 'designation',
             'icon__id', 'icon__title', 'icon__cached_thumbnail_url',
             'icon__cached_thumbnail_updated', 'day__date', 'day__church'
         )
@@ -96,6 +96,9 @@ class GetFeastForDate(generics.GenericAPIView):
 
             # Use the feast from the utility function, or get it from the day if None
             feast = feast_obj if feast_obj else day.feasts.first()
+            # Re-fetch through optimized queryset to avoid loading large icon binary data
+            if feast is not None:
+                feast = self.get_queryset().filter(pk=feast.pk).first()
             
             if feast is None:
                 # No feast on this day

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -52,7 +52,7 @@ class GetFeastForDate(generics.GenericAPIView):
         return Feast.objects.select_related('icon', 'day').only(
             'id', 'name', 'name_en', 'name_hy', 'designation',
             'icon__id', 'icon__title', 'icon__cached_thumbnail_url',
-            'icon__image', 'day__date', 'day__church'
+            'icon__cached_thumbnail_updated', 'day__date', 'day__church'
         )
 
     def get(self, request, *args, **kwargs):

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -48,6 +48,13 @@ class GetFeastForDate(generics.GenericAPIView):
         }
     """
 
+    def get_queryset(self):
+        return Feast.objects.select_related('icon', 'day').only(
+            'id', 'name', 'name_en', 'name_hy', 'designation',
+            'icon__id', 'icon__title', 'icon__cached_thumbnail_url',
+            'icon__image', 'day__date', 'day__church'
+        )
+
     def get(self, request, *args, **kwargs):
         date_format = "%Y-%m-%d"
 


### PR DESCRIPTION
## Summary

Add get_queryset() to GetFeastForDate that uses select_related('icon', 'day') and only() to avoid loading icon image binary data and unbounded related objects into memory.

## Problem

Workers getting SIGKILL (out of memory) on /api/feasts/ endpoint. The queryset was loading all fields including potentially large icon.image data without optimization.

## Fix



## Notes

This builds on PR #332 (icon serializer memory fix) and PR #333 (sentry production errors). Already in main via PR #332 was the icon serializer fix that prevents thumbnail.generate() calls during serialization.

## Labels

- bug
- performance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a hot API endpoint and changes ORM loading behavior; incorrect `only()` field coverage could introduce extra queries or missing/deferred-field access at runtime. CI change removes parallel test execution but is otherwise low impact.
> 
> **Overview**
> Reduces memory usage on the `/api/feasts/` endpoint by introducing an optimized `Feast` queryset (`select_related('icon','day')` + `only(...)`) and re-fetching the selected feast through it to avoid loading heavy icon/image fields.
> 
> Updates GitHub Actions CI to run `manage.py test` without `--parallel` while still excluding `performance` and `slow` tagged tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b31fcf902ecd339e4df7d9c9435d19fb7d9686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->