### PR TITLE
Fix: normalize book names with curly quotes for Catena URL lookup (#351)

### DIFF
--- a/hub/constants.py
+++ b/hub/constants.py
@@ -1,4 +1,7 @@
 """App constants."""
+import unicodedata
+
+
 DAYS_TO_CACHE_THUMBNAIL = 7
 NUMBER_PARTICIPANTS_TO_SHOW_WEB = 6  # number of participant thumbnails to show on fast card on web version
 DATE_FORMAT_STRING = "%m/%d/%Y"  # format string for dates (month, day, year)
@@ -237,4 +240,32 @@ CATENA_ABBREV_FOR_BOOK = {
     "Jude": "jude",
     "St. Jude's General Epistle": "jude",
     "Revelation": "rv"
+}
+
+
+def normalize_book_name(name: str | None) -> str | None:
+    """Normalize a book name for dictionary lookup.
+
+    Handles curly/smart quotes that scrapers may return:
+    - U+2018/U+2019 curly single quotes → straight apostrophe (U+0027)
+    - U+201C/U+201D curly double quotes → straight double quote (U+0022)
+    - NFKC normalization handles other Unicode variations
+    - Strips leading/trailing whitespace
+
+    Returns None if name is None or empty after stripping.
+    """
+    if not name:
+        return None
+    name = unicodedata.normalize("NFKC", name)
+    name = name.replace("\u2018", "'").replace("\u2019", "'")
+    name = name.replace("\u201c", '"').replace("\u201d", '"')
+    name = name.strip()
+    return name if name else None
+
+
+# Normalized lookup dict — built once at import time
+# Keys are normalized via normalize_book_name so curly-quote variants match
+CATENA_ABBREV_FOR_BOOK_NORMALIZED: dict[str, str] = {
+    normalize_book_name(k): v
+    for k, v in CATENA_ABBREV_FOR_BOOK.items()
 }

--- a/hub/models.py
+++ b/hub/models.py
@@ -18,7 +18,7 @@ from taggit.managers import TaggableManager
 
 import bahk.settings as settings
 from hub.constants import (
-    CATENA_ABBREV_FOR_BOOK,
+    CATENA_ABBREV_FOR_BOOK_NORMALIZED,
     CATENA_HOME_PAGE_URL,
     DAYS_TO_CACHE_THUMBNAIL,
 )
@@ -649,11 +649,20 @@ class Reading(models.Model):
         ]
 
     def create_url(self):
