### PR TITLE
Fix: scraper robustness and feast endpoint resilience (#349, #350)

### DIFF
--- a/hub/tests/test_feast_views.py
+++ b/hub/tests/test_feast_views.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 from hub.models import Church, Day, Feast
-from hub.utils import _fetch_sacredtradition
+from hub.utils import _fetch_sacredtradition, _stable_url_key
 
 
 class FeastViewDegradedResponseTests(TestCase):
@@ -152,7 +152,7 @@ class CircuitBreakerTests(TestCase):
             self.assertIsNone(result)
 
         # Circuit breaker should now be open
-        circuit_key = f"circuit_breaker:{hash(url)}"
+        circuit_key = f"circuit_breaker:{_stable_url_key(url)}"
         self.assertTrue(cache.get(circuit_key))
 
         # Fourth call should return None immediately (circuit open)
@@ -183,7 +183,7 @@ class CircuitBreakerTests(TestCase):
         _fetch_sacredtradition(url)
         _fetch_sacredtradition(url)
 
-        circuit_key = f"circuit_breaker:{hash(url)}"
+        circuit_key = f"circuit_breaker:{_stable_url_key(url)}"
         # After 2 failures (< max), circuit should NOT be open
         self.assertIsNone(cache.get(circuit_key))
 
@@ -197,6 +197,7 @@ class CircuitBreakerTests(TestCase):
         result = _fetch_sacredtradition(url)
         self.assertIsNotNone(result)
 
+        circuit_key = f"circuit_breaker:{_stable_url_key(url)}"
         # Circuit breaker should be cleared
         self.assertIsNone(cache.get(circuit_key))
 

--- a/hub/tests/test_feast_views.py
+++ b/hub/tests/test_feast_views.py
@@ -1,0 +1,226 @@
+"""Tests for feast view resilience: degraded responses, caching, circuit breaker."""
+from datetime import date
+from unittest.mock import Mock, patch
+import urllib.error
+
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from hub.models import Church, Day, Feast
+from hub.utils import _fetch_sacredtradition
+
+
+class FeastViewDegradedResponseTests(TestCase):
+    """Tests for degraded feast endpoint responses on scrape failure."""
+
+    def setUp(self):
+        self.church = Church.objects.get(pk=Church.get_default_pk())
+        self.test_date = date(2025, 12, 25)
+        self.date_str = self.test_date.strftime("%Y-%m-%d")
+        cache.clear()
+
+    @patch('hub.views.feasts.get_or_create_feast_for_date')
+    def test_degraded_response_on_scrape_failure(self, mock_get_or_create):
+        """Endpoint returns 200 with feast:None when get_or_create_feast_for_date raises."""
+        from hub.views.feasts import GetFeastForDate
+
+        mock_get_or_create.side_effect = Exception("Scraper timeout")
+
+        factory = APIRequestFactory()
+        request = factory.get(f'/feasts/?date={self.date_str}')
+        view = GetFeastForDate.as_view()
+
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.data['feast'])
+        self.assertIn('error', response.data)
+        self.assertEqual(response.data['error'], 'Feast data temporarily unavailable')
+
+    @patch('hub.views.feasts.get_or_create_feast_for_date')
+    def test_graceful_response_on_database_error(self, mock_get_or_create):
+        """Endpoint returns degraded response on DB errors too."""
+        from hub.views.feasts import GetFeastForDate
+
+        # Simulate a DB error during the view logic
+        mock_get_or_create.side_effect = RuntimeError("Database connection lost")
+
+        factory = APIRequestFactory()
+        request = factory.get(f'/feasts/?date={self.date_str}')
+        view = GetFeastForDate.as_view()
+
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.data['feast'])
+        self.assertIn('error', response.data)
+
+
+class FeastViewCacheTests(TestCase):
+    """Tests for feast endpoint caching."""
+
+    def setUp(self):
+        self.church = Church.objects.get(pk=Church.get_default_pk())
+        self.test_date = date(2025, 12, 25)
+        self.date_str = self.test_date.strftime("%Y-%m-%d")
+        cache.clear()
+
+    @patch('hub.views.feasts.get_or_create_feast_for_date')
+    def test_cache_hit_prevents_scraper_call(self, mock_get_or_create):
+        """Second call to endpoint uses cache and does not call scraper."""
+        from hub.views.feasts import GetFeastForDate
+
+        day = Day.objects.create(date=self.test_date, church=self.church)
+        feast = Feast.objects.create(day=day, name="Christmas")
+        mock_get_or_create.return_value = (feast, False, {"status": "success"})
+
+        factory = APIRequestFactory()
+
+        # First call — should call get_or_create_feast_for_date
+        request1 = factory.get(f'/feasts/?date={self.date_str}')
+        view1 = GetFeastForDate.as_view()
+        response1 = view1(request1)
+        self.assertEqual(response1.status_code, 200)
+        self.assertEqual(mock_get_or_create.call_count, 1)
+
+        # Second call — should hit cache, NOT call scraper again
+        request2 = factory.get(f'/feasts/?date={self.date_str}')
+        view2 = GetFeastForDate.as_view()
+        response2 = view2(request2)
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(response2.data, response1.data)
+        # Call count should still be 1 (cached, not re-scraped)
+        self.assertEqual(mock_get_or_create.call_count, 1)
+
+    @patch('hub.views.feasts.get_or_create_feast_for_date')
+    def test_cache_key_isolation(self, mock_get_or_create):
+        """Different dates and churches use different cache keys."""
+        from hub.views.feasts import GetFeastForDate
+
+        day1 = Day.objects.create(date=self.test_date, church=self.church)
+        Feast.objects.create(day=day1, name="Christmas")
+        mock_get_or_create.return_value = (day1.feasts.first(), False, {"status": "success"})
+
+        factory = APIRequestFactory()
+
+        # Call for first date
+        request1 = factory.get(f'/feasts/?date={self.date_str}')
+        response1 = GetFeastForDate.as_view()(request1)
+        self.assertEqual(mock_get_or_create.call_count, 1)
+
+        # Call for a different date — should NOT use cache
+        other_date = date(2025, 1, 6)
+        request2 = factory.get(f'/feasts/?date={other_date.strftime("%Y-%m-%d")}')
+        response2 = GetFeastForDate.as_view()(request2)
+        self.assertEqual(mock_get_or_create.call_count, 2)
+
+        # First date's cached response should still be same
+        request3 = factory.get(f'/feasts/?date={self.date_str}')
+        response3 = GetFeastForDate.as_view()(request3)
+        self.assertEqual(mock_get_or_create.call_count, 2)  # Still cached
+        self.assertEqual(response3.data['feast']['name'], response1.data['feast']['name'])
+
+
+class CircuitBreakerTests(TestCase):
+    """Tests for the circuit breaker in _fetch_sacredtradition."""
+
+    def setUp(self):
+        cache.clear()
+
+    def test_url_validation_invalid(self):
+        """_fetch_sacredtradition returns None for invalid URLs."""
+        # Wrong domain
+        result = _fetch_sacredtradition("https://evil.example.com/page")
+        self.assertIsNone(result)
+
+        # No netloc
+        result = _fetch_sacredtradition("not-a-url")
+        self.assertIsNone(result)
+
+    @patch('urllib.request.urlopen')
+    def test_circuit_breaker_trips_after_failures(self, mock_urlopen):
+        """After 3+ failures, circuit breaker opens and subsequent calls return None."""
+        url = "https://sacredtradition.am/Calendar/nter.php?NM=0&iM=1103&iL=2&ymd=20251225"
+
+        # Simulate 3 consecutive failures
+        mock_urlopen.side_effect = urllib.error.URLError("Connection timeout")
+
+        # First 3 calls should fail
+        for _ in range(3):
+            result = _fetch_sacredtradition(url)
+            self.assertIsNone(result)
+
+        # Circuit breaker should now be open
+        circuit_key = f"circuit_breaker:{hash(url)}"
+        self.assertTrue(cache.get(circuit_key))
+
+        # Fourth call should return None immediately (circuit open)
+        mock_urlopen.reset_mock()
+        result = _fetch_sacredtradition(url)
+        self.assertIsNone(result)
+        # urlopen should NOT have been called (circuit breaker blocked it)
+        mock_urlopen.assert_not_called()
+
+    @patch('urllib.request.urlopen')
+    def test_circuit_breaker_resets_on_success(self, mock_urlopen):
+        """A successful call resets the circuit breaker."""
+        url = "https://sacredtradition.am/Calendar/nter.php?NM=0&iM=1103&iL=2&ymd=20251225"
+
+        # Use a side_effect function to simulate failures then success
+        call_count = [0]
+        def _side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 6:  # 2 calls × 3 retries each
+                raise urllib.error.URLError("Connection timeout")
+            mock_resp = Mock()
+            mock_resp.status = 200
+            mock_resp.read.return_value = b'<html><div class="dname">Test</div></html>'
+            return mock_resp
+
+        mock_urlopen.side_effect = _side_effect
+
+        _fetch_sacredtradition(url)
+        _fetch_sacredtradition(url)
+
+        circuit_key = f"circuit_breaker:{hash(url)}"
+        # After 2 failures (< max), circuit should NOT be open
+        self.assertIsNone(cache.get(circuit_key))
+
+        # Now the third call should succeed (side_effect function returns success for call_count > 6)
+        mock_html = b'<html><div class="dname">Test</div></html>'
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.read.return_value = mock_html
+        mock_urlopen.side_effect = [mock_response]
+
+        result = _fetch_sacredtradition(url)
+        self.assertIsNotNone(result)
+
+        # Circuit breaker should be cleared
+        self.assertIsNone(cache.get(circuit_key))
+
+    @patch('urllib.request.urlopen')
+    def test_cache_returns_stale_on_failure(self, mock_urlopen):
+        """When scrape fails, cached stale data is returned as fallback."""
+        url = "https://sacredtradition.am/Calendar/nter.php?NM=0&iM=1103&iL=2&ymd=20251225"
+
+        # First, a successful fetch that caches the result
+        mock_html = b'<html><div class="dname">Cached Feast</div></html>'
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.read.return_value = mock_html
+        mock_urlopen.return_value = mock_response
+
+        result1 = _fetch_sacredtradition(url)
+        self.assertIsNotNone(result1)
+        self.assertIn("Cached Feast", result1)
+
+        # Now simulate 3 consecutive failures
+        mock_urlopen.side_effect = urllib.error.URLError("Connection timeout")
+
+        for _ in range(3):
+            result = _fetch_sacredtradition(url)
+            # Should return cached data even on failure
+            self.assertIsNotNone(result)
+            self.assertIn("Cached Feast", result)

