### PR TITLE
fix: skip external scraping in /api/feasts/ when feast has all translations

### DIFF
--- a/hub/tests/test_get_or_create_feast_for_date.py
+++ b/hub/tests/test_get_or_create_feast_for_date.py
@@ -57,14 +57,14 @@ class GetOrCreateFeastForDateTests(TestCase):
             self.test_date, self.church, check_fast=True
         )
 
-        # Verify existing feast is returned
+        # Verify existing feast is returned without scraping
         self.assertEqual(feast_obj, existing_feast)
         self.assertFalse(created)
         self.assertEqual(status_dict["status"], "skipped")
         self.assertEqual(status_dict["reason"], "feast_already_exists")
-        
-        # Verify scrape_feast was called (we always scrape now to check for updates)
-        mock_scrape.assert_called_once_with(self.test_date, self.church)
+
+        # Verify scrape_feast was NOT called (feast exists with all translations)
+        mock_scrape.assert_not_called()
 
     def test_skip_when_fast_associated_with_check_fast_true(self):
         """Test skipping feast lookup when Fast is associated and check_fast=True."""

--- a/hub/utils.py
+++ b/hub/utils.py
@@ -515,8 +515,20 @@ def get_or_create_feast_for_date(date_obj, church, check_fast=True):
     
     # Check if feast already exists for this day
     existing_feast = day.feasts.first() if day.feasts.exists() else None
-    
-    # Scrape feast data (always scrape to potentially update existing feast with missing translations)
+
+    # If feast exists and has all translations, return it immediately (no scrape needed)
+    if existing_feast and existing_feast.name and existing_feast.name_hy:
+        return (
+            existing_feast,
+            False,
+            {
+                "status": "skipped",
+                "reason": "feast_already_exists",
+                "date": str(date_obj)
+            }
+        )
+
+    # Scrape feast data only if feast doesn't exist or is missing translations
     feast_data = scrape_feast(date_obj, church)
     
     if not feast_data:


### PR DESCRIPTION
## Summary
- `/api/feasts/` was making 2 HTTP requests to sacredtradition.am on **every call**, even when the feast already existed with complete translations
- This caused **6s average / 30s p95** response times across 2,283 calls in the last 30 days (per Sentry)
- Now returns immediately when the feast has both English and Armenian names, eliminating external HTTP calls for the common case

## What changed
- `hub/utils.py`: Added early return in `get_or_create_feast_for_date()` when feast exists with all translations
- `hub/tests/test_get_or_create_feast_for_date.py`: Updated test to assert scrape is NOT called when feast is complete

## Edge cases verified
- Feast with `name` but no `name_hy` → still scrapes (fills translation)
- Feast with empty string `name_hy=""` → still scrapes (falsy check)
- No feast exists → scrapes and creates (unchanged)
- Daily Celery task behavior → unchanged (still fills missing translations)
- Corrections on sacredtradition.am → same as before (never picked up even with old code)

## Test plan
- [x] All 20 feast-related tests pass
- [x] All 21 feast designation tests pass
- [x] All 17 feast icon matching tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an early-return optimization to skip external scraping when a feast already has both English and Armenian names, with a matching test update. Main impact is changed scrape invocation behavior, which could only affect cases relying on re-scraping for corrections.
> 
> **Overview**
> Speeds up `get_or_create_feast_for_date()` by **skipping the external `scrape_feast` call** when a feast already exists for the day *and* has both `name` and `name_hy` populated.
> 
> Updates the corresponding test to assert that scraping is **not** performed in this fully-populated feast case, while keeping scraping behavior for missing-translation or missing-feast scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0916a72908b7133b12748413c6fd47943733ac18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->