-        """Creates URL to read the reading."""
-        book_abbrev = CATENA_ABBREV_FOR_BOOK.get(self.book)
+        """Creates URL to read the reading.
+
+        Uses normalized book name lookup to handle curly/smart quote
+        variations returned by scrapers (e.g. ' vs U+2019).
+        """
+        from hub.constants import normalize_book_name
+
+        normalized_book = normalize_book_name(self.book)
+        book_abbrev = CATENA_ABBREV_FOR_BOOK_NORMALIZED.get(normalized_book)
         if book_abbrev is None:
             logging.error(
-                "Missing Catena URL abbreviation for %s. Returning home page", self.book
+                "Missing Catena URL abbreviation for %r (normalized: %r). Returning home page",
+                self.book,
+                normalized_book,
             )
             return CATENA_HOME_PAGE_URL
         verse_ref = (

--- a/hub/tests/test_bible_api.py
+++ b/hub/tests/test_bible_api.py
@@ -14,7 +14,14 @@ from unittest.mock import patch, MagicMock
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from hub.constants import BOOK_NAME_TO_USFM, APOCRYPHA_USFM_IDS, CATENA_ABBREV_FOR_BOOK
+from hub.constants import (
+    BOOK_NAME_TO_USFM,
+    APOCRYPHA_USFM_IDS,
+    CATENA_ABBREV_FOR_BOOK,
+    CATENA_ABBREV_FOR_BOOK_NORMALIZED,
+    normalize_book_name,
+    CATENA_HOME_PAGE_URL,
+)
 from hub.models import Church, Day, Reading
 from hub.services.bible_api_service import (
     BibleAPIService,
@@ -77,6 +84,78 @@ class BookNameMappingTests(TestCase):
                 usfm_id, APOCRYPHA_USFM_IDS,
                 f"{name} -> {usfm_id} should NOT be in APOCRYPHA_USFM_IDS"
             )
+
+    # ── normalize_book_name tests ────────────────────────────────── #
+
+    def test_normalize_book_name_with_curly_quote(self):
+        """Curly single quote (U+2019) should normalize to straight apostrophe."""
+        curly_hebrews = "St. Paul\u2019s Epistle to the Hebrews"
+        result = normalize_book_name(curly_hebrews)
+        self.assertEqual(result, "St. Paul's Epistle to the Hebrews")
+
+    def test_normalize_book_name_already_straight(self):
+        """Already straight apostrophe should remain unchanged."""
+        straight = "St. Paul's Epistle to the Hebrews"
+        result = normalize_book_name(straight)
+        self.assertEqual(result, straight)
+
+    def test_normalize_book_name_none(self):
+        """None input should return None."""
+        self.assertIsNone(normalize_book_name(None))
+
+    def test_normalize_book_name_empty_string(self):
+        """Empty or whitespace-only string should return None."""
+        self.assertIsNone(normalize_book_name(""))
+        self.assertIsNone(normalize_book_name("   "))
+
+    # ── CATENA_ABBREV_FOR_BOOK_NORMALIZED tests ──────────────────── #
+
+    def test_normalized_dict_matches_curly_quote_book_name(self):
+        """Normalized dict should resolve a curly-quote book name."""
+        curly_hebrews = "St. Paul\u2019s Epistle to the Hebrews"
+        self.assertEqual(
+            CATENA_ABBREV_FOR_BOOK_NORMALIZED.get(normalize_book_name(curly_hebrews)),
+            "heb",
+        )
+
+    def test_normalized_dict_has_same_entries_as_original(self):
+        """All original keys should be present in the normalized dict."""
+        for k, v in CATENA_ABBREV_FOR_BOOK.items():
+            normalized_k = normalize_book_name(k)
+            self.assertIn(normalized_k, CATENA_ABBREV_FOR_BOOK_NORMALIZED)
+            self.assertEqual(
+                CATENA_ABBREV_FOR_BOOK_NORMALIZED[normalized_k], v
+            )
+
+    # ── create_url tests ─────────────────────────────────────────── #
+
+    def test_create_url_with_curly_quote_book_name(self):
+        """Reading.create_url() should handle curly-quote book names."""
+
+        # Create a reading with curly-quote book name
+        reading = Reading(
+            book="St. Paul\u2019s Epistle to the Hebrews",
+
+            start_chapter=1,
+            start_verse=1,
+            end_chapter=1,
+            end_verse=5,
+        )
+        url = reading.create_url()
+        self.assertIn("heb", url)
+        self.assertNotEqual(url, CATENA_HOME_PAGE_URL)
+
+    def test_create_url_with_unknown_book_returns_home(self):
+        """Unknown book should return CATENA_HOME_PAGE_URL."""
+        reading = Reading(
+            book="Completely Made Up Book",
+            start_chapter=1,
+            start_verse=1,
+            end_chapter=1,
+            end_verse=5,
+        )
+        url = reading.create_url()
+        self.assertEqual(url, CATENA_HOME_PAGE_URL)
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Problem
326 Sentry events: `create_url()` returning the Catena home page fallback because `CATENA_ABBREV_FOR_BOOK.get(self.book)` returns `None` when the scraper provides a book name with curly quotes (e.g. `St. Paul\u2019s Epistle to the Hebrews` with U+2019 instead of U+0027 apostrophe).

## Solution
1. **`normalize_book_name()`** in `hub/constants.py` — NFKC normalization + curly/smart quote replacement (both single and double quotes)
2. **`CATENA_ABBREV_FOR_BOOK_NORMALIZED`** — precomputed normalized lookup dict (built once at import time)
3. **`Reading.create_url()`** uses `normalize_book_name()` before lookup

## Tests (7 new)
- 4 normalization tests (curly → straight, already straight, None, empty/whitespace)
- 2 normalized dict tests (curly-quote resolution, all original keys preserved)
- 2 `create_url` integration tests (curly-quote Hebrew → "heb" URL, unknown book → home page)

## Lint & CI
- `ruff check .` — clean
- 45 tests pass (hub.tests.test_bible_api)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to `Reading.create_url()` that improves robustness of book-name lookup and adds coverage for the new normalization behavior.
> 
> **Overview**
> Fixes Catena URL generation when scrapers return Unicode curly/smart quotes in `Reading.book`.
> 
> Adds `normalize_book_name()` plus a precomputed `CATENA_ABBREV_FOR_BOOK_NORMALIZED` mapping in `hub/constants.py`, updates `Reading.create_url()` to normalize before lookup (and logs both raw/normalized on fallback), and extends `hub/tests/test_bible_api.py` with unit + integration tests covering normalization and URL generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52f2cff12d3c6c381be2023371c2442264c32e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->