--- a/hub/tests/test_feast_views.py
+++ b/hub/tests/test_feast_views.py
@@ -225,3 +225,35 @@ class CircuitBreakerTests(TestCase):
             # Should return cached data even on failure
             self.assertIsNotNone(result)
             self.assertIn("Cached Feast", result)
+
+
+    @patch('urllib.request.urlopen')
+    def test_failure_counter_resets_on_success(self, mock_urlopen):
+        """Failure counter is cleared when a fetch succeeds (before circuit trips)."""
+        url = "https://sacredtradition.am/Calendar/nter.php?NM=0&iM=1103&iL=2&ymd=20251225"
+        circuit_key = f"circuit_breaker:{_stable_url_key(url)}"
+        circuit_failures_key = circuit_key + ":failures"
+
+        mock_html = b'<html><div class="dname">Test Feast</div></html>'
+        mock_success = Mock()
+        mock_success.status = 200
+        mock_success.read.return_value = mock_html
+
+        # Set up: cache some data for stale fallback, prime counter at 2
+        cache.set(f"scrape_result:{_stable_url_key(url)}", '<html><div class="dname">Test Feast</div></html>', 21600)
+        cache.set(circuit_failures_key, 2, 900)  # 2 prior failures
+
+        # Success resets the counter (even though circuit isn't open yet)
+        mock_urlopen.return_value = mock_success
+        result = _fetch_sacredtradition(url)
+        self.assertIsNotNone(result)
+        # Counter should be reset by success
+        self.assertIsNone(cache.get(circuit_failures_key))
+        self.assertIsNone(cache.get(circuit_key))
+
+        # Now 2 failures: should land at count 2, not 4 (reset works)
+        mock_urlopen.side_effect = urllib.error.URLError("Connection timeout")
+        for _ in range(2):
+            _fetch_sacredtradition(url)
+        self.assertEqual(cache.get(circuit_failures_key), 2)
+        self.assertIsNone(cache.get(circuit_key))  # not tripped yet

