### PR TITLE
chore: add ruff linter to CI and fix all lint errors

### DIFF
--- a/.github/workflows/django_ci.yml
+++ b/.github/workflows/django_ci.yml
@@ -72,14 +72,9 @@ jobs:
           exit 1
         fi
 
-    # Optional but recommended: Add linting step
-    # - name: Lint with flake8 
-    #   run: |
-    #     pip install flake8
-    #     # Stop the build if there are Python syntax errors or undefined names
-    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-    #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Lint with ruff
+      run: |
+        ruff check .
 
     - name: Run Tests
       env:

--- a/app_management/tests.py
+++ b/app_management/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
 
 # Create your tests here.

--- a/app_management/views.py
+++ b/app_management/views.py
@@ -1,3 +1,2 @@
-from django.shortcuts import render
 
 # Create your views here.

--- a/bahk/celery.py
+++ b/bahk/celery.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 import os
 from celery import Celery
 from celery.schedules import crontab
-from ssl import CERT_NONE
 from celery.signals import celeryd_init, beat_init
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration

--- a/bahk/urls.py
+++ b/bahk/urls.py
@@ -18,7 +18,6 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import RedirectView
-import hub.views as views
 #Apply Simple JSON Web Token (SimpleJWT) Authentication Routes to the API
 from rest_framework_simplejwt.views import (
     TokenRefreshView,

--- a/cleanup_test_media.py
+++ b/cleanup_test_media.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 """Standalone script to clean up test media files."""
 import os
-import shutil
-import sys
 
 
 def cleanup_test_media():

--- a/events/admin.py
+++ b/events/admin.py
@@ -4,14 +4,12 @@ Provides comprehensive views for events, event types, and analytics.
 """
 
 from django.contrib import admin
-from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, Q, Avg, FloatField
 from django.db.models.functions import Cast, TruncDate
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.urls import path, reverse
 from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from django.utils import timezone
 from datetime import timedelta
 import json
@@ -165,7 +163,7 @@ class EventAdmin(admin.ModelAdmin):
                 model_name = content_type.model
                 url = reverse(f'admin:{app_label}_{model_name}_change', args=[obj.object_id])
                 return format_html('<a href="{}">{}</a>', url, str(obj.target)[:50])
-            except:
+            except Exception:
                 return str(obj.target)[:50]
         return "-"
     target_link.short_description = "Target"
@@ -430,7 +428,7 @@ class EventAdmin(admin.ModelAdmin):
         ).order_by('-timestamp')[:5]
         
         # Get current and upcoming fasts
-        from hub.models import Fast, Day
+        from hub.models import Fast
         today = timezone.now().date()
         
         # Current fasts (have days that include today)
@@ -524,7 +522,6 @@ class EventAdmin(admin.ModelAdmin):
         AJAX endpoint for fetching analytics data with different date ranges.
         """
         from django.http import JsonResponse
-        from django.contrib.contenttypes.models import ContentType
         
         try:
             # Get date range from request with validation
@@ -663,7 +660,7 @@ class EventAdmin(admin.ModelAdmin):
         }
         
         # Get current and upcoming fasts
-        from hub.models import Fast, Day
+        from hub.models import Fast
         today = timezone.now().date()
         
         # Current fasts (have days that include today)
@@ -835,7 +832,6 @@ class EventAdmin(admin.ModelAdmin):
         Returns paginated list of devotionals with view counts and unique users.
         """
         from django.http import JsonResponse
-        from django.db.models import Count
 
         try:
             # Get parameters
@@ -1244,7 +1240,6 @@ class EventAdmin(admin.ModelAdmin):
         """
         App Analytics Dashboard: shows analytics-category events only.
         """
-        from django.http import JsonResponse
         from django.db.models.functions import ExtractHour
 
         days = int(request.GET.get('days', 30))
@@ -1281,7 +1276,6 @@ class EventAdmin(admin.ModelAdmin):
         events_by_day = daily_aggregates['events_by_day']
 
         # App opens by hour of day (0-23) within window
-        from django.db.models import IntegerField
         from django.db.models.functions import ExtractHour
         app_open_hours = base_qs.filter(event_type__code=EventType.APP_OPEN).annotate(
             hour=ExtractHour('timestamp')

--- a/events/analytics_optimizer.py
+++ b/events/analytics_optimizer.py
@@ -3,11 +3,9 @@ Analytics query optimization module.
 Provides high-performance analytics data aggregation to replace N+1 query patterns.
 """
 
-from django.db.models import Count, Case, When, Q
-from django.db.models.functions import TruncDate
+from django.db.models import Count, Case, When
 from django.utils import timezone
 from datetime import timedelta
-from collections import defaultdict
 from .models import Event, EventType
 
 

--- a/events/apps.py
+++ b/events/apps.py
@@ -2,12 +2,13 @@ from django.apps import AppConfig
 
 
 class EventsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'events'
-    verbose_name = 'User Events'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "events"
+    verbose_name = "User Events"
 
     def ready(self):
         """
         Connect signals when the app is ready.
         This ensures our event tracking signals are properly registered.
         """
+        import events.signals  # noqa: F401

--- a/events/apps.py
+++ b/events/apps.py
@@ -11,4 +11,3 @@ class EventsConfig(AppConfig):
         Connect signals when the app is ready.
         This ensures our event tracking signals are properly registered.
         """
-        import events.signals  # Import to register the signals

--- a/events/management/commands/award_retroactive_milestones.py
+++ b/events/management/commands/award_retroactive_milestones.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils import timezone
 from events.models import UserMilestone
-from hub.models import Fast, Profile
+from hub.models import Fast
 from notifications.utils import is_weekly_fast
 
 User = get_user_model()

--- a/events/management/commands/engagement_report.py
+++ b/events/management/commands/engagement_report.py
@@ -7,11 +7,11 @@ import os
 import tempfile
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandParser
-from django.db.models import Count, DateField, F, Q
+from django.db.models import Count
 from django.db.models.functions import TruncDate
 from django.utils import timezone
 
@@ -352,8 +352,6 @@ class Command(BaseCommand):
         Compute detailed timeline of user activities.
         Returns last 10 activities per user, plus daily aggregations if they have more.
         """
