### PR TITLE
fix: handle UnknownTimeZoneError gracefully, fall back to UTC

### DIFF
--- a/hub/views/mixins.py
+++ b/hub/views/mixins.py
@@ -2,6 +2,7 @@ from rest_framework.exceptions import ValidationError
 from ..models import Church
 from django.core.exceptions import ObjectDoesNotExist
 import pytz
+from pytz.exceptions import UnknownTimeZoneError
 
 
 class ChurchContextMixin:
@@ -45,5 +46,8 @@ class TimezoneMixin:
                 tz_str = None
 
         if tz_str:
-            return pytz.timezone(tz_str)
+            try:
+                return pytz.timezone(tz_str)
+            except UnknownTimeZoneError:
+                pass
         return pytz.UTC


### PR DESCRIPTION
Users sometimes have corrupted timezone values (e.g. 'Etc/Unknown'). Instead of crashing, catch UnknownTimeZoneError and fall back to UTC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a defensive exception handler around timezone parsing to prevent request crashes when user/query timezone data is invalid.
> 
> **Overview**
> Prevents failures when a request/user profile contains an invalid IANA timezone string.
> 
> `TimezoneMixin.get_timezone()` now catches `pytz.exceptions.UnknownTimeZoneError` from `pytz.timezone()` and **falls back to `pytz.UTC`** instead of propagating the exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8695d7dbacfcfd40a7bc0cf2ce5977fb6b8fe8c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->