--- a/hub/tests/test_scrape_feast.py
+++ b/hub/tests/test_scrape_feast.py
@@ -3,6 +3,7 @@ from datetime import date
 from unittest.mock import Mock, patch
 import urllib.error
 
+from django.core.cache import cache
 from django.test import TestCase
 
 from hub.models import Church
@@ -13,6 +14,7 @@ class ScrapeFeastTests(TestCase):
     """Tests for the scrape_feast utility function."""
 
     def setUp(self):
+        cache.clear()
         self.church = Church.objects.get(pk=Church.get_default_pk())
         self.test_date = date(2025, 12, 25)
 

--- a/hub/utils.py
+++ b/hub/utils.py
@@ -4,6 +4,7 @@ import logging
 import re
 import urllib
 import urllib.parse
+import hashlib
 
 import sentry_sdk
 
@@ -32,6 +33,11 @@ SCRAPE_CIRCUIT_BREAKER_MAX_FAILURES = 3
 SCRAPE_CACHE_TIMEOUT = 21600  # 6 hours
 
 
+def _stable_url_key(url: str) -> str:
+    """Stable hash for URL cache keys (unlike Python's salted hash())."""
+    return hashlib.md5(url.encode()).hexdigest()[:16]
+
+
 def _fetch_sacredtradition(url: str, timeout: int = 10) -> str | None:
     """Fetch a sacredtradition.am page with retries, circuit breaker, and caching.
     
@@ -48,19 +54,21 @@ def _fetch_sacredtradition(url: str, timeout: int = 10) -> str | None:
         logger.error("Invalid URL for sacredtradition.am scrape: %s", url)
         return None
     
+    url_key = _stable_url_key(url)
+    
     # Check circuit breaker
-    circuit_key = f"circuit_breaker:{hash(url)}"
+    circuit_key = f"circuit_breaker:{url_key}"
     circuit_open = cache.get(circuit_key)
     if circuit_open:
         logger.warning("Circuit breaker open for %s, skipping scrape", url)
         # Try cache fallback anyway
-        cached = cache.get(f"scrape_result:{hash(url)}")
+        cached = cache.get(f"scrape_result:{url_key}")
         if cached:
             return cached
         return None
     
     # Try cached result first
-    cache_key = f"scrape_result:{hash(url)}"
+    cache_key = f"scrape_result:{url_key}"
     cached = cache.get(cache_key)
     if cached:
         return cached

--- a/hub/utils.py
+++ b/hub/utils.py
@@ -67,11 +67,9 @@ def _fetch_sacredtradition(url: str, timeout: int = 10) -> str | None:
             return cached
         return None
     
-    # Try cached result first
+    # Get any cached result to use as stale fallback
     cache_key = f"scrape_result:{url_key}"
     cached = cache.get(cache_key)
-    if cached:
-        return cached
     
     # Fetch with retries
     last_error = None
@@ -83,8 +81,9 @@ def _fetch_sacredtradition(url: str, timeout: int = 10) -> str | None:
                 data = response.read().decode("utf-8")
                 # Cache successful result
                 cache.set(cache_key, data, SCRAPE_CACHE_TIMEOUT)
-                # Reset circuit breaker on success
+                # Reset circuit breaker + failure counter on success
                 cache.delete(circuit_key)
+                cache.delete(circuit_key + ":failures")
                 return data
             else:
                 last_error = f"HTTP {response.status}"
@@ -107,7 +106,9 @@ def _fetch_sacredtradition(url: str, timeout: int = 10) -> str | None:
     # Log the final failure
     if last_error:
         sentry_sdk.capture_exception(Exception(f"Scrape failed for {url} after 3 attempts: {last_error}"))
-    return cached  # Return stale cached data as fallback, or None
+    
+    # Return stale cached data as fallback (or None if never cached)
+    return cached
 
 
 def get_user_profile_safe(user):

--- a/hub/utils.py
+++ b/hub/utils.py
@@ -3,6 +3,9 @@ from datetime import datetime, timedelta
 import logging
 import re
 import urllib
+import urllib.parse
+
+import sentry_sdk
 
 from django.core.mail import EmailMultiAlternatives, send_mail
 from django.conf import settings
@@ -21,6 +24,82 @@ logger = logging.getLogger(__name__)
 
 PARSER_REGEX = r"^([\w\u0531-\u058A\u0400-\u04FF1-4\'\.\s]+) ([0-9]+\.)?([0-9]+)\-?([0-9]+\.)?([0-9]+)?$"
 SUPPORTED_CHURCHES = Church.objects.filter(name=settings.DEFAULT_CHURCH_NAME)
+
+# Circuit breaker state: key = "circuit_breaker:{url_hash}" (store in cache)
+# After 3 consecutive failures in 15 min, block further attempts for 15 min
+SCRAPE_CIRCUIT_BREAKER_CACHE_TIMEOUT = 900  # 15 min
+SCRAPE_CIRCUIT_BREAKER_MAX_FAILURES = 3
+SCRAPE_CACHE_TIMEOUT = 21600  # 6 hours
+
+
+def _fetch_sacredtradition(url: str, timeout: int = 10) -> str | None:
+    """Fetch a sacredtradition.am page with retries, circuit breaker, and caching.
+    
+    Args:
+        url: Full URL to fetch
+        timeout: Request timeout in seconds
+        
+    Returns:
+        Decoded HTML string, or None on failure (with cached data if avail)
+    """
+    # URL validation
+    parsed = urllib.parse.urlparse(url)
+    if not parsed.netloc or parsed.netloc != "sacredtradition.am":
+        logger.error("Invalid URL for sacredtradition.am scrape: %s", url)
+        return None
+    
+    # Check circuit breaker
+    circuit_key = f"circuit_breaker:{hash(url)}"
+    circuit_open = cache.get(circuit_key)
+    if circuit_open:
+        logger.warning("Circuit breaker open for %s, skipping scrape", url)
+        # Try cache fallback anyway
+        cached = cache.get(f"scrape_result:{hash(url)}")
+        if cached:
+            return cached
+        return None
+    
+    # Try cached result first
+    cache_key = f"scrape_result:{hash(url)}"
+    cached = cache.get(cache_key)
+    if cached:
+        return cached
+    
+    # Fetch with retries
+    last_error = None
+    for attempt in range(3):
+        try:
+            req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0 (compatible; BahkBot/1.0)'})
+            response = urllib.request.urlopen(req, timeout=timeout)
+            if response.status == 200:
+                data = response.read().decode("utf-8")
+                # Cache successful result
+                cache.set(cache_key, data, SCRAPE_CACHE_TIMEOUT)
+                # Reset circuit breaker on success
+                cache.delete(circuit_key)
+                return data
+            else:
+                last_error = f"HTTP {response.status}"
+                logger.error("sacredtradition.am returned status %d for %s", response.status, url)
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError) as e:
+            last_error = str(e)
+            logger.warning("Attempt %d/3 failed for %s: %s", attempt + 1, url, last_error)
+            if attempt < 2:
+                import time
+                time.sleep(1 * (attempt + 1))  # 1s, 2s backoff
+    
+    # All attempts failed — trip circuit breaker
+    failure_count = cache.get(circuit_key + ":failures", 0)
+    failure_count += 1
+    cache.set(circuit_key + ":failures", failure_count, SCRAPE_CIRCUIT_BREAKER_CACHE_TIMEOUT)
+    if failure_count >= SCRAPE_CIRCUIT_BREAKER_MAX_FAILURES:
+        cache.set(circuit_key, True, SCRAPE_CIRCUIT_BREAKER_CACHE_TIMEOUT)
+        sentry_sdk.capture_exception(Exception(f"Circuit breaker tripped for {url}"))
+    
+    # Log the final failure
+    if last_error:
+        sentry_sdk.capture_exception(Exception(f"Scrape failed for {url} after 3 attempts: {last_error}"))
+    return cached  # Return stale cached data as fallback, or None
 
 
 def get_user_profile_safe(user):
@@ -94,15 +173,8 @@ def scrape_readings(date_obj, church, date_format="%Y%m%d", max_num_readings=40)
             language_code: 2 for English, 3 for Armenian
         """
         url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM=1103&iL={language_code}&ymd={date_str}"
