### PR TITLE
fix: handle Feast.DoesNotExist gracefully in views and tasks (#375)

### DIFF
--- a/hub/tasks/feast_tasks.py
+++ b/hub/tasks/feast_tasks.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from celery import shared_task
 import sentry_sdk
 
-from hub.models import Church
+from hub.models import Church, Feast
 from hub.utils import get_or_create_feast_for_date
 
 logger = logging.getLogger(__name__)
@@ -85,6 +85,9 @@ def create_feast_date_task():
         
         return status_dict
         
+    except Feast.DoesNotExist:
+        logger.warning(f"Feast not found when creating feast date for {today} — may have been deleted")
+        return {"status": "skipped", "reason": "feast_deleted"}
     except Exception as e:
         logger.error(f"Error creating feast date for {today}: {e}", exc_info=True)
         sentry_sdk.capture_exception(e)

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -211,6 +211,13 @@ class GetFeastForDate(generics.GenericAPIView):
             cache.set(cache_key, response_data, 3600)
             return Response(response_data)
 
+        except Feast.DoesNotExist:
+            # Feast may have been deleted between scheduling and execution — log and degrade gracefully
+            logging.warning("Feast not found for date %s (church %s) — may have been deleted", date_obj, church)
+            return Response(
+                {"date": date_obj.isoformat(), "feast": None},
+                status=status.HTTP_200_OK,
+            )
         except Exception as e:
             sentry_sdk.capture_exception(e)
             logging.error("Failed to get feast for date %s (church %s): %s", date_obj, church, e)


### PR DESCRIPTION
## Summary
Fixes #375 — `Feast.DoesNotExist` errors (17 events) when referencing Feast PK 255 that no longer exists.

## Root Cause
All existing `Feast.objects.get()` calls in the codebase already handle `DoesNotExist` — the error was surfacing through broad `except Exception` handlers in `GetFeastForDate` view and `create_feast_date_task` that were sending the exception to Sentry before returning a degraded response.

## Fix
Added specific `except Feast.DoesNotExist` handlers BEFORE the broad exception catches in:
- `hub/views/feasts.py` — `GetFeastForDate.get()` 
- `hub/tasks/feast_tasks.py` — `create_feast_date_task()`

Both now log a warning and degrade gracefully without polluting Sentry.

## Testing
- `ruff check` — passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a targeted `Feast.DoesNotExist` catch to avoid noisy Sentry errors and return degraded-but-successful responses when a referenced feast was deleted.
> 
> **Overview**
> Prevents `Feast.DoesNotExist` from bubbling into broad exception handlers in both the daily `create_feast_date_task` and the `GetFeastForDate` API.
> 
> Both code paths now **catch `Feast.DoesNotExist` explicitly**, log a warning, and *degrade gracefully* (task returns a skipped status; API returns `200` with `feast: null`) instead of reporting the error to Sentry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8325da4946ebd086f9ca300fe6848984382751e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->