### PR TITLE
fix: remove stale get_llm_service patch from prayer request tests

### DIFF
--- a/tests/test_prayer_requests.py
+++ b/tests/test_prayer_requests.py
@@ -683,7 +683,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             content=[SimpleNamespace(text='{"approved": true, "reason": "ok"}')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), patch('anthropic.Anthropic') as mock_anthropic:
+        with patch('anthropic.Anthropic') as mock_anthropic:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
             result = moderate_prayer_request_task(prayer_request.id)
@@ -720,8 +720,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), \
-             patch('anthropic.Anthropic') as mock_anthropic:
+        with patch('anthropic.Anthropic') as mock_anthropic:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
             result = moderate_prayer_request_task(prayer_request.id)
@@ -772,7 +771,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), patch('anthropic.Anthropic') as mock_anthropic:
+        with patch('anthropic.Anthropic') as mock_anthropic:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
             result = moderate_prayer_request_task(prayer_request.id)
@@ -809,7 +808,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), patch('anthropic.Anthropic') as mock_anthropic:
+        with patch('anthropic.Anthropic') as mock_anthropic:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
             result = moderate_prayer_request_task(prayer_request.id)
@@ -846,8 +845,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), \
-             patch('anthropic.Anthropic') as mock_anthropic, \
+        with patch('anthropic.Anthropic') as mock_anthropic, \
              patch('prayers.tasks._send_moderation_alert_email') as mock_email:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
@@ -887,8 +885,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), \
-             patch('anthropic.Anthropic') as mock_anthropic, \
+        with patch('anthropic.Anthropic') as mock_anthropic, \
              patch('prayers.tasks._send_moderation_alert_email') as mock_email:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
@@ -925,8 +922,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), \
-             patch('anthropic.Anthropic') as mock_anthropic:
+        with patch('anthropic.Anthropic') as mock_anthropic:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
             result = moderate_prayer_request_task(prayer_request.id)
@@ -961,8 +957,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), \
-             patch('anthropic.Anthropic') as mock_anthropic, \
+        with patch('anthropic.Anthropic') as mock_anthropic, \
              patch('prayers.tasks._send_moderation_alert_email') as mock_email:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
@@ -1011,8 +1006,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), \
-             patch('anthropic.Anthropic') as mock_anthropic, \
+        with patch('anthropic.Anthropic') as mock_anthropic, \
              patch('prayers.tasks._send_moderation_alert_email') as mock_email:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
@@ -1061,8 +1055,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), \
-             patch('anthropic.Anthropic') as mock_anthropic, \
+        with patch('anthropic.Anthropic') as mock_anthropic, \
              patch('prayers.tasks._send_moderation_alert_email') as mock_email:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response
@@ -1101,8 +1094,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
             }''')]
         )
 
-        with patch('prayers.tasks.get_llm_service'), \
-             patch('anthropic.Anthropic') as mock_anthropic, \
+        with patch('anthropic.Anthropic') as mock_anthropic, \
              patch('prayers.tasks._send_moderation_alert_email') as mock_email:
             mock_client = mock_anthropic.return_value
             mock_client.messages.create.return_value = mock_response


### PR DESCRIPTION
## Summary
- The linting PR (#335) correctly removed the unused `get_llm_service` import from `prayers/tasks.py`
- 11 tests were patching `prayers.tasks.get_llm_service` which no longer exists (it was replaced with direct `Anthropic` client usage in an earlier refactor)
- The tests already mock `anthropic.Anthropic` correctly — the `get_llm_service` patch was redundant dead code
- CI passed on the linting PR because these tests aren't tagged with `slow` but the patch target resolution happens at runtime, not import time

## Test plan
- [x] All 34 prayer request tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that removes redundant mocking of a deleted symbol; low risk aside from potentially exposing any remaining runtime patch-target issues.
> 
> **Overview**
> Removes the stale `patch('prayers.tasks.get_llm_service')` from the prayer request moderation task tests, leaving only the `anthropic.Anthropic` client mock.
> 
> This updates the test suite to match the current implementation (direct `Anthropic` usage) and avoids runtime failures from patching a non-existent `get_llm_service` symbol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6364c58b5114bab138c14e2582f065950aebf9ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->