-        try:
-            response = urllib.request.urlopen(url, timeout=10)
-            if response.status != 200:
-                logging.error("Could not access readings from url %s. Failed with status %r", url, response.status)
-                return []
-            data = response.read()
-            html_content = data.decode("utf-8")
-        except (urllib.error.URLError, OSError):
-            logging.error("Failed to fetch %s", url)
+        html_content = _fetch_sacredtradition(url)
+        if html_content is None:
             return []
 
         book_start = html_content.find("<b>")
@@ -411,18 +483,8 @@ def scrape_feast(date_obj, church, date_format="%Y%m%d"):
             language_code: 2 for English, 3 for Armenian
         """
         url = f"https://sacredtradition.am/Calendar/nter.php?NM=0&iM=1103&iL={language_code}&ymd={date_str}"
-        
-        req = urllib.request.Request(url, headers={'User-agent': 'Mozilla/5.0'})
-        
-        try:
-            response = urllib.request.urlopen(req, timeout=10)
-            if response.status != 200:
-                logging.error("Could not access feast from url %s. Failed with status %r", url, response.status)
-                return None
-            data = response.read()
-            html_content = data.decode("utf-8")
-        except (urllib.error.URLError, OSError):
-            logging.error("Failed to fetch %s", url)
+        html_content = _fetch_sacredtradition(url)
+        if html_content is None:
             return None
 
         # Look for elements with class="dname" or class=dname (with or without quotes)

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -6,8 +6,10 @@ Currently based on the Daily Worship app's website, sacredtradition.am
 import logging
 from datetime import datetime
 
+import sentry_sdk
 from django.conf import settings
 from django.db.models import F
+from django.core.cache import cache
 from django.shortcuts import get_object_or_404
 from django.utils.translation import activate, get_language_from_request
 from rest_framework import generics, status
@@ -71,130 +73,156 @@ class GetFeastForDate(generics.GenericAPIView):
         else:
             church = Church.objects.get(pk=Church.get_default_pk())
 
-        # Use the shared utility function to get or create feast
-        # Note: check_fast=False because the view should still return feasts even if a Fast exists
-        feast_obj, _, _ = get_or_create_feast_for_date(date_obj, church, check_fast=False)
-        
-        # Get the day for the date (needed for the rest of the view logic)
-        day = Day.objects.get(date=date_obj, church=church)
+        # Cache key for feast lookup
+        cache_key = f"feast:{date_obj}:{church.id}"
+        cached_result = cache.get(cache_key)
+        if cached_result:
+            return Response(cached_result)
 
-        # Use the feast from the utility function, or get it from the day if None
-        feast = feast_obj if feast_obj else day.feasts.first()
-        
-        if feast is None:
-            # No feast on this day
-            return Response({
-                "date": date_str,
-                "feast": None,
-            })
-
-        # Get translated feast name with proper fallback
-        name_translated = getattr(feast, 'name_i18n', None)
-        if not name_translated:
-            # Fallback to base name field
-            name_translated = feast.name
-        
-        # If name is still None or empty, treat as no feast
-        if not name_translated or not name_translated.strip():
-            return Response({
-                "date": date_str,
-                "feast": None,
-            })
-
-        # Check if context exists and has all translations
-        active_context = feast.active_context
-        should_trigger_generation = True
-        
-        # Don't trigger context generation if feast name includes "Fast"
-        if "Fast" in feast.name:
-            should_trigger_generation = False
-        
-        if active_context is None:
-            # No context at all, trigger generation for all languages if appropriate
-            if should_trigger_generation:
-                logging.warning("No context found for feast %s", str(feast))
-                logging.info("Enqueue context generation for feast %s (all languages)", feast.id)
-                generate_feast_context_task.delay(feast.id)
+        try:
+            # Use the shared utility function to get or create feast
+            # Note: check_fast=False because the view should still return feasts even if a Fast exists
+            feast_obj, _, _ = get_or_create_feast_for_date(date_obj, church, check_fast=False)
             
-            context_dict = {
-                "text": "",
-                "short_text": "",
-                "context_thumbs_up": 0,
-                "context_thumbs_down": 0,
-            }
-        else:
-            # Get the requested language translations
-            context_text = getattr(active_context, 'text_i18n', active_context.text)
-            short_context_text = getattr(active_context, 'short_text_i18n', active_context.short_text)
+            # Get the day for the date (needed for the rest of the view logic)
+            day = Day.objects.get(date=date_obj, church=church)
 
-            # Check if all languages have translations
-            available_languages = getattr(settings, 'MODELTRANS_AVAILABLE_LANGUAGES', ['en', 'hy'])
-            all_languages_present = True
-            for available_lang in available_languages:
-                if available_lang == 'en':
-                    lang_text = active_context.text
-                    lang_short = active_context.short_text
-                else:
-                    lang_text = getattr(active_context, f'text_{available_lang}', None)
-                    lang_short = getattr(active_context, f'short_text_{available_lang}', None)
+            # Use the feast from the utility function, or get it from the day if None
+            feast = feast_obj if feast_obj else day.feasts.first()
+            
+            if feast is None:
+                # No feast on this day
+                response_data = {
+                    "date": date_str,
+                    "feast": None,
+                }
+                cache.set(cache_key, response_data, 3600)
+                return Response(response_data)
+
+            # Get translated feast name with proper fallback
+            name_translated = getattr(feast, 'name_i18n', None)
+            if not name_translated:
+                # Fallback to base name field
+                name_translated = feast.name
+            
+            # If name is still None or empty, treat as no feast
+            if not name_translated or not name_translated.strip():
+                response_data = {
+                    "date": date_str,
+                    "feast": None,
+                }
+                cache.set(cache_key, response_data, 3600)
+                return Response(response_data)
+
+            # Check if context exists and has all translations
+            active_context = feast.active_context
+            should_trigger_generation = True
+            
+            # Don't trigger context generation if feast name includes "Fast"
+            if "Fast" in feast.name:
+                should_trigger_generation = False
+            
+            if active_context is None:
+                # No context at all, trigger generation for all languages if appropriate
+                if should_trigger_generation:
+                    logging.warning("No context found for feast %s", str(feast))
+                    logging.info("Enqueue context generation for feast %s (all languages)", feast.id)
+                    generate_feast_context_task.delay(feast.id)
                 
-                if not lang_text or not lang_text.strip() or not lang_short or not lang_short.strip():
-                    all_languages_present = False
-                    break
+                context_dict = {
+                    "text": "",
+                    "short_text": "",
+                    "context_thumbs_up": 0,
+                    "context_thumbs_down": 0,
+                }
+            else:
+                # Get the requested language translations
+                context_text = getattr(active_context, 'text_i18n', active_context.text)
+                short_context_text = getattr(active_context, 'short_text_i18n', active_context.short_text)
 
-            # If any translation is missing, trigger generation for all languages if appropriate
-            if not all_languages_present and should_trigger_generation:
-                logging.info(
-                    "Context translations missing for feast %s, enqueuing generation for all languages",
-                    feast.id
-                )
-                generate_feast_context_task.delay(feast.id)
+                # Check if all languages have translations
+                available_languages = getattr(settings, 'MODELTRANS_AVAILABLE_LANGUAGES', ['en', 'hy'])
+                all_languages_present = True
+                for available_lang in available_languages:
+                    if available_lang == 'en':
+                        lang_text = active_context.text
+                        lang_short = active_context.short_text
+                    else:
+                        lang_text = getattr(active_context, f'text_{available_lang}', None)
+                        lang_short = getattr(active_context, f'short_text_{available_lang}', None)
+                    
+                    if not lang_text or not lang_text.strip() or not lang_short or not lang_short.strip():
+                        all_languages_present = False
+                        break
 
-            context_dict = {
-                "text": context_text or "",
-                "short_text": short_context_text or "",
-                "context_thumbs_up": active_context.thumbs_up,
-                "context_thumbs_down": active_context.thumbs_down,
+                # If any translation is missing, trigger generation for all languages if appropriate
+                if not all_languages_present and should_trigger_generation:
+                    logging.info(
+                        "Context translations missing for feast %s, enqueuing generation for all languages",
+                        feast.id
+                    )
+                    generate_feast_context_task.delay(feast.id)
+
+                context_dict = {
+                    "text": context_text or "",
+                    "short_text": short_context_text or "",
+                    "context_thumbs_up": active_context.thumbs_up,
+                    "context_thumbs_down": active_context.thumbs_down,
+                }
+
+            # Serialize icon if it exists
+            icon_data = None
+            if feast.icon:
+                icon_serializer = IconSerializer(feast.icon, context={'request': request})
+                icon_data = icon_serializer.data
+
+            feast_data = {
+                "id": feast.id,
+                "name": name_translated,
+                "designation": feast.designation,
+                "icon": icon_data,
+                **context_dict,
             }
 
-        # Serialize icon if it exists
-        icon_data = None
-        if feast.icon:
-            icon_serializer = IconSerializer(feast.icon, context={'request': request})
-            icon_data = icon_serializer.data
+            # Check if feast has a prayer for its designation
+            feast_prayer_data = None
+            if feast.designation:
+                try:
+                    from prayers.models import FeastPrayer
+                    from prayers.serializers import FeastPrayerSerializer
 
-        feast_data = {
-            "id": feast.id,
-            "name": name_translated,
-            "designation": feast.designation,
-            "icon": icon_data,
-            **context_dict,
-        }
+                    feast_prayer = FeastPrayer.objects.get(designation=feast.designation)
+                    serializer = FeastPrayerSerializer(
+                        feast_prayer,
+                        context={'request': request, 'lang': lang, 'feast': feast}
+                    )
+                    feast_prayer_data = serializer.data
+                except FeastPrayer.DoesNotExist:
+                    pass
 
-        # Check if feast has a prayer for its designation
-        feast_prayer_data = None
-        if feast.designation:
-            try:
-                from prayers.models import FeastPrayer
-                from prayers.serializers import FeastPrayerSerializer
+            feast_data['prayer'] = feast_prayer_data
 
-                feast_prayer = FeastPrayer.objects.get(designation=feast.designation)
-                serializer = FeastPrayerSerializer(
-                    feast_prayer,
-                    context={'request': request, 'lang': lang, 'feast': feast}
-                )
-                feast_prayer_data = serializer.data
-            except FeastPrayer.DoesNotExist:
-                pass
+            response_data = {
+                "date": date_str,
+                "feast": feast_data,
+            }
 
-        feast_data['prayer'] = feast_prayer_data
+            # Cache successful response for 1 hour
+            cache.set(cache_key, response_data, 3600)
+            return Response(response_data)
 
-        response_data = {
-            "date": date_str,
-            "feast": feast_data,
-        }
-
-        return Response(response_data)
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            logging.error("Failed to get feast for date %s (church %s): %s", date_obj, church, e)
+            # Return degraded response
+            return Response(
+                {
+                    "date": date_obj.isoformat(),
+                    "feast": None,
+                    "error": "Feast data temporarily unavailable",
+                },
+                status=status.HTTP_200_OK  # Return 200 not 500 so clients handle gracefully
+            )
 
 
 class FeastContextFeedbackView(APIView):

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -73,8 +73,8 @@ class GetFeastForDate(generics.GenericAPIView):
         else:
             church = Church.objects.get(pk=Church.get_default_pk())
 
-        # Cache key for feast lookup
-        cache_key = f"feast:{date_obj}:{church.id}"
+        # Cache key for feast lookup (includes lang to prevent cross-language poisoning)
+        cache_key = f"feast:{date_obj}:{church.id}:{lang}"
         cached_result = cache.get(cache_key)
         if cached_result:
             return Response(cached_result)

--- a/prayers/serializers.py
+++ b/prayers/serializers.py
@@ -1,4 +1,7 @@
 """Serializers for prayers app."""
+import logging
+
+import sentry_sdk
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -467,6 +470,9 @@ class PrayerRequestThanksSerializer(serializers.Serializer):
         return value.strip()
 
 
+logger = logging.getLogger(__name__)
+
+
 class FeastPrayerSerializer(serializers.ModelSerializer):
     """Serializer for FeastPrayer with translation and rendering support."""
 
@@ -493,24 +499,29 @@ class FeastPrayerSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         """Add translation support and template rendering."""
-        # Get language from request
-        lang = self.context.get('lang') or (
-            self.context.get('request').query_params.get('lang')
-            if self.context.get('request') else None
-        ) or 'en'
-        activate(lang)
+        try:
+            # Get language from request
+            lang = self.context.get('lang') or (
+                self.context.get('request').query_params.get('lang')
+                if self.context.get('request') else None
+            ) or 'en'
+            activate(lang)
 
-        data = super().to_representation(instance)
+            data = super().to_representation(instance)
 
-        # Get translated template fields
-        data['title_template'] = getattr(instance, 'title_i18n', instance.title)
-        data['text_template'] = getattr(instance, 'text_i18n', instance.text)
+            # Get translated template fields
+            data['title_template'] = getattr(instance, 'title_i18n', instance.title)
+            data['text_template'] = getattr(instance, 'text_i18n', instance.text)
 
-        # Render with feast if provided in context
-        feast = self.context.get('feast')
-        if feast:
-            rendered = instance.render_for_feast(feast, lang)
-            data['title_rendered'] = rendered['title']
-            data['text_rendered'] = rendered['text']
+            # Render with feast if provided in context
+            feast = self.context.get('feast')
+            if feast:
+                rendered = instance.render_for_feast(feast, lang)
+                data['title_rendered'] = rendered['title']
+                data['text_rendered'] = rendered['text']
 
-        return data
+            return data
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            logger.error("Failed to serialize FeastPrayer %s: %s", instance.id, e)
+            return {"id": instance.id, "error": "Failed to render"}

--- a/tests/e2e_settings.py
+++ b/tests/e2e_settings.py
@@ -1,0 +1,9 @@
+"""E2E test settings - like test_settings but with a persistent SQLite DB."""
+from tests.test_settings import *  # noqa: F401,F403
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': '/tmp/bahk_e2e.sqlite3',
+    }
+}


### PR DESCRIPTION
## Changes

### #350 — Scraper Robustness (prerequisite)
- Added shared `_fetch_sacredtradition()` with:
  - URL validation
  - Retry logic (3 attempts with exponential backoff)
  - Circuit breaker (3 consecutive failures → 15 min block)
  - Cache (6h TTL for successful results)
  - Sentry exception capture
- Refactored `scrape_feast()` and `scrape_readings()` to use the shared helper

### #349 — Feast Endpoint Resilience
- Added cache around feast lookup (1h TTL)
- Wrapped view in try/except → returns degraded response (200 with feast: null)
- Added exception handling in FeastPrayerSerializer

### Tests
- 8 new tests: degraded response, cache hit, cache isolation, circuit breaker trip/reset, stale cache fallback, URL validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new retry/circuit-breaker and caching behavior for external scraping plus response caching/degraded 200s in the feast API, which can affect freshness and failure modes. Risk is mitigated by added test coverage but should be validated in production-like cache settings.
> 
> **Overview**
> **Improves resilience of sacredtradition.am scraping and the feast API.** A new shared `_fetch_sacredtradition()` adds URL validation, retries with backoff, a cache-backed circuit breaker, stale-result fallback, and Sentry reporting; `scrape_feast()`/`scrape_readings()` are refactored to use it.
> 
> **Makes `GetFeastForDate` more client-friendly under failures.** The endpoint now caches per `date/church/lang` for 1 hour and wraps the handler in a broad try/except to return a degraded `200` response with `feast: null` and an error message instead of erroring.
> 
> Also adds defensive exception handling in `FeastPrayerSerializer`, new tests covering degraded responses/caching/circuit breaker behavior, and an `e2e_settings.py` that uses a persistent SQLite DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c19201dff8fc6e34a1fb08dfb2896fc0c2ea965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->