### PR TITLE
fix: resolve ruff lint issues (F401 unused imports)

### DIFF
--- a/icons/tests.py
+++ b/icons/tests.py
@@ -1,5 +1,4 @@
 """Tests for the icons app."""
-from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from django.core.files.uploadedfile import SimpleUploadedFile

--- a/icons/views.py
+++ b/icons/views.py
@@ -9,7 +9,6 @@ from rest_framework.permissions import AllowAny, BasePermission
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 
-from hub.services.llm_service import get_llm_service
 from icons.models import Icon, IconFeedback
 from icons.serializers import IconSerializer, IconFeedbackSerializer
 


### PR DESCRIPTION
## Summary

Brings the repo into compliance with CI's ruff lint checks.

## Changes

- **2 unused imports removed** (`F401`) in `icons/tests.py` and `icons/views.py` — leftovers from the Icon Feedback PR (#333)

## Verification

```
ruff check --select E9,F63,F7,F82,F401,E722 .
All checks passed!
```

No logic changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes only unused imports in tests and views with no behavior changes; potential risk is minimal and limited to import-time side effects (unlikely here).
> 
> **Overview**
> Removes unused imports flagged by ruff `F401`: `unittest.mock.patch` from `icons/tests.py` and `get_llm_service` from `icons/views.py`.
> 
> No functional or API behavior changes are introduced; this is strictly a lint/cleanup PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5450ba0f31e7cc1ceee7755a73a6725b23df77d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->