-        from django.db.models import Window
-        from django.db.models.functions import RowNumber
         
         # Get all activity feed items in period
         activities = UserActivityFeed.objects.filter(

--- a/events/management/commands/warm_analytics_cache.py
+++ b/events/management/commands/warm_analytics_cache.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        from events.analytics_cache import AnalyticsCacheWarmer, AnalyticsCacheService
+        from events.analytics_cache import AnalyticsCacheService
         from events.analytics_optimizer import AnalyticsQueryOptimizer
         
         force = options['force']

--- a/events/serializers.py
+++ b/events/serializers.py
@@ -3,7 +3,6 @@ Django REST Framework serializers for the events app.
 """
 
 from rest_framework import serializers
-from django.contrib.contenttypes.models import ContentType
 from .models import Event, EventType
 from .models import UserActivityFeed
 from django.utils import timezone

--- a/events/signals.py
+++ b/events/signals.py
@@ -5,7 +5,7 @@ These signals listen for specific model changes and create corresponding event r
 
 import logging
 from django.contrib.auth.signals import user_logged_in, user_logged_out
-from django.db.models.signals import post_save, post_delete, m2m_changed, pre_save
+from django.db.models.signals import post_save, m2m_changed, pre_save
 from django.dispatch import receiver
 from hub.utils import get_user_profile_safe
 @receiver(pre_save, sender='hub.Fast')
@@ -35,7 +35,6 @@ def cache_fast_original_values(sender, instance, **kwargs):
     except Exception as e:
         logger.error(f"Error caching original Fast values: {e}")
 
-from django.contrib.contenttypes.models import ContentType
 
 from .models import Event, EventType
 

--- a/events/tasks.py
+++ b/events/tasks.py
@@ -658,7 +658,7 @@ def check_completed_fast_milestones_task():
     This task runs daily to check for fasts that ended yesterday.
     """
     try:
-        from hub.models import Fast, Profile
+        from hub.models import Fast
         from django.utils import timezone
         from datetime import timedelta
         from django.db import models

--- a/events/tests/test_analytics_integration.py
+++ b/events/tests/test_analytics_integration.py
@@ -11,7 +11,7 @@ This module tests the complete analytics flow including:
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.test import TestCase, RequestFactory, override_settings
+from django.test import RequestFactory, override_settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.urls import reverse

--- a/events/tests/test_analytics_performance.py
+++ b/events/tests/test_analytics_performance.py
@@ -7,9 +7,8 @@ This module tests:
 - Performance optimizations
 """
 
-import json
-from datetime import datetime, timedelta
-from unittest.mock import patch, MagicMock
+from datetime import timedelta
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from django.test.utils import tag

--- a/events/tests/test_engagement_endpoints.py
+++ b/events/tests/test_engagement_endpoints.py
@@ -6,7 +6,7 @@ This module tests the API endpoints that track user engagement:
 - TrackChecklistUsedView
 """
 
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework.test import APITestCase, APIClient

--- a/events/tests/test_engagement_report_command.py
+++ b/events/tests/test_engagement_report_command.py
@@ -5,15 +5,13 @@ import json
 import tempfile
 import os
 from datetime import datetime, timedelta
-from io import StringIO
-from unittest.mock import patch, MagicMock
 
 from django.test import TestCase
 from django.core.management import call_command
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
-from events.models import Event, EventType, UserActivityFeed
+from events.models import EventType, UserActivityFeed
 from events.management.commands.engagement_report import Command
 from hub.models import Fast, Church, Profile
 

--- a/events/tests/test_jwt_login_tracking.py
+++ b/events/tests/test_jwt_login_tracking.py
@@ -5,7 +5,6 @@ This module tests the TrackingTokenObtainPairView that emits
 USER_LOGGED_IN events when JWT tokens are obtained.
 """
 
-from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework.test import APITestCase, APIClient

--- a/events/tests/test_middleware.py
+++ b/events/tests/test_middleware.py
@@ -11,13 +11,12 @@ This module tests the analytics tracking middleware that handles:
 
 import uuid
 from datetime import timedelta
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from django.test import TestCase, RequestFactory, override_settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.utils import timezone
-from django.conf import settings
 
 from events.middleware import AnalyticsTrackingMiddleware
 from events.models import Event, EventType

--- a/events/tests/tests.py
+++ b/events/tests/tests.py
@@ -9,9 +9,6 @@ from rest_framework.test import APITestCase
 from rest_framework import status
 from unittest.mock import patch
 from django.utils import timezone
-from django.contrib.contenttypes.models import ContentType
-from django.core.management import call_command
-from django.test.utils import override_settings
 
 from events.models import Event, EventType, UserActivityFeed
 from hub.models import Fast, Church, Profile, Day
@@ -932,7 +929,6 @@ class UserActivityFeedSignalsTest(TestCase):
     
     def test_signal_creates_feed_item_sync(self):
         """Test that signal creates feed item synchronously."""
-        from django.conf import settings
         
         # Ensure sync mode
         with self.settings(USE_ASYNC_ACTIVITY_FEED=False):
@@ -957,7 +953,6 @@ class UserActivityFeedSignalsTest(TestCase):
     @patch('events.tasks.create_activity_feed_item_task')
     def test_signal_creates_feed_item_async(self, mock_task):
         """Test that signal creates feed item asynchronously."""
-        from django.conf import settings
         
         # Ensure async mode
         with self.settings(USE_ASYNC_ACTIVITY_FEED=True):
@@ -1185,7 +1180,6 @@ class UserActivityFeedManagementCommandsTest(TestCase):
     def test_populate_activity_feeds_command(self):
         """Test populate_activity_feeds management command."""
         from django.core.management import call_command
-        from django.core.management.base import CommandError
         from io import StringIO
         
         # Clear any existing feed items
@@ -2147,7 +2141,6 @@ class AnnouncementTasksTest(TestCase):
     
     def test_create_announcement_feed_items_task(self):
         """Test the announcement feed items creation task."""
-        from events.tasks import create_announcement_feed_items_task
         from events.models import Announcement, UserActivityFeed
         
         # Create announcement

--- a/events/views.py
+++ b/events/views.py
@@ -3,7 +3,7 @@ API views for the events app.
 Provides endpoints for retrieving events, analytics, and statistics.
 """
 
-from django.db.models import Count, Q
+from django.db.models import Count
 from django.utils import timezone
 from datetime import timedelta
 from rest_framework import generics, permissions, status
@@ -16,7 +16,7 @@ from .models import Event, EventType, UserActivityFeed
 from .serializers import (
     EventSerializer, EventListSerializer, EventTypeSerializer,
     EventStatsSerializer, UserEventStatsSerializer, FastEventStatsSerializer,
-    UserActivityFeedSerializer, UserActivityFeedSummarySerializer
+    UserActivityFeedSerializer
 )
 
 

--- a/hub/apps.py
+++ b/hub/apps.py
@@ -2,8 +2,8 @@ from django.apps import AppConfig
 
 
 class HubConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'hub'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "hub"
 
     def ready(self):
         """
@@ -12,6 +12,8 @@ class HubConfig(AppConfig):
         """
         # Configure global profanity filter overrides (used across multiple apps).
         from hub.profanity import configure_profanity_filter
+
         configure_profanity_filter()
 
         # Import signals to register them
+        import hub.signals  # noqa: F401

--- a/hub/apps.py
+++ b/hub/apps.py
@@ -15,4 +15,3 @@ class HubConfig(AppConfig):
         configure_profanity_filter()
 
         # Import signals to register them
-        import hub.signals

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -29,7 +29,7 @@ class AddDaysToFastAdminForm(forms.Form):
         for date_str in self.cleaned_data["dates"].splitlines():
             try:
                 dates.append(datetime.datetime.strptime(date_str, DATE_FORMAT_STRING).date())
-            except:
+            except (ValueError, TypeError):
                 raise ValidationError(f"{date_str} not in valid date format (<month>/<day>/<year>)")
 
         return dates

--- a/hub/management/commands/create_test_users_for_fast.py
+++ b/hub/management/commands/create_test_users_for_fast.py
@@ -1,14 +1,12 @@
 """
 Management command to generate test users with valid profiles and add them to a specified fast.
 """
-import os
 import random
 import uuid
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.contrib.auth.models import User
 from hub.models import Fast, Profile, Church
-from django.utils import timezone
 from faker import Faker
 
 class Command(BaseCommand):

--- a/hub/management/commands/geocode_locations.py
+++ b/hub/management/commands/geocode_locations.py
@@ -4,7 +4,7 @@ Command to geocode user locations using AWS Location Service
 This management command allows administrators to geocode all user locations
 in the database, either all at once or only those without coordinates.
 """
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from hub.tasks import batch_geocode_profiles
 from hub.models import Profile
 

--- a/hub/management/commands/regenerate_feast_contexts.py
+++ b/hub/management/commands/regenerate_feast_contexts.py
@@ -1,5 +1,4 @@
 """Regenerate feast contexts to apply new parsing logic."""
-import logging
 
 from django.core.management.base import BaseCommand
 

--- a/hub/management/commands/seed.py
+++ b/hub/management/commands/seed.py
@@ -1,10 +1,9 @@
 """Generates seed data for app with python manage.py seed."""
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta
 from django.utils import timezone
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from django.core.exceptions import ObjectDoesNotExist
 
 import hub.models as models
 from notifications.models import DeviceToken, PromoEmail

--- a/hub/management/commands/seed_multilingual_data.py
+++ b/hub/management/commands/seed_multilingual_data.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from django.utils.translation import activate
 from hub.models import Church, Fast, Day, DevotionalSet, Devotional
 from learning_resources.models import Video, Article, Recipe
-from events.models import Announcement, UserActivityFeed
+from events.models import Announcement
 
 
 class Command(BaseCommand):

--- a/hub/middleware.py
+++ b/hub/middleware.py
@@ -3,7 +3,6 @@ Middleware for handling timezone updates based on API request timezone informati
 """
 import pytz
 import logging
-from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
 from .utils import get_user_profile_safe
 

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -7,14 +7,13 @@ from django.contrib.auth.models import Group, User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from rest_framework import serializers
-from django.utils.translation import activate, get_language
+from django.utils.translation import activate
 from django.contrib.auth.password_validation import validate_password
 from rest_framework.validators import UniqueValidator
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.http import urlsafe_base64_decode
 from django.utils.encoding import force_str
-from django.conf import settings
 from django.utils.functional import cached_property
 
 from hub import models
@@ -36,7 +35,7 @@ class ProfileSerializer(serializers.ModelSerializer, ThumbnailCacheMixin):
             # Fall back to direct thumbnail URL if caching fails
             try:
                 return obj.profile_image_thumbnail.url
-            except:
+            except Exception:
                 return None
         return None
 
@@ -527,7 +526,7 @@ class DevotionalSerializer(serializers.ModelSerializer):
             # Fall back to generating URL
             try:
                 return obj.video.thumbnail_small.url
-            except:
+            except Exception:
                 return None
         return None
 

--- a/hub/services/aws_geocoding.py
+++ b/hub/services/aws_geocoding.py
@@ -10,7 +10,7 @@ import logging
 import boto3
 from django.conf import settings
 from botocore.exceptions import ClientError, BotoCoreError
-from typing import Dict, Tuple, Optional, List, Any
+from typing import Dict, Tuple, Optional, List
 
 logger = logging.getLogger(__name__)
 

--- a/hub/tasks/geocoding_tasks.py
+++ b/hub/tasks/geocoding_tasks.py
@@ -1,9 +1,7 @@
 """
 Geocoding tasks for the hub app.
 """
-import logging
 from django.db import transaction
-from django.utils import timezone
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from hub.models import Profile, GeocodingCache

--- a/hub/tasks/llm_tasks.py
+++ b/hub/tasks/llm_tasks.py
@@ -3,7 +3,6 @@ import re
 
 from celery import shared_task
 from django.conf import settings
-from django.utils import timezone
 
 from hub.models import LLMPrompt, Reading, ReadingContext, Feast, FeastContext
 from hub.services.llm_service import get_llm_service

--- a/hub/tasks/mapping_tasks.py
+++ b/hub/tasks/mapping_tasks.py
@@ -6,7 +6,6 @@ with clustering support for areas with many participants.
 """
 import time
 import logging
-from io import BytesIO
 from uuid import uuid4
 from django.core.files.base import ContentFile
 from django.utils import timezone
@@ -23,7 +22,6 @@ import numpy as np
 import geopandas as gpd
 # import contextily as ctx  # Removing dependency on contextily
 from shapely.geometry import Point, Polygon
-import pandas as pd
 from pathlib import Path
 from sklearn.cluster import DBSCAN
 import urllib.request

--- a/hub/tests/test_email_tasks.py
+++ b/hub/tests/test_email_tasks.py
@@ -1,10 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from django.core import mail
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.contrib.auth import get_user_model
 
-from hub.models import Fast, Profile, Day, Church
+from hub.models import Day
 from hub.utils import send_fast_reminders
 from tests.fixtures.test_data import TestDataFactory
 

--- a/hub/tests/test_email_templates.py
+++ b/hub/tests/test_email_templates.py
@@ -1,9 +1,6 @@
 from django.test import TestCase, override_settings
-from django.contrib.auth.models import User
 from django.template.loader import render_to_string
-from django.urls import reverse
 from django.conf import settings
-from django.contrib.staticfiles.storage import StaticFilesStorage
 from django.core.files.storage import FileSystemStorage
 from tests.fixtures.test_data import TestDataFactory
 

--- a/hub/tests/test_fast_views.py
+++ b/hub/tests/test_fast_views.py
@@ -1,12 +1,12 @@
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.utils import timezone
-from hub.models import Church, Fast, Day, Profile
+from hub.models import Day
 from hub.views.fast import FastListView, FastByFeastDateView
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.test import APIRequestFactory
 from rest_framework.test import force_authenticate
-from datetime import datetime, timedelta
+from datetime import timedelta
 from django.core.cache import cache
 from tests.fixtures.test_data import TestDataFactory
 from rest_framework.exceptions import ValidationError

--- a/hub/tests/test_feast_designation.py
+++ b/hub/tests/test_feast_designation.py
@@ -7,7 +7,7 @@ from django.db.models.signals import post_save
 
 from hub.models import Church, Day, Feast, LLMPrompt
 from hub.tasks.llm_tasks import determine_feast_designation_task
-from hub.services.llm_service import AnthropicService, OpenAIService, get_llm_service
+from hub.services.llm_service import AnthropicService, OpenAIService
 from hub.signals import handle_feast_save
 
 

--- a/hub/tests/test_feast_icon_matching.py
+++ b/hub/tests/test_feast_icon_matching.py
@@ -1,14 +1,13 @@
 """Tests for feast icon matching functionality."""
 from datetime import date
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from django.test import TestCase, override_settings
 from django.test.utils import tag
 from django.db.models.signals import post_save
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from hub.models import Church, Day, Feast
-from hub.constants import ICON_MATCH_CONFIDENCE_THRESHOLD
-from hub.tasks.icon_tasks import match_icon_to_feast_task, _match_icons_with_llm, _simple_match_icons
+from hub.tasks.icon_tasks import match_icon_to_feast_task, _simple_match_icons
 from hub.signals import handle_feast_save
 from icons.models import Icon
 

--- a/hub/tests/test_feast_tasks.py
+++ b/hub/tests/test_feast_tasks.py
@@ -1,12 +1,11 @@
 """Tests for feast-related Celery tasks."""
-from datetime import date, datetime
+from datetime import date
 from unittest.mock import patch, Mock
 
 from django.test import TestCase, override_settings
 
-from hub.models import Church, Day, Feast, Fast
+from hub.models import Church, Feast
 from hub.tasks.feast_tasks import create_feast_date_task
-from tests.fixtures.test_data import TestDataFactory
 
 
 @override_settings(

--- a/hub/tests/test_get_or_create_feast_for_date.py
+++ b/hub/tests/test_get_or_create_feast_for_date.py
@@ -1,10 +1,10 @@
 """Tests for the get_or_create_feast_for_date utility function."""
 from datetime import date
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from django.test import TestCase
 
-from hub.models import Church, Day, Feast, Fast
+from hub.models import Church, Day, Feast
 from hub.utils import get_or_create_feast_for_date
 from tests.fixtures.test_data import TestDataFactory
 

--- a/hub/tests/test_patristic_quotes.py
+++ b/hub/tests/test_patristic_quotes.py
@@ -1,13 +1,11 @@
 """Tests for patristic quotes feature."""
 import hashlib
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import patch
 
-from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
-from django.utils import timezone
 from rest_framework.test import APITestCase
 from rest_framework import status
 

--- a/hub/tests/test_reading_context.py
+++ b/hub/tests/test_reading_context.py
@@ -1,10 +1,9 @@
 from datetime import date
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
-from django.utils import timezone
 from rest_framework.test import APITestCase
 
 from hub.models import Church, Day, LLMPrompt, Reading, ReadingContext

--- a/hub/tests/test_timezone_functionality.py
+++ b/hub/tests/test_timezone_functionality.py
@@ -2,13 +2,10 @@
 Tests for timezone functionality in user profiles.
 """
 from django.test import TestCase, RequestFactory
-from django.contrib.auth.models import User
 from django.http import HttpResponse
-from hub.models import Profile
 from hub.serializers import ProfileSerializer
 from hub.middleware import TimezoneUpdateMiddleware
 from tests.fixtures.test_data import TestDataFactory
-import pytz
 
 
 class TimezoneModelTest(TestCase):

--- a/hub/views/admin.py
+++ b/hub/views/admin.py
@@ -1,6 +1,5 @@
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import render, get_object_or_404
-from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 
 from hub.models import Reading, LLMPrompt

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -1,7 +1,7 @@
 from rest_framework import generics, permissions
 from ..constants import NUMBER_PARTICIPANTS_TO_SHOW_WEB
-from ..models import Fast, Church, Day, Profile, FastParticipantMap
-from ..serializers import FastSerializer, JoinFastSerializer, ParticipantSerializer, FastStatsSerializer, DaySerializer, FastParticipantMapSerializer
+from ..models import Fast, Church, Profile, FastParticipantMap
+from ..serializers import FastSerializer, JoinFastSerializer, ParticipantSerializer, FastStatsSerializer, FastParticipantMapSerializer
 from .mixins import ChurchContextMixin, TimezoneMixin
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -11,7 +11,7 @@ import logging
 import pytz
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
-from django.views.decorators.vary import vary_on_headers, vary_on_cookie
+from django.views.decorators.vary import vary_on_headers
 from django.conf import settings
 from django.core.cache import cache
 from django.utils.encoding import force_str

--- a/hub/views/patristic_quotes.py
+++ b/hub/views/patristic_quotes.py
@@ -255,7 +255,7 @@ class PatristicQuoteOfTheDayView(views.APIView):
             try:
                 user_tz = pytz.timezone(request.user.profile.timezone)
                 current_date = datetime.now(user_tz).date()
-            except:
+            except Exception:
                 current_date = datetime.now().date()
         else:
             current_date = datetime.now().date()

--- a/icons/views.py
+++ b/icons/views.py
@@ -4,10 +4,9 @@ from django.conf import settings
 from django.db.models import Q
 from rest_framework import generics, status, views
 from rest_framework.pagination import PageNumberPagination
-from rest_framework.permissions import AllowAny, BasePermission, IsAuthenticated
+from rest_framework.permissions import AllowAny, BasePermission
 from rest_framework.response import Response
 
-from hub.services.llm_service import get_llm_service
 from icons.models import Icon
 from icons.serializers import IconSerializer
 

--- a/learning_resources/admin.py
+++ b/learning_resources/admin.py
@@ -132,7 +132,7 @@ class BookmarkAdmin(admin.ModelAdmin):
                     url,
                     content
                 )
