### PR TITLE
perf: reduce queries and memory in /api/fasts/ endpoint

### DIFF
--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -207,27 +207,28 @@ class FastSerializer(serializers.ModelSerializer, ThumbnailCacheMixin):
         return obj.id in self._user_fast_ids
 
     def get_participant_count(self, obj):
-        """Use annotated count if available"""
-        return getattr(obj, 'participant_count', obj.profiles.count())
+        """Use annotated count if available, otherwise query"""
+        if hasattr(obj, 'participant_count'):
+            return obj.participant_count
+        return obj.profiles.count()
     
     def get_countdown(self, obj):
-        """Use cached current_date and optimize database queries"""
+        """Use cached current_date and annotated end_date to avoid extra queries"""
         if obj.culmination_feast and obj.culmination_feast_date:
             days_to_feast = (obj.culmination_feast_date - self.current_date).days
             if days_to_feast < 0:
                 return f"{obj.culmination_feast} has passed"
             return f"<span class='days_to_finish'>{days_to_feast}</span> day{'' if days_to_feast == 1 else 's'} until {obj.culmination_feast}"
-        
-        # Optimized version: Use database aggregation instead of loading all days into memory
-        # This replaces the inefficient [day.date for day in obj.days.all()]
-        from django.db.models import Max
-        
-        # Use database aggregation to get the latest date without loading all objects
-        latest_day = obj.days.aggregate(max_date=Max('date'))['max_date']
-        
+
+        # Use annotated end_date if available, otherwise fall back to aggregate
+        latest_day = getattr(obj, 'end_date', None)
+        if latest_day is None:
+            from django.db.models import Max
+            latest_day = obj.days.aggregate(max_date=Max('date'))['max_date']
+
         if not latest_day:
             return f"No days available for {obj.name}"
-        
+
         days_to_finish = (latest_day - self.current_date).days + 1  # + 1 to get days until first day *after* fast
         if days_to_finish < 0:
             return f"{obj.name} has passed"
@@ -243,14 +244,18 @@ class FastSerializer(serializers.ModelSerializer, ThumbnailCacheMixin):
         return None
 
     def get_start_date(self, obj):
-        """Use annotated value if available"""
-        return getattr(obj, 'start_date', 
-                     obj.days.order_by('date').first().date if obj.days.exists() else None)
-    
+        """Use annotated value if available, otherwise query"""
+        if hasattr(obj, 'start_date'):
+            return obj.start_date
+        first_day = obj.days.order_by('date').values_list('date', flat=True).first()
+        return first_day
+
     def get_end_date(self, obj):
-        """Use annotated value if available"""
-        return getattr(obj, 'end_date',
-                     obj.days.order_by('date').last().date if obj.days.exists() else None)
+        """Use annotated value if available, otherwise query"""
+        if hasattr(obj, 'end_date'):
+            return obj.end_date
+        last_day = obj.days.order_by('-date').values_list('date', flat=True).first()
+        return last_day
     
     def get_has_passed(self, obj):
         """Use cached current_date and optimize end_date check"""
@@ -260,17 +265,13 @@ class FastSerializer(serializers.ModelSerializer, ThumbnailCacheMixin):
         return end_date < self.current_date
     
     def get_next_fast_date(self, obj):
-        """Use cached current_date"""
-        if obj.days.count() == 0:
-            return None
-        next_day = obj.days.filter(date__gte=self.current_date).order_by('date').first()
-        if next_day is not None:
-            return next_day.date
-        return None
+        """Use cached current_date, single query instead of count + filter"""
+        next_day = obj.days.filter(date__gte=self.current_date).order_by('date').values_list('date', flat=True).first()
+        return next_day
     
     def get_total_number_of_days(self, obj):
         """Use annotated value if available, excluding Day 0 from the count."""
-        total = getattr(obj, 'total_days', obj.days.count())
+        total = obj.total_days if hasattr(obj, 'total_days') else obj.days.count()
         if obj.has_day_zero:
             total -= 1
         return total

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -147,9 +147,6 @@ class FastListView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
             days__date__lte=end_date
         ).select_related(
             'church'
-        ).prefetch_related(
-            'days',
-            'profiles'
         ).distinct()
 
         # Cache the queryset for 10 minutes
@@ -211,7 +208,7 @@ class FastDetailView(TimezoneMixin, generics.RetrieveAPIView):
     permission_classes = [permissions.AllowAny]
 
     def get_queryset(self):
-        return Fast.objects.all().select_related('church').prefetch_related('days', 'profiles')
+        return Fast.objects.all().select_related('church')
 
     def get_object(self):
         # Return the model instance as expected by DRF
@@ -311,15 +308,12 @@ class FastByDateView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
             days__date=target_date
         ).select_related(
             'church'
-        ).prefetch_related(
-            'days',
-            'profiles'
         )
-        
+
         # Cache the list of Fast IDs instead of the queryset
         fast_ids = list(queryset.values_list('id', flat=True))
         cache.set(cache_key, fast_ids, CACHE_TTL)
-        
+
         return queryset
 
 
@@ -392,15 +386,12 @@ class FastByFeastDateView(ChurchContextMixin, TimezoneMixin, generics.ListAPIVie
             culmination_feast_date=feast_date
         ).select_related(
             'church'
-        ).prefetch_related(
-            'days',
-            'profiles'
         )
-        
+
         # Cache the list of Fast IDs instead of the queryset
         fast_ids = list(queryset.values_list('id', flat=True))
         cache.set(cache_key, fast_ids, CACHE_TTL)
-        
+
         return queryset
 
 


### PR DESCRIPTION
## Summary
- Remove `prefetch_related('days', 'profiles')` from fast list/detail/by-date views — the serializer never iterates profiles and uses filtered queries on days that bypass the prefetch cache
- Fix `get_countdown` to use the already-annotated `end_date` instead of a separate aggregate query per fast
- Fix `get_next_fast_date` to use a single `values_list` query instead of `count()` + `filter()`
- Fix eager evaluation bug in `get_start_date`, `get_end_date`, `get_participant_count`, `get_total_number_of_days` — `getattr(obj, 'x', expensive_fallback())` always evaluates the fallback even when the annotation exists; replaced with `hasattr` guards

## Impact
- **List view (annotated):** Saves ~2N unnecessary queries per request + eliminates loading all participant/day objects into memory
- **Detail view (no annotations):** Falls back to individual queries (single fast, cached response — acceptable)
- Sentry showed 4.3s p95 on 1,222 calls/month for this endpoint

## Test plan
- [x] All 30 fast view/endpoint tests pass
- [x] Verified fallback paths work for detail view (no annotations)
- [x] Verified web views still function (partial annotations)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes query patterns and removes `prefetch_related` on fast list/detail endpoints, which could affect response performance or expose new N+1 query paths if serializer behavior changes.
> 
> **Overview**
> Improves performance of the fast list/detail/by-date endpoints by **removing `prefetch_related('days', 'profiles')`** and relying on annotations/targeted queries instead of loading related objects into memory.
> 
> Fixes several serializer methods to avoid unintended extra DB work: replaces eager `getattr(..., expensive())` fallbacks with `hasattr` guards, reuses annotated `end_date` for `get_countdown`, and simplifies `get_next_fast_date`/`get_start_date`/`get_end_date` to single `values_list` lookups when annotations aren’t present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c567cdf7933f9c969f173f392d0414cb4cc79d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->