### PR TITLE
Fix #348: cron crash on prayer titles with curly braces

### DIFF
--- a/notifications/constants.py
+++ b/notifications/constants.py
@@ -16,6 +16,13 @@ WEEKLY_PRAYER_REQUEST_MESSAGE = (
     "Join in or share one of your own"
 )
 
+WARNING: All message strings in this file use .replace() for template substitution,
+NOT str.format(). This prevents KeyError/IndexError crashes when user-provided
+values (titles, names, descriptions) contain { or } characters.
+
+If you add a new message template with placeholders, always use .replace()
+to populate them — never str.format().
+
 PRAYER_REQUEST_COMPLETED_MESSAGE = (
     'Your prayer request "{title}" has completed. Send a thank you to those who prayed for you!'
 )

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -429,7 +429,7 @@ def send_upcoming_fast_push_notification_task():
         if is_weekly_fast(upcoming_fast_to_display):
             users_to_notify = users_to_notify.filter(profile__include_weekly_fasts_in_notifications=True)
 
-        message = UPCOMING_FAST_MESSAGE.format(fast_name=upcoming_fast_to_display.name)
+        message = UPCOMING_FAST_MESSAGE.replace('{fast_name}', str(upcoming_fast_to_display.name), 1)
         data = {
             "fast_id": upcoming_fast_to_display.id,
             "fast_name": upcoming_fast_to_display.name,
@@ -464,16 +464,17 @@ def send_ongoing_fast_push_notification_task():
         
         # Choose message based on whether there's a devotional
         if today_devotional and today_devotional.video and today_devotional.video.title:
-            message = ONGOING_FAST_WITH_DEVOTIONAL_MESSAGE.format(
-                fast_name=ongoing_fast_to_display.name,
-                devotional_title=today_devotional.video.title
+            message = ONGOING_FAST_WITH_DEVOTIONAL_MESSAGE.replace(
+                '{fast_name}', str(ongoing_fast_to_display.name), 1
+            ).replace(
+                '{devotional_title}', str(today_devotional.video.title), 1
             )
             data = {
                 "fast_id": ongoing_fast_to_display.id,
                 "fast_name": ongoing_fast_to_display.name
             }
         else:
-            message = ONGOING_FAST_MESSAGE.format(fast_name=ongoing_fast_to_display.name)
+            message = ONGOING_FAST_MESSAGE.replace('{fast_name}', str(ongoing_fast_to_display.name), 1)
             data = {
                 "fast_id": ongoing_fast_to_display.id,
                 "fast_name": ongoing_fast_to_display.name,
@@ -509,7 +510,7 @@ def send_daily_fast_push_notification_task():
         users_to_notify = users_to_notify.filter(profile__include_weekly_fasts_in_notifications=True)
 
     # send push notification to each user
-    message = DAILY_FAST_MESSAGE.format(fast_name=today_fast.name)
+    message = DAILY_FAST_MESSAGE.replace('{fast_name}', str(today_fast.name), 1)
     data = {
         "fast_id": today_fast.id,
         "fast_name": today_fast.name,
@@ -715,9 +716,10 @@ def send_fast_nonjoin_nudge_task():
         if not user_ids:
             continue
 
-        message = FAST_NONJOIN_NUDGE_MESSAGE.format(
-            count=participant_count,
-            fast_name=fast.name,
+        message = FAST_NONJOIN_NUDGE_MESSAGE.replace(
+            '{count}', str(participant_count), 1,
+        ).replace(
+            '{fast_name}', str(fast.name), 1,
         )
         send_push_notification_to_users_task.delay(
             message=message,
@@ -779,7 +781,7 @@ def send_inactive_fast_member_nudge_task():
             continue
 
         send_push_notification_to_users_task.delay(
-            message=INACTIVE_FAST_MEMBER_MESSAGE.format(fast_name=fast.name),
+            message=INACTIVE_FAST_MEMBER_MESSAGE.replace('{fast_name}', str(fast.name), 1),
             data={'screen': f'fast/{fast.id}'},
             user_ids=eligible_ids,
         )
@@ -900,7 +902,7 @@ def send_prayer_acceptance_nudge_task():
         count = len(requests)
         if count == 1:
             pr = requests[0]
-            message = PRAYER_NUDGE_SINGLE_MESSAGE.format(title=pr.title)
+            message = PRAYER_NUDGE_SINGLE_MESSAGE.replace('{title}', str(pr.title), 1)
             data = {'screen': f'prayer-request/{pr.id}'}
         else:
             message = PRAYER_NUDGE_MULTIPLE_MESSAGE.format(count=count)

--- a/prayers/tasks.py
+++ b/prayers/tasks.py
@@ -37,11 +37,10 @@ def _get_moderation_prompt_and_service(prayer_request):
         llm_prompt = LLMPrompt.objects.get(applies_to='prayer_requests', active=True)
 
         # Format the prompt with prayer request data
-        # The database prompt should use {title} and {description} placeholders
-        prompt_text = llm_prompt.prompt.format(
-            title=prayer_request.title,
-            description=prayer_request.description
-        )
+        # Use .replace() instead of .format() to avoid KeyError when
+        # prayer_request.title or .description contain { or } characters
+        prompt_text = llm_prompt.prompt.replace('{title}', str(prayer_request.title))
+        prompt_text = prompt_text.replace('{description}', str(prayer_request.description))
 
         # Get the role/system message (may be empty)
         system_role = llm_prompt.role if llm_prompt.role else None
@@ -474,13 +473,18 @@ def check_expired_prayer_requests_task():
 
     count = 0
     for prayer_request in expired_requests:
-        _, completed = prayer_request.complete_if_expired_with_side_effects()
-        if completed:
-            count += 1
-            send_push_notification_to_users_task.delay(
-                message=PRAYER_REQUEST_COMPLETED_MESSAGE.format(title=prayer_request.title),
-                data={'screen': f'prayer-request/{prayer_request.id}'},
-                user_ids=[prayer_request.requester_id],
+        try:
+            _, completed = prayer_request.complete_if_expired_with_side_effects()
+            if completed:
+                count += 1
+                send_push_notification_to_users_task.delay(
+                    message=PRAYER_REQUEST_COMPLETED_MESSAGE.replace('{title}', str(prayer_request.title), 1),
+                    data={'screen': f'prayer-request/{prayer_request.id}'},
+                    user_ids=[prayer_request.requester_id],
+                )
+        except Exception:
+            logger.exception(
+                f"Failed to process expired prayer request {prayer_request.id}"
             )
 
     logger.info(f"Marked {count} prayer requests as completed")

--- a/tests/test_prayer_requests.py
+++ b/tests/test_prayer_requests.py
@@ -532,6 +532,23 @@ class PrayerRequestAPITests(BaseAPITestCase):
             ).exists()
         )
 
+    def test_expired_prayer_with_curly_braces_in_title_does_not_crash(self):
+        """Prayer requests with { or } in the title should not crash the cron."""
+        requester = self.create_user(email='curly@example.com')
+        prayer_request = self.create_prayer_request(
+            requester, title='Pray for {my} family }'
+        )
+        prayer_request.expiration_date = timezone.now() - timedelta(days=1)
+        prayer_request.save(update_fields=['expiration_date'])
+
+        # Should not raise KeyError
+        result = check_expired_prayer_requests_task()
+        prayer_request.refresh_from_db()
+
+        self.assertEqual(prayer_request.status, 'completed')
+        self.assertEqual(result['completed_count'], 1)
+        self.assertEqual(result['success'], True)
+
     @tag('integration')
     def test_retrieve_auto_completes_expired_request(self):
         """Detail fetch should auto-complete expired approved requests."""


### PR DESCRIPTION
## What

Fixes the nightly cron crash (2,422 Sentry events) where a prayer request with curly braces in its title (e.g. "Pray for {my} family") crashes the entire batch via str.format().

## Changes

**prayers/tasks.py**
- Replace `str.format(title=prayer_request.title)` with `.replace('{title}', ...)` in the cron task
- Replace `str.format()` for moderation prompt construction (same vulnerability)
- Wrap each expired-request loop iteration in try/except so one bad request never kills the batch

**notifications/tasks.py**
- Audit all `.format(fast_name=...)`, `.format(title=...)`, and `.format(devotional_title=...)` calls — replaced with `.replace()` everywhere the template value is user-provided

**notifications/constants.py**
- Add warning comment about using .replace() instead of .format() for any new message templates

**tests/test_prayer_requests.py**
- Add regression test: prayer request with { and } in title runs without crashing

## Risk

Very low. All changes are purely error-handling and string formatting — no logic changes to task behavior or notification delivery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to safer string substitution for user-provided values and added per-item exception handling in scheduled tasks.
> 
> **Overview**
> Prevents scheduled tasks from crashing when user-provided text (e.g., prayer request titles/descriptions or fast/devotional names) contains `{` or `}` by replacing `str.format()` with bounded `.replace()` substitutions in `prayers/tasks.py` and multiple push-notification message builders.
> 
> Hardens the expired-prayer completion cron to continue processing even if one request errors (per-request `try/except` with logging), adds a regression test covering curly-brace titles, and documents the `.replace()`-only convention in `notifications/constants.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd800e6d7eb978bbf5815aa988e2f150b88c703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->