-            except:
+            except Exception:
                 return str(content)
         return "Content not found"
     content_object_link.short_description = 'Content Object'

--- a/learning_resources/cache.py
+++ b/learning_resources/cache.py
@@ -13,7 +13,6 @@ from typing import Set, Optional, List, Dict, Any
 from django.core.cache import cache
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import User
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 from django.contrib.contenttypes.models import ContentType
-from django.utils import timezone
 from hub.mixins import ThumbnailCacheMixin
 from .models import Article, Recipe, Video, Bookmark
 from django.utils.translation import activate
@@ -68,7 +67,7 @@ class VideoSerializer(BookmarkOptimizedSerializerMixin, serializers.ModelSeriali
             # Fall back to direct thumbnail URL if caching fails
             try:
                 return obj.thumbnail_small.url
-            except:
+            except Exception:
                 return None
         return None
 
@@ -102,7 +101,7 @@ class ArticleSerializer(BookmarkOptimizedSerializerMixin, serializers.ModelSeria
             # Fall back to direct thumbnail URL if caching fails
             try:
                 return obj.thumbnail.url
-            except:
+            except Exception:
                 return None
         return None 
     

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -1,7 +1,6 @@
 """
 Celery tasks for learning resources operations.
 """
-import logging
 from typing import Dict, Any, Optional
 from django.db import transaction
 from django.utils import timezone

--- a/learning_resources/tests.py
+++ b/learning_resources/tests.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -6,12 +6,10 @@ from rest_framework.test import APITestCase
 from rest_framework import status
 import tempfile
 from PIL import Image
-import json
 
 from hub.models import Church, Fast, DevotionalSet, Day, Devotional
 from learning_resources.models import Video, Article, Recipe, Bookmark
 from learning_resources.serializers import DevotionalSetSerializer
-from tests.fixtures.test_data import TestDataFactory
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -1,10 +1,10 @@
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import get_object_or_404
 from rest_framework import generics, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Q, Prefetch
+from django.db.models import Q
 import logging
 from .models import Video, Article, Recipe, Bookmark
 from .serializers import (

--- a/memory_debug.py
+++ b/memory_debug.py
@@ -15,7 +15,6 @@ import gc
 import time
 import resource
 import importlib
-import traceback
 from collections import defaultdict
 
 # --------------- Configuration ---------------

--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -7,20 +7,16 @@ from .models import DeviceToken, PromoEmail, PromoEmailImage
 from .utils import send_push_notification
 from .tasks import send_promo_email_task, send_push_notification_to_users_task
 from django.contrib.admin import SimpleListFilter
-from hub.models import Fast, Profile, Church
+from hub.models import Fast
 from django.utils import timezone
 from django import forms
 from django.urls import reverse
 from django.template.loader import render_to_string
 from django.conf import settings
 from django_celery_beat.models import PeriodicTask, ClockedSchedule
-from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.contrib.auth import get_user_model
-from django.db.models import Q
 from django.utils.html import format_html
-from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
-from datetime import datetime
 
 import json
 import logging

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -799,7 +799,7 @@ def send_activity_feed_nudge_task():
 
     Runs at 11 AM — after the inactive fast member nudge at 10 AM.
     """
-    from events.models import Event, EventType, UserActivityFeed
+    from events.models import Event, EventType
 
     cutoff = timezone.now() - timedelta(days=_INACTIVITY_DAYS)
     unread_threshold = 5

--- a/notifications/tests/test_batch_processing.py
+++ b/notifications/tests/test_batch_processing.py
@@ -1,14 +1,13 @@
 """
 Test batch processing and index calculation correctness in promo email tasks.
 """
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from django.core import mail
 from django.core.cache import cache
-from django.test import TestCase, override_settings, tag
+from django.test import TestCase, override_settings
 
 from notifications.tasks import send_promo_email_task
 from notifications.models import PromoEmail
-from hub.models import User
 from tests.fixtures.test_data import TestDataFactory
 
 

--- a/notifications/tests/test_device_tokens.py
+++ b/notifications/tests/test_device_tokens.py
@@ -1,13 +1,9 @@
-from django.test import TestCase
 from django.urls import reverse
-from django.contrib.auth.models import User
 from rest_framework.test import APITestCase, APIClient
 from rest_framework import status
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from ..models import DeviceToken
-from ..views import DeviceTokenCreateView, TestPushNotificationView
 from tests.fixtures.test_data import TestDataFactory
-import json
 
 class DeviceTokenTests(APITestCase):
     def setUp(self):

--- a/notifications/tests/test_email_templates.py
+++ b/notifications/tests/test_email_templates.py
@@ -1,10 +1,8 @@
 from django.test import TestCase, override_settings
-from django.contrib.auth.models import User
 from django.template.loader import render_to_string
 from django.urls import reverse
 from notifications.models import PromoEmail
 from django.conf import settings
-from django.contrib.staticfiles.storage import StaticFilesStorage
 from django.core.files.storage import FileSystemStorage
 from tests.fixtures.test_data import TestDataFactory
 

--- a/notifications/tests/test_promo_email_admin.py
+++ b/notifications/tests/test_promo_email_admin.py
@@ -1,15 +1,13 @@
 from django.test import TestCase, Client, override_settings, modify_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
-from django.core import mail
 from django.utils import timezone
 from django.contrib.auth.models import Permission, Group
 from django.contrib.contenttypes.models import ContentType
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import datetime
 
 from notifications.models import PromoEmail
-from hub.models import Church, Fast, Profile
 from tests.fixtures.test_data import TestDataFactory
 
 User = get_user_model()

--- a/notifications/tests/test_promo_email_images.py
+++ b/notifications/tests/test_promo_email_images.py
@@ -1,9 +1,7 @@
 """Tests for PromoEmailImage model and functionality."""
-import os
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.conf import settings
 from notifications.models import PromoEmailImage
 
 

--- a/notifications/tests/test_promo_emails.py
+++ b/notifications/tests/test_promo_emails.py
@@ -5,7 +5,7 @@ from django.test import TestCase, override_settings
 
 from notifications.tasks import send_promo_email_task
 from notifications.models import PromoEmail
-from hub.models import User, Profile, Church, Fast
+from hub.models import Church
 from tests.fixtures.test_data import TestDataFactory
 
 

--- a/notifications/tests/test_race_conditions.py
+++ b/notifications/tests/test_race_conditions.py
@@ -3,16 +3,15 @@ Test race conditions and concurrency issues in promo email tasks.
 """
 import threading
 import time
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from django.core import mail
 from django.core.cache import cache
 from django.test import TestCase, override_settings, TransactionTestCase, tag
-from django.db import transaction, connection
+from django.db import connection
 from django.db.utils import OperationalError
 
 from notifications.tasks import send_promo_email_task, increment_email_count, get_email_count
 from notifications.models import PromoEmail
-from hub.models import User, Profile, Church
 from tests.fixtures.test_data import TestDataFactory
 
 

--- a/notifications/tests/test_settings.py
+++ b/notifications/tests/test_settings.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 
 # Test settings
 SITE_URL = 'http://testserver'

--- a/notifications/tests/test_unsubscribe.py
+++ b/notifications/tests/test_unsubscribe.py
@@ -1,13 +1,9 @@
 from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
-from django.utils import timezone
 from django.core.signing import TimestampSigner
-import base64
-import hmac
-import hashlib
 
-from hub.models import User, Profile, Church
+from hub.models import User
 from tests.fixtures.test_data import TestDataFactory
 
 User = get_user_model()

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -4,7 +4,6 @@ import logging
 import json
 import re
 from django.utils import timezone
-from django.db.models import Q
 from .constants import NOTIFICATION_TYPE_FILTERS
 
 logger = logging.getLogger(__name__)

--- a/prayers/models.py
+++ b/prayers/models.py
@@ -2,7 +2,6 @@
 import logging
 from datetime import timedelta
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError

--- a/prayers/tasks.py
+++ b/prayers/tasks.py
@@ -1,7 +1,5 @@
 """Celery tasks for the prayers app."""
 import logging
-from datetime import date, timedelta
-from collections import defaultdict
 
 from better_profanity import profanity
 from celery import shared_task
@@ -11,7 +9,6 @@ from django.db.models import Count, Q
 from django.utils import timezone
 
 from events.models import Event, EventType, UserActivityFeed, UserMilestone
-from hub.services.llm_service import get_llm_service
 from hub.models import LLMPrompt
 from hub.profanity import configure_profanity_filter
 from prayers.models import PrayerRequest, PrayerRequestPrayerLog

--- a/prayers/views.py
+++ b/prayers/views.py
@@ -4,7 +4,6 @@ from django.utils.translation import activate, get_language_from_request
 from rest_framework import generics
 from rest_framework.permissions import AllowAny
 
-from learning_resources.cache import BookmarkCacheManager
 from notifications.tasks import send_push_notification_to_users_task
 from prayers.models import Prayer, PrayerSet
 from prayers.serializers import (
@@ -222,13 +221,11 @@ class PrayerSetDetailView(generics.RetrieveAPIView):
 
 # Prayer Request Views
 
-from datetime import date
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
 from events.models import Event, EventType, UserActivityFeed, UserMilestone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[tool.ruff]
+# Target Python 3.11
+target-version = "py311"
+
+# Line length matching common Django convention
+line-length = 120
+
+# Exclude auto-generated and vendored files
+exclude = [
+    "*/migrations/*",
+    "venv/",
+    "node_modules/",
+    "staticfiles/",
+    ".git/",
+]
+
+[tool.ruff.lint]
+# Phase 1: Critical errors only (safe, won't break CI on style)
+# E9: Runtime errors (syntax errors, etc.)
+# F63: Invalid assertions
+# F7: Syntax errors in type comments
+# F82: Undefined names
+# F401: Unused imports
+# E722: Bare except
+select = ["E9", "F63", "F7", "F82", "F401", "E722"]
+
+# Per-file ignores
+[tool.ruff.lint.per-file-ignores]
+# Allow wildcard imports in settings
+"bahk/settings.py" = ["F401"]
+"tests/test_settings.py" = ["F401"]
+# __init__.py files commonly re-export
+"__init__.py" = ["F401"]
+# Django signal registration pattern
+"*/apps.py" = ["F401"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,5 @@ openai
 anthropic
 # Bible API
 requests
+# Linting
+ruff

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -2,10 +2,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 from rest_framework_simplejwt.tokens import RefreshToken
-from django.contrib.auth.models import User
-from hub.models import Church, Profile
 from tests.fixtures.test_data import TestDataFactory
-import datetime
 
 class AuthenticationTest(APITestCase):
     def setUp(self):

--- a/tests/integration/test_aws_location.py
+++ b/tests/integration/test_aws_location.py
@@ -4,8 +4,6 @@ AWS Location Service Geocoding Integration Test
 This test verifies that the AWS Location Service geocoding functionality
 is working correctly with our Django application.
 """
-import os
-import sys
 import time
 import logging
 from django.conf import settings

--- a/tests/integration/test_bookmark_api.py
+++ b/tests/integration/test_bookmark_api.py
@@ -1,11 +1,8 @@
 """Integration tests for bookmark API endpoints."""
 
-import json
 from django.urls import reverse
-from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import status
-from rest_framework.test import APITestCase
 from learning_resources.models import Video, Article, Recipe, Bookmark
 from hub.models import DevotionalSet
 from tests.base import BaseAPITestCase

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -2,10 +2,7 @@
 import datetime
 from django.test import TestCase
 from django.urls import reverse
-from django.contrib.auth.models import User
 from rest_framework.test import APIRequestFactory
-from hub.models import Church, Fast, Day, Profile
-from hub.views.fast import FastOnDate
 from rest_framework import status
 from tests.fixtures.test_data import TestDataFactory
 

--- a/tests/performance/test_bookmark_cache.py
+++ b/tests/performance/test_bookmark_cache.py
@@ -1,11 +1,9 @@
 """Performance tests for bookmark caching functionality."""
 
 import time
-from django.test import TestCase
 from django.test.utils import tag
-from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
-from learning_resources.models import Video, Article, Recipe, Bookmark
+from learning_resources.models import Video, Bookmark
 from learning_resources.cache import BookmarkCacheManager, BookmarkCacheService
 from tests.base import BaseTestCase
 

--- a/tests/tasks/test_llm_tasks.py
+++ b/tests/tasks/test_llm_tasks.py
@@ -1,5 +1,5 @@
-from unittest.mock import Mock, patch, MagicMock
-from django.test import TestCase, override_settings
+from unittest.mock import patch
+from django.test import TestCase
 from django.utils import timezone
 
 from hub.models import Reading, ReadingContext, LLMPrompt, Day, Fast, Church

--- a/tests/test_fast_endpoints.py
+++ b/tests/test_fast_endpoints.py
@@ -1,15 +1,12 @@
-from django.test import TestCase, Client
 from django.test.utils import tag
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient, APITestCase
 from rest_framework import status
-from hub.models import Fast, Church, Profile, Day
+from hub.models import Day
 from tests.fixtures.test_data import TestDataFactory
 from datetime import datetime, timedelta
 import time
-import json
-import pytz
 
 User = get_user_model()
 

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -1,11 +1,10 @@
 from django.utils.translation import activate
-from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import tag
 from rest_framework.test import APITestCase
 from rest_framework import status
-from hub.models import Church, Fast, Day, DevotionalSet, Devotional
-from learning_resources.models import Video, Article, Recipe
+from hub.models import Church, Fast, Day, Devotional
+from learning_resources.models import Video
 from django.db import IntegrityError
 
 

--- a/tests/test_optimized_profile_endpoints.py
+++ b/tests/test_optimized_profile_endpoints.py
@@ -17,14 +17,12 @@ Usage:
 import time
 import tracemalloc
 from datetime import date, timedelta
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from django.urls import reverse
-from django.contrib.auth.models import User
 from rest_framework.test import APIClient, APITestCase
 from rest_framework import status
 from django.db import connection
 from django.test.utils import override_settings, tag
-from hub.models import Church, Fast, Day, Profile
 from tests.fixtures.test_data import TestDataFactory
 
 

--- a/tests/test_participant_lists.py
+++ b/tests/test_participant_lists.py
@@ -1,16 +1,13 @@
-from django.test import TestCase
 from django.test.utils import tag
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient, APITestCase
 from rest_framework import status
-from hub.models import Fast, Church, Profile, Day
+from hub.models import Day
 from tests.fixtures.test_data import TestDataFactory
 from datetime import datetime, timedelta
 import unittest
 import time
-import json
-import pytz
 
 User = get_user_model()
 

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import User
 from django.urls import reverse
 from django.core import mail
 from django.utils.http import urlsafe_base64_encode

--- a/tests/test_profile_memory_leaks.py
+++ b/tests/test_profile_memory_leaks.py
@@ -17,14 +17,12 @@ Usage:
 import time
 import tracemalloc
 from datetime import date, timedelta
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from django.urls import reverse
-from django.contrib.auth.models import User
 from rest_framework.test import APIClient, APITestCase
 from rest_framework import status
 from django.db import connection
 from django.test.utils import override_settings, tag
-from hub.models import Church, Fast, Day, Profile
 from tests.fixtures.test_data import TestDataFactory
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 """Test utilities for cleanup and setup."""
 import os
-import shutil
 from django.conf import settings
 
 

--- a/tests/unit/learning_resources/test_bookmark_cache.py
+++ b/tests/unit/learning_resources/test_bookmark_cache.py
@@ -1,7 +1,5 @@
 """Unit tests for bookmark cache functionality."""
 
-from django.test import TestCase
-from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from learning_resources.models import Video, Article, Bookmark

--- a/tests/unit/learning_resources/test_bookmark_models.py
+++ b/tests/unit/learning_resources/test_bookmark_models.py
@@ -1,10 +1,7 @@
 """Unit tests for bookmark models."""
 
-from django.test import TestCase
-from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError
-from django.core.exceptions import ValidationError
 from learning_resources.models import Video, Article, Recipe, Bookmark
 from hub.models import DevotionalSet
 from tests.base import BaseTestCase
@@ -175,7 +172,6 @@ class BookmarkModelTests(BaseTestCase):
     
     def test_get_content_representation_nonexistent_object(self):
         """Test get_content_representation when content object is deleted."""
-        from django.test.utils import override_settings
         from django.db.models.signals import post_delete
         from learning_resources.signals import video_deleted_signal
         

--- a/tests/unit/learning_resources/test_bookmark_performance.py
+++ b/tests/unit/learning_resources/test_bookmark_performance.py
@@ -2,12 +2,12 @@
 Tests for bookmark performance optimizations and bulk operations.
 """
 from unittest.mock import patch, MagicMock, call
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from django.test.utils import tag
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from tests.base import BaseTransactionTestCase
-from learning_resources.models import Bookmark, Video, Article
+from learning_resources.models import Bookmark, Video
 from learning_resources.cache import BookmarkCacheManager
 from learning_resources import signals
 

--- a/tests/unit/learning_resources/test_bookmark_signals.py
+++ b/tests/unit/learning_resources/test_bookmark_signals.py
@@ -1,7 +1,5 @@
 """Unit tests for bookmark signal handlers."""
 
-from django.test import TestCase
-from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from learning_resources.models import Video, Article, Recipe, Bookmark
 from hub.models import DevotionalSet

--- a/tests/unit/learning_resources/test_bookmark_tasks.py
+++ b/tests/unit/learning_resources/test_bookmark_tasks.py
@@ -1,12 +1,9 @@
 """
 Tests for learning resources Celery tasks.
 """
-from django.test import TestCase
 from django.test.utils import override_settings
-from unittest.mock import patch, MagicMock
 from tests.base import BaseTestCase
 from learning_resources.models import Bookmark
-from django.contrib.contenttypes.models import ContentType
 
 
 class BookmarkTasksTests(BaseTestCase):
@@ -39,7 +36,6 @@ class BookmarkTasksTests(BaseTestCase):
     def test_management_command_async_option(self):
         """Test that management command has async options."""
         from django.core.management import get_commands
-        from django.core.management.base import BaseCommand
         from learning_resources.management.commands.cleanup_orphaned_bookmarks import Command
         
         # Verify the command exists

--- a/tests/unit/notifications/test_weekly_prayer_notifications.py
+++ b/tests/unit/notifications/test_weekly_prayer_notifications.py
@@ -1,8 +1,7 @@
 """Unit tests for weekly prayer request notifications."""
 from datetime import timedelta
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-from django.test import TestCase
 from django.utils import timezone
 
 from notifications.tasks import send_weekly_prayer_request_push_notification_task

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -3,14 +3,13 @@ import datetime
 import os
 from unittest.mock import patch
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.utils import IntegrityError
 from django.test import TestCase, TransactionTestCase
 from django.test.utils import tag
 from tests.fixtures.test_data import TestDataFactory
 
-from hub.models import Church, Day, Fast, Profile
+from hub.models import Fast
 
 
 class ModelCreationTests(TestCase):


### PR DESCRIPTION
## Summary
- Adds ruff as the project linter with Phase 1 rules (critical errors, unused imports, bare excepts)
- Replaces the commented-out flake8 CI step with `ruff check .`
- Auto-fixes 236 unused imports and 8 bare `except:` clauses across 93 files

## Configuration (pyproject.toml)
- **Rules enabled:** E9, F63, F7, F82 (critical), F401 (unused imports), E722 (bare except)
- **Excluded:** migrations, venv, node_modules, staticfiles
- **Per-file ignores:** settings files (F401), `__init__.py` (F401), `apps.py` (F401 for signal registration)

## Future phases
- Phase 2: Add complexity checks, naming conventions
- Phase 3: Style enforcement (line length, etc.)

## Test plan
- [x] `ruff check .` passes clean
- [x] Unit tests pass (`tests.unit.hub`, `tests.unit.learning_resources`, `tests.unit.notifications`)
- [x] All runtime imports verified (django setup + module imports)
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical lint-driven changes (add `ruff` to CI, remove unused imports, and replace bare `except:` with `except Exception`/specific exceptions), with minimal runtime impact. Small behavior change is limited to narrowed exception handling in a few places, which should be safer but could expose previously swallowed non-`Exception` errors.
> 
> **Overview**
> Adds `ruff` as the project linter: introduces `pyproject.toml` Ruff config, adds `ruff` to `requirements.txt`, and updates GitHub Actions to run `ruff check .` during CI.
> 
> Cleans up Ruff findings across the codebase by removing unused imports, adding `# noqa: F401` for signal-registration imports, and tightening several `except:` blocks to `except Exception` (or specific exception types) to avoid bare-except lint violations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f024c3fda77ad42f6588f567df5ad11e4ef78500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->