### PR TITLE
fix: normalize book names in API.Bible lookup to handle curly quotes (#374, #371)

### DIFF
--- a/hub/services/bible_api_service.py
+++ b/hub/services/bible_api_service.py
@@ -101,8 +101,8 @@ class BibleAPIService:
         """Resolve a book name (as stored in Reading.book) to its 3-letter USFM ID.
 
         Args:
-            book_name: Book name as it appears in the database, e.g. "Genesis",
-                       "St. Paul's Epistle to the Romans", "Tobit".
+            book_name: Raw book name (may contain curly/smart quotes from scrapers),
+                       e.g. "Genesis", "St. Paul's Epistle to the Romans", "Tobit".
 
         Returns:
             3-letter USFM code (e.g. "GEN", "ROM", "TOB").
@@ -110,7 +110,9 @@ class BibleAPIService:
         Raises:
             ValueError: If the book name is not found in BOOK_NAME_TO_USFM.
         """
-        usfm_id = BOOK_NAME_TO_USFM.get(book_name)
+        from hub.constants import normalize_book_name
+
+        usfm_id = BOOK_NAME_TO_USFM.get(normalize_book_name(book_name))
         if usfm_id is None:
             raise ValueError(
                 f"Unknown book name: '{book_name}'. "


### PR DESCRIPTION
## Summary
Fixes #374 and #371 — book name lookup failures for "St. Peter's First Epistle General" and other books with smart/curly quotes.

## Root Cause
`resolve_book_name()` in `bible_api_service.py` did a raw `BOOK_NAME_TO_USFM.get(book_name)` with no Unicode normalization. Scrapers sometimes return curly quotes (U+2018/U+2019) in book names (e.g. `St. Peter\u2019s First Epistle General`), which doesn't match the straight quote in the dictionary keys. The Catena lookup path already had `normalize_book_name()` applied — the API.Bible path was the sole gap.

## Fix
Added `normalize_book_name()` call in `resolve_book_name()` before the dictionary lookup, matching the pattern already used in `Reading.create_url()` for Catena lookups. This:
- Converts curly/smart quotes → straight quotes (NFKC + manual replacements)
- Handles Unicode normalization variants

## Issues fixed
- **#374:** 70 Sentry events, blocks API.Bible text retrieval
- **#371:** 328 Sentry events, 50 users affected, broken Catena links (already partially addressed by existing normalize; this ensures consistency)

## Testing
- `ruff check .` — passes
- Verified `normalize_book_name` correctly handles curly quote variants

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change that normalizes `book_name` before dictionary lookup, reducing lookup failures without altering API call logic.
> 
> **Overview**
> Fixes API.Bible book mapping failures caused by curly/smart quotes and other Unicode variants by normalizing `book_name` in `BibleAPIService.resolve_book_name()` before the `BOOK_NAME_TO_USFM` lookup.
> 
> Also updates the docstring to clarify that the input book name may be “raw” scraper output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d218c62760e758bf252157ed2325ab8d06e0365d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->