### PR TITLE
feat: add intentions to fast joins (backend)

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -37,6 +37,7 @@ from hub.models import (
     Profile,
     Reading,
     ReadingContext,
+    FastIntention,
 )
 from hub.services.bible_api_service import BibleAPIService, fetch_text_for_reading
 from hub.tasks import (
@@ -1417,3 +1418,19 @@ class PatristicQuoteAdmin(MarkdownxModelAdmin):
         return ', '.join(tag.name for tag in obj.tags.all())
 
     tag_list.short_description = 'Tags'
+
+
+@admin.register(FastIntention, site=admin.site)
+class FastIntentionAdmin(admin.ModelAdmin):
+    list_display = ('user', 'fast', 'text_preview', 'is_public', 'is_active', 'updated_at')
+    list_filter = ('is_public', 'is_active', 'fast', 'updated_at')
+    search_fields = ('text', 'user__username', 'user__email', 'fast__name')
+    readonly_fields = ('created_at', 'updated_at')
+    raw_id_fields = ('user', 'fast')
+
+    def text_preview(self, obj):
+        if obj.text:
+            return Truncator(obj.text).chars(50)
+        return '(empty)'
+
+    text_preview.short_description = 'Text'

--- a/hub/migrations/0051_fast_intention.py
+++ b/hub/migrations/0051_fast_intention.py
@@ -1,0 +1,46 @@
+# Generated manually for FastIntention model
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('hub', '0050_add_fast_designation_to_feast'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='FastIntention',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('text', models.CharField(blank=True, default='', help_text='The intention text (max 280 characters)', max_length=280)),
+                ('is_public', models.BooleanField(default=False, help_text='Whether this intention is visible to other fast participants')),
+                ('is_active', models.BooleanField(default=True, help_text='Soft-delete flag; set to False when user leaves the fast')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('fast', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='intentions', to='hub.fast')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='fast_intentions', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'verbose_name': 'Fast Intention',
+                'verbose_name_plural': 'Fast Intentions',
+                'ordering': ['-created_at'],
+            },
+        ),
+        migrations.AddConstraint(
+            model_name='fastintention',
+            constraint=models.UniqueConstraint(condition=models.Q(('is_active', True)), fields=('user', 'fast'), name='one_active_intention_per_user_fast'),
+        ),
+        migrations.AddIndex(
+            model_name='fastintention',
+            index=models.Index(fields=['fast', 'is_active', 'is_public'], name='hub_fastint_fast_id_7f8e1e_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='fastintention',
+            index=models.Index(fields=['user', 'fast'], name='hub_fastint_user_id_3a2b1c_idx'),
+        ),
+    ]

--- a/hub/models.py
+++ b/hub/models.py
@@ -1048,3 +1048,98 @@ class PatristicQuote(models.Model):
         # Return first 50 characters of the quote text
         from django.utils.text import Truncator
         return f"{Truncator(self.text).chars(50)} - {self.attribution}"
+
+
+class FastIntention(models.Model):
+    """Stores a user's spiritual intention for a specific fast."""
+
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="fast_intentions",
+    )
+    fast = models.ForeignKey(
+        Fast,
+        on_delete=models.CASCADE,
+        related_name="intentions",
+    )
+    text = models.CharField(max_length=280, blank=True)
+    is_public = models.BooleanField(default=False)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "fast"],
+                condition=models.Q(is_active=True),
+                name="one_active_intention_per_user_fast",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["fast", "is_active", "is_public"]),
+            models.Index(fields=["user", "fast"]),
+        ]
+
+    def __str__(self):
+        visibility = "public" if self.is_public else "private"
+        status = "active" if self.is_active else "inactive"
+        return f"Intention for {self.user.email} on {self.fast} ({visibility}, {status})"
+
+
+class FastIntention(models.Model):
+    """Stores a user's spiritual intention for a fast.
+
+    Intentions can be private (only the user sees them) or public
+    (visible to other participants on the participant sheet).
+    Soft-delete via is_active=False on leave so rejoining restores.
+    """
+
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name='fast_intentions',
+    )
+    fast = models.ForeignKey(
+        Fast,
+        on_delete=models.CASCADE,
+        related_name='intentions',
+    )
+    text = models.CharField(
+        max_length=280,
+        blank=True,
+        default='',
+        help_text='The intention text (max 280 characters)',
+    )
+    is_public = models.BooleanField(
+        default=False,
+        help_text='Whether this intention is visible to other fast participants',
+    )
+    is_active = models.BooleanField(
+        default=True,
+        help_text='Soft-delete flag; set to False when user leaves the fast',
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=['user', 'fast'],
+                condition=models.Q(is_active=True),
+                name='one_active_intention_per_user_fast',
+            ),
+        ]
+        indexes = [
+            models.Index(fields=['fast', 'is_active', 'is_public']),
+            models.Index(fields=['user', 'fast']),
+        ]
+        ordering = ['-created_at']
+        verbose_name = 'Fast Intention'
+        verbose_name_plural = 'Fast Intentions'
+
+    def __str__(self):
+        visibility = 'public' if self.is_public else 'private'
+        status = 'active' if self.is_active else 'inactive'
+        return f"Intention for {self.fast.name} by {self.user.username} ({visibility}, {status})"

--- a/hub/models.py
+++ b/hub/models.py
@@ -1050,43 +1050,6 @@ class PatristicQuote(models.Model):
         return f"{Truncator(self.text).chars(50)} - {self.attribution}"
 
 
-class FastIntention(models.Model):
-    """Stores a user's spiritual intention for a specific fast."""
-
-    user = models.ForeignKey(
-        User,
-        on_delete=models.CASCADE,
-        related_name="fast_intentions",
-    )
-    fast = models.ForeignKey(
-        Fast,
-        on_delete=models.CASCADE,
-        related_name="intentions",
-    )
-    text = models.CharField(max_length=280, blank=True)
-    is_public = models.BooleanField(default=False)
-    is_active = models.BooleanField(default=True)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        constraints = [
-            models.UniqueConstraint(
-                fields=["user", "fast"],
-                condition=models.Q(is_active=True),
-                name="one_active_intention_per_user_fast",
-            ),
-        ]
-        indexes = [
-            models.Index(fields=["fast", "is_active", "is_public"]),
-            models.Index(fields=["user", "fast"]),
-        ]
-
-    def __str__(self):
-        visibility = "public" if self.is_public else "private"
-        status = "active" if self.is_active else "inactive"
-        return f"Intention for {self.user.email} on {self.fast} ({visibility}, {status})"
-
 
 class FastIntention(models.Model):
     """Stores a user's spiritual intention for a fast.

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -373,6 +373,13 @@ class JoinFastSerializer(serializers.ModelSerializer):
         write_only=True,
     )
 
+    def validate_intention_text(self, value):
+        if value and len(value) > 280:
+            raise serializers.ValidationError('Intention text must be 280 characters or fewer.')
+        if value and profanity.contains_profanity(value):
+            raise serializers.ValidationError('The intention text is suspected of profanity.')
+        return value
+
     class Meta:
         model = models.Profile
         fields = ['fast_id', 'intention_text', 'intention_is_public']
@@ -481,7 +488,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
         fast_id = self.context.get('fast_id')
         if not fast_id:
             return None
-        intention = getattr(obj, '_prefetched_intention', None)
+        intention = getattr(obj, '_intention', None)
         if intention is None:
             return None
         if not intention.is_active or not intention.is_public or not intention.text:

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -345,12 +345,37 @@ class FastSerializer(serializers.ModelSerializer, ThumbnailCacheMixin):
             return set()
         return set(request.user.profile.fasts.values_list('id', flat=True))
 
+class FastIntentionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.FastIntention
+        fields = ['id', 'text', 'is_public', 'is_active', 'created_at', 'updated_at']
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+    def validate_text(self, value):
+        if value and len(value) > 280:
+            raise serializers.ValidationError('Intention text must be 280 characters or fewer.')
+        if value and profanity.contains_profanity(value):
+            raise serializers.ValidationError('The intention text is suspected of profanity.')
+        return value
+
+
 class JoinFastSerializer(serializers.ModelSerializer):
     fast_id = serializers.IntegerField(write_only=True)
+    intention_text = serializers.CharField(
+        max_length=280,
+        required=False,
+        allow_blank=True,
+        write_only=True,
+    )
+    intention_is_public = serializers.BooleanField(
+        required=False,
+        default=False,
+        write_only=True,
+    )
 
     class Meta:
         model = models.Profile
-        fields = ['fast_id']
+        fields = ['fast_id', 'intention_text', 'intention_is_public']
 
 class FastStatsSerializer(serializers.Serializer):
     joined_fasts = serializers.SerializerMethodField()
@@ -431,6 +456,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
     thumbnail = serializers.SerializerMethodField()
     abbreviation = serializers.SerializerMethodField()
     user = serializers.SerializerMethodField()
+    intention = serializers.SerializerMethodField()
 
     def get_user(self, obj):
         # user is returning name while frontend is transitioning to api change.
@@ -451,9 +477,20 @@ class ParticipantSerializer(serializers.ModelSerializer):
             return obj.profile_image_thumbnail.url
         return None
 
+    def get_intention(self, obj):
+        fast_id = self.context.get('fast_id')
+        if not fast_id:
+            return None
+        intention = getattr(obj, '_prefetched_intention', None)
+        if intention is None:
+            return None
+        if not intention.is_active or not intention.is_public or not intention.text:
+            return None
+        return intention.text
+
     class Meta:
         model = models.Profile
-        fields = ['id', 'name', 'profile_image', 'thumbnail', 'location', 'abbreviation', 'user']
+        fields = ['id', 'name', 'profile_image', 'thumbnail', 'location', 'abbreviation', 'user', 'intention']
 
 class PasswordResetSerializer(serializers.Serializer):
     email = serializers.EmailField()

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -369,7 +369,6 @@ class JoinFastSerializer(serializers.ModelSerializer):
     )
     intention_is_public = serializers.BooleanField(
         required=False,
-        default=False,
         write_only=True,
     )
 

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -16,6 +16,7 @@ from .views.fast import (
     LeaveFastView, 
     FastStatsView,
     FastParticipantsMapView,
+    FastIntentionView,
 )
 from .views.day import FastDaysListView, UserDaysView
 from .views.devotionals import DevotionalByDateView, DevotionalsByFastView, DevotionalDetailView, DevotionalListView
@@ -69,6 +70,7 @@ urlpatterns = [
     path('fasts/<int:fast_id>/participants/paginated/', PaginatedFastParticipantsView.as_view(), name='fast-participants-paginated'),
     path('fasts/stats/', FastStatsView.as_view(), name='fast-stats'),
     path('fasts/<int:fast_id>/participants/map/', FastParticipantsMapView.as_view(), name='fast-participants-map'),
+    path('fasts/<int:fast_id>/intention/', FastIntentionView.as_view(), name='fast-intention'),
 
 
     # TODO: Remove these legacy endpoints after frontend is updated

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -482,8 +482,9 @@ class JoinFastView(generics.UpdateAPIView):
         serializer.save()
         
         # Handle intention
-        intention_text = self.request.data.get('intention_text', '').strip()
-        intention_is_public = self.request.data.get('intention_is_public', False)
+        validated = serializer.validated_data
+        intention_text = validated.get('intention_text', '') or ''
+        intention_is_public = validated.get('intention_is_public', False)
         
         # Check for soft-kept intention and reactivate or create new
         if intention_text or intention_is_public:
@@ -496,7 +497,7 @@ class JoinFastView(generics.UpdateAPIView):
             if soft_kept:
                 soft_kept.is_active = True
                 soft_kept.text = intention_text or soft_kept.text
-                soft_kept.is_public = intention_is_public if 'intention_is_public' in self.request.data else soft_kept.is_public
+                soft_kept.is_public = intention_is_public if 'intention_is_public' in validated else soft_kept.is_public
                 soft_kept.save()
             else:
                 FastIntention.objects.create(
@@ -766,13 +767,12 @@ class PaginatedFastParticipantsView(generics.ListAPIView):
             # If not in cache, get from database and cache it
             fast = get_object_or_404(Fast, id=fast_id)
             cache.set(cache_key, fast, CACHE_TTL)
+
+        self._participants_fast = fast
         
         queryset = fast.profiles.select_related(
             'user'  # For email/username
         ).order_by('user__date_joined')  # Consistent ordering
-        
-        # Hydrate intentions to avoid N+1
-        _hydrate_intentions(fast, queryset)
         
         return queryset
     
@@ -794,16 +794,18 @@ class PaginatedFastParticipantsView(generics.ListAPIView):
         if cached_count is not None and hasattr(self.paginator, 'count'):
             # If count is cached, use it directly to avoid COUNT(*) query
             self.paginator.count = cached_count
-            return super().paginate_queryset(queryset)
-        
-        # Get paginated results normally (will perform COUNT(*))
-        result = super().paginate_queryset(queryset)
-        
-        # Cache the count for future requests if it was calculated
-        if hasattr(self.paginator, 'count'):
-            cache.set(count_cache_key, self.paginator.count, CACHE_TTL)
-            
-        return result
+            page = super().paginate_queryset(queryset)
+        else:
+            # Get paginated results normally (will perform COUNT(*))
+            page = super().paginate_queryset(queryset)
+            # Cache the count for future requests if it was calculated
+            if hasattr(self.paginator, 'count'):
+                cache.set(count_cache_key, self.paginator.count, CACHE_TTL)
+
+        if page is not None:
+            _hydrate_intentions(self._participants_fast, page)
+
+        return page
 
 
 class FastStatsView(views.APIView):
@@ -1100,8 +1102,18 @@ class FastIntentionView(views.APIView):
         if membership_error:
             return membership_error
 
-        text = request.data.get('text', '').strip()
+        text_value = request.data.get('text', '')
+        if text_value is None:
+            text_value = ''
+        elif not isinstance(text_value, str):
+            return response.Response(
+                {"detail": "Intention text must be a string."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        text = text_value.strip()
         is_public = request.data.get('is_public', False)
+        if is_public is None:
+            is_public = False
 
         # Validate text length
         if len(text) > 280:

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -1117,16 +1117,30 @@ class FastIntentionView(views.APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
-        # Upsert: find existing (active or soft-kept) or create new
-        intention, created = FastIntention.objects.update_or_create(
+        # Look for existing intention (any state) to determine if created or updated
+        existing = FastIntention.objects.filter(
             user=request.user,
             fast=fast,
-            defaults={
-                'text': text,
-                'is_public': is_public,
-                'is_active': True,
-            }
-        )
+        ).first()
+
+        if existing:
+            # Update existing (could be soft-kept or active)
+            existing.text = text
+            existing.is_public = is_public
+            existing.is_active = True
+            existing.save()
+            intention = existing
+            created = False
+        else:
+            # Create new
+            intention = FastIntention.objects.create(
+                user=request.user,
+                fast=fast,
+                text=text,
+                is_public=is_public,
+                is_active=True,
+            )
+            created = True
 
         # Invalidate participant cache since visibility may have changed
         invalidate_fast_participants_cache(fast.id)

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -1,7 +1,7 @@
 from rest_framework import generics, permissions
 from ..constants import NUMBER_PARTICIPANTS_TO_SHOW_WEB
-from ..models import Fast, Church, Profile, Day, FastParticipantMap
-from ..serializers import FastSerializer, JoinFastSerializer, ParticipantSerializer, FastStatsSerializer, FastParticipantMapSerializer
+from ..models import Fast, Church, Profile, Day, FastParticipantMap, FastIntention
+from ..serializers import FastSerializer, JoinFastSerializer, ParticipantSerializer, FastStatsSerializer, FastParticipantMapSerializer, FastIntentionSerializer
 from .mixins import ChurchContextMixin, TimezoneMixin
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -21,6 +21,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from ..utils import invalidate_fast_participants_cache, invalidate_fast_stats_cache
 from functools import wraps
 from hub.tasks import generate_participant_map
+from better_profanity import profanity
 import sentry_sdk
 
 
@@ -480,6 +481,42 @@ class JoinFastView(generics.UpdateAPIView):
         profile.fasts.add(fast)
         serializer.save()
         
+        # Handle intention
+        intention_text = self.request.data.get('intention_text', '').strip()
+        intention_is_public = self.request.data.get('intention_is_public', False)
+        
+        # Check for soft-kept intention and reactivate or create new
+        if intention_text or intention_is_public:
+            # Try to reactivate a soft-kept intention
+            soft_kept = FastIntention.objects.filter(
+                user=self.request.user,
+                fast=fast,
+                is_active=False
+            ).first()
+            if soft_kept:
+                soft_kept.is_active = True
+                soft_kept.text = intention_text or soft_kept.text
+                soft_kept.is_public = intention_is_public if 'intention_is_public' in self.request.data else soft_kept.is_public
+                soft_kept.save()
+            else:
+                FastIntention.objects.create(
+                    user=self.request.user,
+                    fast=fast,
+                    text=intention_text,
+                    is_public=intention_is_public,
+                    is_active=True,
+                )
+        else:
+            # Reactivate soft-kept intention if exists (no text provided)
+            soft_kept = FastIntention.objects.filter(
+                user=self.request.user,
+                fast=fast,
+                is_active=False
+            ).first()
+            if soft_kept:
+                soft_kept.is_active = True
+                soft_kept.save()
+        
         # Invalidate the participant list cache for this fast
         invalidate_fast_participants_cache(fast.id)
         
@@ -558,6 +595,13 @@ class LeaveFastView(generics.UpdateAPIView):
         profile.fasts.remove(fast)
         serializer.save()
         
+        # Soft-keep intention (mark inactive)
+        FastIntention.objects.filter(
+            user=self.request.user,
+            fast=fast,
+            is_active=True
+        ).update(is_active=False)
+        
         # Invalidate the participant list cache for this fast
         invalidate_fast_participants_cache(fast.id)
         
@@ -634,6 +678,9 @@ class FastParticipantsView(views.APIView):
         other_participants = fast.profiles.select_related(
             'user'  # For email/username
         ).order_by('user__date_joined')[:limit]
+
+        # Hydrate intentions to avoid N+1
+        self._hydrate_intentions(fast, other_participants, request.user)
             
         serialized_participants = ParticipantSerializer(
             other_participants, 
@@ -694,15 +741,40 @@ class PaginatedFastParticipantsView(generics.ListAPIView):
             fast = get_object_or_404(Fast, id=fast_id)
             cache.set(cache_key, fast, CACHE_TTL)
         
-        return fast.profiles.select_related(
+        queryset = fast.profiles.select_related(
             'user'  # For email/username
         ).order_by('user__date_joined')  # Consistent ordering
+        
+        # Hydrate intentions to avoid N+1
+        self._hydrate_intentions(fast, queryset, self.request.user)
+        
+        return queryset
     
     def get_serializer_context(self):
         """Add request to serializer context for thumbnail URL generation"""
         context = super().get_serializer_context()
         context['request'] = self.request
         return context
+
+    def _hydrate_intentions(self, fast, profiles, current_user):
+        """Attach intentions to profile objects to avoid N+1 queries."""
+        profile_ids = [p.id for p in profiles]
+        if not profile_ids:
+            return
+        
+        # Fetch all relevant intentions for these profiles in this fast
+        intentions = FastIntention.objects.filter(
+            fast=fast,
+            user__profile__id__in=profile_ids,
+            is_active=True
+        ).select_related('user')
+        
+        # Build lookup by user_id
+        intention_map = {i.user_id: i for i in intentions}
+        
+        # Attach to each profile
+        for profile in profiles:
+            profile._intention = intention_map.get(profile.user_id)
     
     def paginate_queryset(self, queryset):
         """Override to add count caching for pagination performance"""
@@ -967,3 +1039,113 @@ class FastParticipantsMapView(views.APIView):
             # Return the map data
             serializer = FastParticipantMapSerializer(map_obj)
             return response.Response(serializer.data)
+
+
+class FastIntentionView(views.APIView):
+    """
+    API view to manage a user's intention for a specific fast.
+
+    GET    → returns the user's active intention for the fast, or 404.
+    PUT    → upsert intention. Body: { text, is_public }.
+    DELETE → clear intention text (keeps the row).
+
+    Permissions:
+        - IsAuthenticated
+        - 403 if user is not a participant in the fast
+    """
+    permission_classes = [permissions.IsAuthenticated]
+
+    def _get_fast(self, fast_id):
+        return get_object_or_404(Fast, id=fast_id)
+
+    def _check_membership(self, fast, user):
+        if not fast.profiles.filter(user=user).exists():
+            return response.Response(
+                {"detail": "You are not a participant in this fast."},
+                status=status.HTTP_403_FORBIDDEN
+            )
+        return None
+
+    def get(self, request, fast_id):
+        fast = self._get_fast(fast_id)
+        membership_error = self._check_membership(fast, request.user)
+        if membership_error:
+            return membership_error
+
+        intention = FastIntention.objects.filter(
+            user=request.user,
+            fast=fast,
+            is_active=True
+        ).first()
+
+        if not intention:
+            return response.Response(
+                {"detail": "No active intention found."},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        serializer = FastIntentionSerializer(intention)
+        return response.Response(serializer.data)
+
+    def put(self, request, fast_id):
+        fast = self._get_fast(fast_id)
+        membership_error = self._check_membership(fast, request.user)
+        if membership_error:
+            return membership_error
+
+        text = request.data.get('text', '').strip()
+        is_public = request.data.get('is_public', False)
+
+        # Validate text length
+        if len(text) > 280:
+            return response.Response(
+                {"detail": "Intention text must be 280 characters or fewer."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Check profanity
+        if text and profanity.contains_profanity(text):
+            return response.Response(
+                {"detail": "The intention text contains inappropriate language."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Upsert: find existing (active or soft-kept) or create new
+        intention, created = FastIntention.objects.update_or_create(
+            user=request.user,
+            fast=fast,
+            defaults={
+                'text': text,
+                'is_public': is_public,
+                'is_active': True,
+            }
+        )
+
+        # Invalidate participant cache since visibility may have changed
+        invalidate_fast_participants_cache(fast.id)
+
+        serializer = FastIntentionSerializer(intention)
+        status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        return response.Response(serializer.data, status=status_code)
+
+    def delete(self, request, fast_id):
+        fast = self._get_fast(fast_id)
+        membership_error = self._check_membership(fast, request.user)
+        if membership_error:
+            return membership_error
+
+        intention = FastIntention.objects.filter(
+            user=request.user,
+            fast=fast,
+            is_active=True
+        ).first()
+
+        if intention:
+            intention.text = ''
+            intention.save()
+            invalidate_fast_participants_cache(fast.id)
+
+        return response.Response(
+            {"detail": "Intention cleared."},
+            status=status.HTTP_200_OK
+        )

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -636,7 +636,7 @@ def vary_on_query_params(*params):
     return decorator
 
 
-def _hydrate_intentions(fast, profiles, current_user):
+def _hydrate_intentions(fast, profiles):
     """Attach intentions to profile objects to avoid N+1 queries.
     
     Sets `_intention` attribute on each profile object with the active
@@ -706,7 +706,7 @@ class FastParticipantsView(views.APIView):
         ).order_by('user__date_joined')[:limit]
 
         # Hydrate intentions to avoid N+1
-        _hydrate_intentions(fast, other_participants, request.user)
+        _hydrate_intentions(fast, other_participants)
             
         serialized_participants = ParticipantSerializer(
             other_participants, 
@@ -772,7 +772,7 @@ class PaginatedFastParticipantsView(generics.ListAPIView):
         ).order_by('user__date_joined')  # Consistent ordering
         
         # Hydrate intentions to avoid N+1
-        _hydrate_intentions(fast, queryset, self.request.user)
+        _hydrate_intentions(fast, queryset)
         
         return queryset
     

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -1,7 +1,12 @@
 from rest_framework import generics, permissions
 from ..constants import NUMBER_PARTICIPANTS_TO_SHOW_WEB
-from ..models import Fast, Church, Profile, Day, FastParticipantMap, FastIntention
-from ..serializers import FastSerializer, JoinFastSerializer, ParticipantSerializer, FastStatsSerializer, FastParticipantMapSerializer, FastIntentionSerializer
+from ..models import (
+    Fast, Church, Profile, Day, FastParticipantMap, FastIntention
+)
+from ..serializers import (
+    FastSerializer, JoinFastSerializer, ParticipantSerializer, FastStatsSerializer,
+    FastParticipantMapSerializer, FastIntentionSerializer
+)
 from .mixins import ChurchContextMixin, TimezoneMixin
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -482,9 +487,8 @@ class JoinFastView(generics.UpdateAPIView):
         serializer.save()
         
         # Handle intention
-        validated = serializer.validated_data
-        intention_text = validated.get('intention_text', '') or ''
-        intention_is_public = validated.get('intention_is_public', False)
+        intention_text = self.request.data.get('intention_text', '').strip()
+        intention_is_public = self.request.data.get('intention_is_public', False)
         
         # Check for soft-kept intention and reactivate or create new
         if intention_text or intention_is_public:
@@ -497,7 +501,8 @@ class JoinFastView(generics.UpdateAPIView):
             if soft_kept:
                 soft_kept.is_active = True
                 soft_kept.text = intention_text or soft_kept.text
-                soft_kept.is_public = intention_is_public if 'intention_is_public' in validated else soft_kept.is_public
+                if 'intention_is_public' in self.request.data:
+                    soft_kept.is_public = intention_is_public
                 soft_kept.save()
             else:
                 FastIntention.objects.create(
@@ -579,11 +584,11 @@ class LeaveFastView(generics.UpdateAPIView):
         self._fast = fast
         
         # Call parent update method which will call perform_update
-        response_obj = super().update(request, *args, **kwargs)
-        
+        super().update(request, *args, **kwargs)
+
         # Override the default response with a custom success message
         return response.Response(
-            {"detail": "Successfully left the fast."}, 
+            {"detail": "Successfully left the fast."},
             status=status.HTTP_200_OK
         )
 
@@ -767,12 +772,13 @@ class PaginatedFastParticipantsView(generics.ListAPIView):
             # If not in cache, get from database and cache it
             fast = get_object_or_404(Fast, id=fast_id)
             cache.set(cache_key, fast, CACHE_TTL)
-
-        self._participants_fast = fast
         
         queryset = fast.profiles.select_related(
             'user'  # For email/username
         ).order_by('user__date_joined')  # Consistent ordering
+        
+        # Hydrate intentions to avoid N+1
+        _hydrate_intentions(fast, queryset)
         
         return queryset
     
@@ -794,18 +800,16 @@ class PaginatedFastParticipantsView(generics.ListAPIView):
         if cached_count is not None and hasattr(self.paginator, 'count'):
             # If count is cached, use it directly to avoid COUNT(*) query
             self.paginator.count = cached_count
-            page = super().paginate_queryset(queryset)
-        else:
-            # Get paginated results normally (will perform COUNT(*))
-            page = super().paginate_queryset(queryset)
-            # Cache the count for future requests if it was calculated
-            if hasattr(self.paginator, 'count'):
-                cache.set(count_cache_key, self.paginator.count, CACHE_TTL)
-
-        if page is not None:
-            _hydrate_intentions(self._participants_fast, page)
-
-        return page
+            return super().paginate_queryset(queryset)
+        
+        # Get paginated results normally (will perform COUNT(*))
+        result = super().paginate_queryset(queryset)
+        
+        # Cache the count for future requests if it was calculated
+        if hasattr(self.paginator, 'count'):
+            cache.set(count_cache_key, self.paginator.count, CACHE_TTL)
+            
+        return result
 
 
 class FastStatsView(views.APIView):
@@ -939,7 +943,7 @@ def _parse_date_str(date_str):
     """Parses a date string in the format yyyymmdd into a date object."""
     try:
         date = datetime.datetime.strptime(date_str, "%Y%m%d").date()
-    except ValueError as e:
+    except ValueError:
         logging.error("Date string %s did not follow the expected format yyyymmdd. Returning None.", date_str)
         return None
 
@@ -1020,9 +1024,15 @@ class FastParticipantsMapView(views.APIView):
             # If no map exists, if it's older than a day, or if force_update is requested, generate a new one
             if not map_obj or (timezone.now() - map_obj.last_updated).days >= 1 or force_update:
                 # Add context about map regeneration decision
+                map_age = (timezone.now() - map_obj.last_updated).days if map_obj else None
+                reason = (
+                    "not_exists" if not map_obj
+                    else "outdated" if map_age is not None and map_age >= 1
+                    else "force_update"
+                )
                 sentry_sdk.set_context("map_generation", {
-                    "reason": "not_exists" if not map_obj else "outdated" if (timezone.now() - map_obj.last_updated).days >= 1 else "force_update",
-                    "map_age_days": (timezone.now() - map_obj.last_updated).days if map_obj else None,
+                    "reason": reason,
+                    "map_age_days": map_age,
                     "force_update": force_update
                 })
                 
@@ -1038,12 +1048,13 @@ class FastParticipantsMapView(views.APIView):
                     )
                 elif force_update:
                     # If force_update was requested, inform the user
-                    return response.Response(
-                        {
-                            "detail": "Map update has been triggered. The current map is being returned, but a new one is being generated.",
-                            "map": FastParticipantMapSerializer(map_obj).data
-                        }
-                    )
+                    return response.Response({
+                        "detail": (
+                            "Map update has been triggered. The current map is "
+                            "being returned, but a new one is being generated."
+                        ),
+                        "map": FastParticipantMapSerializer(map_obj).data
+                    })
             
             # Return the map data
             serializer = FastParticipantMapSerializer(map_obj)
@@ -1102,18 +1113,8 @@ class FastIntentionView(views.APIView):
         if membership_error:
             return membership_error
 
-        text_value = request.data.get('text', '')
-        if text_value is None:
-            text_value = ''
-        elif not isinstance(text_value, str):
-            return response.Response(
-                {"detail": "Intention text must be a string."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        text = text_value.strip()
+        text = request.data.get('text', '').strip()
         is_public = request.data.get('is_public', False)
-        if is_public is None:
-            is_public = False
 
         # Validate text length
         if len(text) > 280:

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -636,6 +636,32 @@ def vary_on_query_params(*params):
     return decorator
 
 
+def _hydrate_intentions(fast, profiles, current_user):
+    """Attach intentions to profile objects to avoid N+1 queries.
+    
+    Sets `_intention` attribute on each profile object with the active
+    FastIntention for the given fast, or None if no active intention exists.
+    """
+    profile_ids = [p.id for p in profiles]
+    if not profile_ids:
+        return
+    
+    # Fetch all relevant intentions for these profiles in this fast
+    intentions = FastIntention.objects.filter(
+        fast=fast,
+        user__profile__id__in=profile_ids,
+        is_active=True,
+        is_public=True,
+    ).select_related('user')
+    
+    # Build lookup by user_id
+    intention_map = {i.user_id: i for i in intentions}
+    
+    # Attach to each profile
+    for profile in profiles:
+        profile._intention = intention_map.get(profile.user_id)
+
+
 class FastParticipantsView(views.APIView):
     """
     API view to retrieve participants of a specific fast.
@@ -680,12 +706,12 @@ class FastParticipantsView(views.APIView):
         ).order_by('user__date_joined')[:limit]
 
         # Hydrate intentions to avoid N+1
-        self._hydrate_intentions(fast, other_participants, request.user)
+        _hydrate_intentions(fast, other_participants, request.user)
             
         serialized_participants = ParticipantSerializer(
             other_participants, 
             many=True, 
-            context={'request': request}
+            context={'request': request, 'fast_id': fast.id}
         )
         return response.Response(serialized_participants.data)
 
@@ -746,7 +772,7 @@ class PaginatedFastParticipantsView(generics.ListAPIView):
         ).order_by('user__date_joined')  # Consistent ordering
         
         # Hydrate intentions to avoid N+1
-        self._hydrate_intentions(fast, queryset, self.request.user)
+        _hydrate_intentions(fast, queryset, self.request.user)
         
         return queryset
     
@@ -754,27 +780,8 @@ class PaginatedFastParticipantsView(generics.ListAPIView):
         """Add request to serializer context for thumbnail URL generation"""
         context = super().get_serializer_context()
         context['request'] = self.request
+        context['fast_id'] = self.kwargs.get('fast_id')
         return context
-
-    def _hydrate_intentions(self, fast, profiles, current_user):
-        """Attach intentions to profile objects to avoid N+1 queries."""
-        profile_ids = [p.id for p in profiles]
-        if not profile_ids:
-            return
-        
-        # Fetch all relevant intentions for these profiles in this fast
-        intentions = FastIntention.objects.filter(
-            fast=fast,
-            user__profile__id__in=profile_ids,
-            is_active=True
-        ).select_related('user')
-        
-        # Build lookup by user_id
-        intention_map = {i.user_id: i for i in intentions}
-        
-        # Attach to each profile
-        for profile in profiles:
-            profile._intention = intention_map.get(profile.user_id)
     
     def paginate_queryset(self, queryset):
         """Override to add count caching for pagination performance"""

--- a/tests/integration/test_intention_endpoints.py
+++ b/tests/integration/test_intention_endpoints.py
@@ -224,7 +224,7 @@ class FastIntentionEndpointTests(BaseAPITestCase):
 
     def test_non_participant_get_returns_403(self):
         other_user = self.create_user(username="other")
-        other_profile = self.create_profile(user=other_user, church=self.church)
+        self.create_profile(user=other_user, church=self.church)
         self.client.force_authenticate(user=other_user)
         url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
         response = self.client.get(url)
@@ -232,7 +232,7 @@ class FastIntentionEndpointTests(BaseAPITestCase):
 
     def test_non_participant_put_returns_403(self):
         other_user = self.create_user(username="other2")
-        other_profile = self.create_profile(user=other_user, church=self.church)
+        self.create_profile(user=other_user, church=self.church)
         self.client.force_authenticate(user=other_user)
         url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
         response = self.client.put(url, {"text": "Hack"})
@@ -240,7 +240,7 @@ class FastIntentionEndpointTests(BaseAPITestCase):
 
     def test_non_participant_delete_returns_403(self):
         other_user = self.create_user(username="other3")
-        other_profile = self.create_profile(user=other_user, church=self.church)
+        self.create_profile(user=other_user, church=self.church)
         self.client.force_authenticate(user=other_user)
         url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
         response = self.client.delete(url)

--- a/tests/integration/test_intention_endpoints.py
+++ b/tests/integration/test_intention_endpoints.py
@@ -1,0 +1,274 @@
+"""Integration tests for Fast Intention endpoints."""
+
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient, APITestCase
+from rest_framework import status
+from hub.models import FastIntention
+from tests.fixtures.test_data import TestDataFactory
+
+User = get_user_model()
+
+
+class IntentionEndpointTests(APITestCase):
+    """Tests for the intention API endpoints."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.church = TestDataFactory.create_church()
+        self.fast = TestDataFactory.create_fast(church=self.church)
+        self.user = TestDataFactory.create_user()
+        self.profile = TestDataFactory.create_profile(user=self.user, church=self.church)
+        self.profile.fasts.add(self.fast)
+        self.client.force_authenticate(user=self.user)
+        self.intention_url = reverse('fast-intention', kwargs={'fast_id': self.fast.id})
+
+    def test_get_intention_not_found(self):
+        """Test GET returns 404 when no intention exists."""
+        response = self.client.get(self.intention_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_create_intention_via_put(self):
+        """Test PUT creates a new intention."""
+        data = {"text": "Pray for peace", "is_public": True}
+        response = self.client.put(self.intention_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["text"], "Pray for peace")
+        self.assertTrue(response.data["is_public"])
+
+    def test_get_intention_after_create(self):
+        """Test GET returns the intention after creation."""
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="My prayer",
+            is_public=False,
+            is_active=True,
+        )
+        response = self.client.get(self.intention_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["text"], "My prayer")
+        self.assertFalse(response.data["is_public"])
+
+    def test_update_intention_via_put(self):
+        """Test PUT updates an existing intention."""
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Old text",
+            is_public=False,
+            is_active=True,
+        )
+        data = {"text": "New text", "is_public": True}
+        response = self.client.put(self.intention_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["text"], "New text")
+        self.assertTrue(response.data["is_public"])
+
+    def test_delete_intention_clears_text(self):
+        """Test DELETE clears intention text."""
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="To be cleared",
+            is_public=True,
+            is_active=True,
+        )
+        response = self.client.delete(self.intention_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast, is_active=True)
+        self.assertEqual(intention.text, "")
+
+    def test_text_too_long_rejected(self):
+        """Test that text over 280 chars is rejected."""
+        data = {"text": "x" * 281, "is_public": False}
+        response = self.client.put(self.intention_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_profanity_rejected(self):
+        """Test that profane text is rejected."""
+        data = {"text": "shitty prayer", "is_public": False}
+        response = self.client.put(self.intention_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_non_participant_gets_403(self):
+        """Test that non-participants get 403."""
+        other_user = TestDataFactory.create_user(username="other@example.com")
+        other_profile = TestDataFactory.create_profile(user=other_user, church=self.church)
+        self.client.force_authenticate(user=other_user)
+        response = self.client.get(self.intention_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_non_participant_put_gets_403(self):
+        """Test that non-participants cannot PUT intention."""
+        other_user = TestDataFactory.create_user(username="other2@example.com")
+        other_profile = TestDataFactory.create_profile(user=other_user, church=self.church)
+        self.client.force_authenticate(user=other_user)
+        data = {"text": "Prayer", "is_public": True}
+        response = self.client.put(self.intention_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class JoinWithIntentionTests(APITestCase):
+    """Tests for joining a fast with an intention."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.church = TestDataFactory.create_church()
+        self.fast = TestDataFactory.create_fast(church=self.church)
+        self.user = TestDataFactory.create_user()
+        self.profile = TestDataFactory.create_profile(user=self.user, church=self.church)
+        self.client.force_authenticate(user=self.user)
+        self.join_url = reverse('fast-join')
+
+    def test_join_with_intention(self):
+        """Test joining a fast with intention creates the intention."""
+        data = {
+            "fast_id": self.fast.id,
+            "intention_text": "Pray for peace",
+            "intention_is_public": True,
+        }
+        response = self.client.post(self.join_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.filter(
+            user=self.user,
+            fast=self.fast,
+            is_active=True
+        ).first()
+        self.assertIsNotNone(intention)
+        self.assertEqual(intention.text, "Pray for peace")
+        self.assertTrue(intention.is_public)
+
+    def test_join_without_intention(self):
+        """Test joining without intention does not create one."""
+        data = {"fast_id": self.fast.id}
+        response = self.client.post(self.join_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.filter(
+            user=self.user,
+            fast=self.fast,
+            is_active=True
+        ).first()
+        self.assertIsNone(intention)
+
+    def test_rejoin_restores_soft_kept_intention(self):
+        """Test rejoining restores a soft-kept intention."""
+        # First join with intention
+        self.profile.fasts.add(self.fast)
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Original prayer",
+            is_public=True,
+            is_active=True,
+        )
+        # Leave
+        self.profile.fasts.remove(self.fast)
+        FastIntention.objects.filter(user=self.user, fast=self.fast).update(is_active=False)
+        # Rejoin without new intention text
+        data = {"fast_id": self.fast.id}
+        response = self.client.post(self.join_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast, is_active=True)
+        self.assertEqual(intention.text, "Original prayer")
+
+    def test_rejoin_with_new_text_overrides(self):
+        """Test rejoining with new text overrides soft-kept intention."""
+        # First join with intention
+        self.profile.fasts.add(self.fast)
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Old prayer",
+            is_public=False,
+            is_active=True,
+        )
+        # Leave
+        self.profile.fasts.remove(self.fast)
+        FastIntention.objects.filter(user=self.user, fast=self.fast).update(is_active=False)
+        # Rejoin with new text
+        data = {
+            "fast_id": self.fast.id,
+            "intention_text": "New prayer",
+            "intention_is_public": True,
+        }
+        response = self.client.post(self.join_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast, is_active=True)
+        self.assertEqual(intention.text, "New prayer")
+        self.assertTrue(intention.is_public)
+
+
+class LeaveFastIntentionTests(APITestCase):
+    """Tests for leaving a fast and intention soft-delete."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.church = TestDataFactory.create_church()
+        self.fast = TestDataFactory.create_fast(church=self.church)
+        self.user = TestDataFactory.create_user()
+        self.profile = TestDataFactory.create_profile(user=self.user, church=self.church)
+        self.profile.fasts.add(self.fast)
+        self.client.force_authenticate(user=self.user)
+        self.leave_url = reverse('leave-fast')
+
+    def test_leave_soft_keeps_intention(self):
+        """Test leaving soft-keeps the intention."""
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="My prayer",
+            is_public=True,
+            is_active=True,
+        )
+        data = {"fast_id": self.fast.id}
+        response = self.client.post(self.leave_url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast)
+        self.assertFalse(intention.is_active)
+        self.assertEqual(intention.text, "My prayer")
+
+
+class ParticipantListIntentionVisibilityTests(APITestCase):
+    """Tests for intention visibility on participant list."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.church = TestDataFactory.create_church()
+        self.fast = TestDataFactory.create_fast(church=self.church)
+        self.user = TestDataFactory.create_user()
+        self.profile = TestDataFactory.create_profile(user=self.user, church=self.church)
+        self.profile.fasts.add(self.fast)
+        self.client.force_authenticate(user=self.user)
+        self.participants_url = reverse('fast-participants', kwargs={'fast_id': self.fast.id})
+
+    def test_public_intention_visible_on_participant_list(self):
+        """Test public intention appears on participant list."""
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Public prayer",
+            is_public=True,
+            is_active=True,
+        )
+        response = self.client.get(self.participants_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Find the current user in the participant list
+        participant = next((p for p in response.data if p['id'] == self.profile.id), None)
+        self.assertIsNotNone(participant)
+        self.assertEqual(participant['intention'], "Public prayer")
+
+    def test_private_intention_hidden_on_participant_list(self):
+        """Test private intention is hidden on participant list."""
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Private prayer",
+            is_public=False,
+            is_active=True,
+        )
+        response = self.client.get(self.participants_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        participant = next((p for p in response.data if p['id'] == self.profile.id), None)
+        self.assertIsNotNone(participant)
+        self.assertIsNone(participant['intention'])

--- a/tests/integration/test_intention_endpoints.py
+++ b/tests/integration/test_intention_endpoints.py
@@ -1,249 +1,273 @@
-"""Integration tests for Fast Intention endpoints."""
+"""Integration tests for FastIntention API endpoints."""
 
 from django.urls import reverse
-from django.contrib.auth import get_user_model
-from rest_framework.test import APIClient, APITestCase
 from rest_framework import status
 from hub.models import FastIntention
-from tests.fixtures.test_data import TestDataFactory
-
-User = get_user_model()
+from tests.base import BaseAPITestCase
 
 
-class IntentionEndpointTests(APITestCase):
-    """Tests for the intention API endpoints."""
-
-    def setUp(self):
-        self.client = APIClient()
-        self.church = TestDataFactory.create_church()
-        self.fast = TestDataFactory.create_fast(church=self.church)
-        self.user = TestDataFactory.create_user()
-        self.profile = TestDataFactory.create_profile(user=self.user, church=self.church)
-        self.profile.fasts.add(self.fast)
-        self.client.force_authenticate(user=self.user)
-        self.intention_url = reverse('fast-intention', kwargs={'fast_id': self.fast.id})
-
-    def test_get_intention_not_found(self):
-        """Test GET returns 404 when no intention exists."""
-        response = self.client.get(self.intention_url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_create_intention_via_put(self):
-        """Test PUT creates a new intention."""
-        data = {"text": "Pray for peace", "is_public": True}
-        response = self.client.put(self.intention_url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["text"], "Pray for peace")
-        self.assertTrue(response.data["is_public"])
-
-    def test_get_intention_after_create(self):
-        """Test GET returns the intention after creation."""
-        FastIntention.objects.create(
-            user=self.user,
-            fast=self.fast,
-            text="My prayer",
-            is_public=False,
-            is_active=True,
-        )
-        response = self.client.get(self.intention_url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["text"], "My prayer")
-        self.assertFalse(response.data["is_public"])
-
-    def test_update_intention_via_put(self):
-        """Test PUT updates an existing intention."""
-        FastIntention.objects.create(
-            user=self.user,
-            fast=self.fast,
-            text="Old text",
-            is_public=False,
-            is_active=True,
-        )
-        data = {"text": "New text", "is_public": True}
-        response = self.client.put(self.intention_url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["text"], "New text")
-        self.assertTrue(response.data["is_public"])
-
-    def test_delete_intention_clears_text(self):
-        """Test DELETE clears intention text."""
-        FastIntention.objects.create(
-            user=self.user,
-            fast=self.fast,
-            text="To be cleared",
-            is_public=True,
-            is_active=True,
-        )
-        response = self.client.delete(self.intention_url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        intention = FastIntention.objects.get(user=self.user, fast=self.fast, is_active=True)
-        self.assertEqual(intention.text, "")
-
-    def test_text_too_long_rejected(self):
-        """Test that text over 280 chars is rejected."""
-        data = {"text": "x" * 281, "is_public": False}
-        response = self.client.put(self.intention_url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_profanity_rejected(self):
-        """Test that profane text is rejected."""
-        data = {"text": "shitty prayer", "is_public": False}
-        response = self.client.put(self.intention_url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_non_participant_gets_403(self):
-        """Test that non-participants get 403."""
-        other_user = TestDataFactory.create_user(username="other@example.com")
-        other_profile = TestDataFactory.create_profile(user=other_user, church=self.church)
-        self.client.force_authenticate(user=other_user)
-        response = self.client.get(self.intention_url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_non_participant_put_gets_403(self):
-        """Test that non-participants cannot PUT intention."""
-        other_user = TestDataFactory.create_user(username="other2@example.com")
-        other_profile = TestDataFactory.create_profile(user=other_user, church=self.church)
-        self.client.force_authenticate(user=other_user)
-        data = {"text": "Prayer", "is_public": True}
-        response = self.client.put(self.intention_url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-
-class JoinWithIntentionTests(APITestCase):
+class JoinWithIntentionTests(BaseAPITestCase):
     """Tests for joining a fast with an intention."""
 
     def setUp(self):
-        self.client = APIClient()
-        self.church = TestDataFactory.create_church()
-        self.fast = TestDataFactory.create_fast(church=self.church)
-        self.user = TestDataFactory.create_user()
-        self.profile = TestDataFactory.create_profile(user=self.user, church=self.church)
-        self.client.force_authenticate(user=self.user)
-        self.join_url = reverse('fast-join')
+        self.user = self.authenticate()
+        self.church = self.create_church()
+        self.profile = self.create_profile(user=self.user, church=self.church)
+        self.fast = self.create_fast(church=self.church)
+
+    def test_join_without_intention(self):
+        url = reverse("fast-join")
+        response = self.client.put(url, {"fast_id": self.fast.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(
+            FastIntention.objects.filter(user=self.user, fast=self.fast).exists()
+        )
 
     def test_join_with_intention(self):
-        """Test joining a fast with intention creates the intention."""
-        data = {
+        url = reverse("fast-join")
+        response = self.client.put(url, {
             "fast_id": self.fast.id,
             "intention_text": "Pray for peace",
             "intention_is_public": True,
-        }
-        response = self.client.post(self.join_url, data, format='json')
+        })
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        intention = FastIntention.objects.filter(
-            user=self.user,
-            fast=self.fast,
-            is_active=True
-        ).first()
-        self.assertIsNotNone(intention)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast)
         self.assertEqual(intention.text, "Pray for peace")
         self.assertTrue(intention.is_public)
+        self.assertTrue(intention.is_active)
 
-    def test_join_without_intention(self):
-        """Test joining without intention does not create one."""
-        data = {"fast_id": self.fast.id}
-        response = self.client.post(self.join_url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        intention = FastIntention.objects.filter(
-            user=self.user,
-            fast=self.fast,
-            is_active=True
-        ).first()
-        self.assertIsNone(intention)
-
-    def test_rejoin_restores_soft_kept_intention(self):
-        """Test rejoining restores a soft-kept intention."""
-        # First join with intention
-        self.profile.fasts.add(self.fast)
-        FastIntention.objects.create(
-            user=self.user,
-            fast=self.fast,
-            text="Original prayer",
-            is_public=True,
-            is_active=True,
-        )
-        # Leave
-        self.profile.fasts.remove(self.fast)
-        FastIntention.objects.filter(user=self.user, fast=self.fast).update(is_active=False)
-        # Rejoin without new intention text
-        data = {"fast_id": self.fast.id}
-        response = self.client.post(self.join_url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        intention = FastIntention.objects.get(user=self.user, fast=self.fast, is_active=True)
-        self.assertEqual(intention.text, "Original prayer")
-
-    def test_rejoin_with_new_text_overrides(self):
-        """Test rejoining with new text overrides soft-kept intention."""
-        # First join with intention
-        self.profile.fasts.add(self.fast)
-        FastIntention.objects.create(
-            user=self.user,
-            fast=self.fast,
-            text="Old prayer",
-            is_public=False,
-            is_active=True,
-        )
-        # Leave
-        self.profile.fasts.remove(self.fast)
-        FastIntention.objects.filter(user=self.user, fast=self.fast).update(is_active=False)
-        # Rejoin with new text
-        data = {
+    def test_join_with_private_intention(self):
+        url = reverse("fast-join")
+        response = self.client.put(url, {
             "fast_id": self.fast.id,
-            "intention_text": "New prayer",
-            "intention_is_public": True,
-        }
-        response = self.client.post(self.join_url, data, format='json')
+            "intention_text": "Private prayer",
+            "intention_is_public": False,
+        })
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast)
+        self.assertFalse(intention.is_public)
+
+    def test_join_reactivates_soft_kept_intention(self):
+        # Create and then soft-delete an intention
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Old intention",
+            is_public=True,
+            is_active=False,
+        )
+        self.profile.fasts.add(self.fast)
+        self.profile.fasts.remove(self.fast)
+
+        url = reverse("fast-join")
+        response = self.client.put(url, {
+            "fast_id": self.fast.id,
+            "intention_text": "New intention",
+            "intention_is_public": False,
+        })
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         intention = FastIntention.objects.get(user=self.user, fast=self.fast, is_active=True)
-        self.assertEqual(intention.text, "New prayer")
+        self.assertEqual(intention.text, "New intention")
+        self.assertFalse(intention.is_public)
+
+    def test_join_reactivates_without_overwrite(self):
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Old intention",
+            is_public=True,
+            is_active=False,
+        )
+        self.profile.fasts.add(self.fast)
+        self.profile.fasts.remove(self.fast)
+
+        url = reverse("fast-join")
+        response = self.client.put(url, {"fast_id": self.fast.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast, is_active=True)
+        self.assertEqual(intention.text, "Old intention")
         self.assertTrue(intention.is_public)
 
+    def test_join_with_profanity_rejected(self):
+        url = reverse("fast-join")
+        response = self.client.put(url, {
+            "fast_id": self.fast.id,
+            "intention_text": "shitty day",
+        })
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-class LeaveFastIntentionTests(APITestCase):
-    """Tests for leaving a fast and intention soft-delete."""
+    def test_join_with_too_long_text_rejected(self):
+        url = reverse("fast-join")
+        response = self.client.put(url, {
+            "fast_id": self.fast.id,
+            "intention_text": "x" * 281,
+        })
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class LeaveFastIntentionTests(BaseAPITestCase):
+    """Tests for leaving a fast and soft-keeping intention."""
 
     def setUp(self):
-        self.client = APIClient()
-        self.church = TestDataFactory.create_church()
-        self.fast = TestDataFactory.create_fast(church=self.church)
-        self.user = TestDataFactory.create_user()
-        self.profile = TestDataFactory.create_profile(user=self.user, church=self.church)
+        self.user = self.authenticate()
+        self.church = self.create_church()
+        self.profile = self.create_profile(user=self.user, church=self.church)
+        self.fast = self.create_fast(church=self.church)
         self.profile.fasts.add(self.fast)
-        self.client.force_authenticate(user=self.user)
-        self.leave_url = reverse('leave-fast')
-
-    def test_leave_soft_keeps_intention(self):
-        """Test leaving soft-keeps the intention."""
         FastIntention.objects.create(
             user=self.user,
             fast=self.fast,
-            text="My prayer",
+            text="My intention",
             is_public=True,
             is_active=True,
         )
-        data = {"fast_id": self.fast.id}
-        response = self.client.post(self.leave_url, data, format='json')
+
+    def test_leave_soft_keeps_intention(self):
+        url = reverse("leave-fast")
+        response = self.client.put(url, {"fast_id": self.fast.id})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         intention = FastIntention.objects.get(user=self.user, fast=self.fast)
         self.assertFalse(intention.is_active)
-        self.assertEqual(intention.text, "My prayer")
+        self.assertEqual(intention.text, "My intention")
 
 
-class ParticipantListIntentionVisibilityTests(APITestCase):
-    """Tests for intention visibility on participant list."""
+class FastIntentionEndpointTests(BaseAPITestCase):
+    """Tests for the fasts/<fast_id>/intention/ endpoints."""
 
     def setUp(self):
-        self.client = APIClient()
-        self.church = TestDataFactory.create_church()
-        self.fast = TestDataFactory.create_fast(church=self.church)
-        self.user = TestDataFactory.create_user()
-        self.profile = TestDataFactory.create_profile(user=self.user, church=self.church)
+        self.user = self.authenticate()
+        self.church = self.create_church()
+        self.profile = self.create_profile(user=self.user, church=self.church)
+        self.fast = self.create_fast(church=self.church)
         self.profile.fasts.add(self.fast)
-        self.client.force_authenticate(user=self.user)
-        self.participants_url = reverse('fast-participants', kwargs={'fast_id': self.fast.id})
 
-    def test_public_intention_visible_on_participant_list(self):
-        """Test public intention appears on participant list."""
+    def test_get_intention(self):
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Pray daily",
+            is_public=False,
+            is_active=True,
+        )
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["text"], "Pray daily")
+        self.assertFalse(response.data["is_public"])
+
+    def test_get_no_intention_returns_404(self):
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_put_create_intention(self):
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.put(url, {
+            "text": "New intention",
+            "is_public": True,
+        })
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast)
+        self.assertEqual(intention.text, "New intention")
+        self.assertTrue(intention.is_public)
+
+    def test_put_update_intention(self):
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Old",
+            is_public=False,
+            is_active=True,
+        )
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.put(url, {
+            "text": "Updated",
+            "is_public": True,
+        })
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast)
+        self.assertEqual(intention.text, "Updated")
+        self.assertTrue(intention.is_public)
+
+    def test_put_reactivates_soft_kept(self):
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Soft kept",
+            is_public=False,
+            is_active=False,
+        )
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.put(url, {
+            "text": "Reactivated",
+            "is_public": True,
+        })
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast)
+        self.assertTrue(intention.is_active)
+        self.assertEqual(intention.text, "Reactivated")
+
+    def test_delete_clears_text(self):
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="To clear",
+            is_public=True,
+            is_active=True,
+        )
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        intention = FastIntention.objects.get(user=self.user, fast=self.fast)
+        self.assertEqual(intention.text, "")
+        self.assertTrue(intention.is_active)
+
+    def test_non_participant_get_returns_403(self):
+        other_user = self.create_user(username="other")
+        other_profile = self.create_profile(user=other_user, church=self.church)
+        self.client.force_authenticate(user=other_user)
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_non_participant_put_returns_403(self):
+        other_user = self.create_user(username="other2")
+        other_profile = self.create_profile(user=other_user, church=self.church)
+        self.client.force_authenticate(user=other_user)
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.put(url, {"text": "Hack"})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_non_participant_delete_returns_403(self):
+        other_user = self.create_user(username="other3")
+        other_profile = self.create_profile(user=other_user, church=self.church)
+        self.client.force_authenticate(user=other_user)
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_put_profanity_rejected(self):
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.put(url, {"text": "shitty day"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_put_too_long_rejected(self):
+        url = reverse("fast-intention", kwargs={"fast_id": self.fast.id})
+        response = self.client.put(url, {"text": "x" * 281})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class ParticipantPayloadIntentionTests(BaseAPITestCase):
+    """Tests that intentions appear correctly on participant payloads."""
+
+    def setUp(self):
+        self.user = self.authenticate()
+        self.church = self.create_church()
+        self.profile = self.create_profile(user=self.user, church=self.church)
+        self.fast = self.create_fast(church=self.church)
+        self.profile.fasts.add(self.fast)
+
+    def test_public_intention_on_participant_list(self):
         FastIntention.objects.create(
             user=self.user,
             fast=self.fast,
@@ -251,15 +275,14 @@ class ParticipantListIntentionVisibilityTests(APITestCase):
             is_public=True,
             is_active=True,
         )
-        response = self.client.get(self.participants_url)
+        url = reverse("fast-participants", kwargs={"fast_id": self.fast.id})
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Find the current user in the participant list
-        participant = next((p for p in response.data if p['id'] == self.profile.id), None)
-        self.assertIsNotNone(participant)
-        self.assertEqual(participant['intention'], "Public prayer")
+        # The participant list should include the intention
+        participant = response.data[0]
+        self.assertEqual(participant["intention"], "Public prayer")
 
     def test_private_intention_hidden_on_participant_list(self):
-        """Test private intention is hidden on participant list."""
         FastIntention.objects.create(
             user=self.user,
             fast=self.fast,
@@ -267,8 +290,22 @@ class ParticipantListIntentionVisibilityTests(APITestCase):
             is_public=False,
             is_active=True,
         )
-        response = self.client.get(self.participants_url)
+        url = reverse("fast-participants", kwargs={"fast_id": self.fast.id})
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        participant = next((p for p in response.data if p['id'] == self.profile.id), None)
-        self.assertIsNotNone(participant)
-        self.assertIsNone(participant['intention'])
+        participant = response.data[0]
+        self.assertIsNone(participant["intention"])
+
+    def test_inactive_intention_hidden(self):
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Inactive",
+            is_public=True,
+            is_active=False,
+        )
+        url = reverse("fast-participants", kwargs={"fast_id": self.fast.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        participant = response.data[0]
+        self.assertIsNone(participant["intention"])

--- a/tests/unit/hub/test_fast_intention.py
+++ b/tests/unit/hub/test_fast_intention.py
@@ -1,8 +1,6 @@
 """Unit tests for FastIntention model, serializer, and visibility rules."""
 
-from django.test import TestCase
-from django.contrib.auth.models import User
-from hub.models import Church, Fast, Profile, FastIntention
+from hub.models import FastIntention
 from hub.serializers import FastIntentionSerializer, ParticipantSerializer
 from tests.base import BaseTestCase
 

--- a/tests/unit/hub/test_fast_intention.py
+++ b/tests/unit/hub/test_fast_intention.py
@@ -116,7 +116,7 @@ class ParticipantSerializerIntentionTests(BaseTestCase):
             context={"fast_id": self.fast.id}
         )
         # Attach intention manually to simulate prefetch
-        self.profile._prefetched_intention = intention
+        self.profile._intention = intention
         result = serializer.data
         self.assertEqual(result["intention"], "Public prayer")
 
@@ -128,7 +128,7 @@ class ParticipantSerializerIntentionTests(BaseTestCase):
             is_public=False,
             is_active=True,
         )
-        self.profile._prefetched_intention = intention
+        self.profile._intention = intention
         serializer = ParticipantSerializer(
             self.profile,
             context={"fast_id": self.fast.id}
@@ -144,7 +144,7 @@ class ParticipantSerializerIntentionTests(BaseTestCase):
             is_public=True,
             is_active=False,
         )
-        self.profile._prefetched_intention = intention
+        self.profile._intention = intention
         serializer = ParticipantSerializer(
             self.profile,
             context={"fast_id": self.fast.id}
@@ -168,7 +168,7 @@ class ParticipantSerializerIntentionTests(BaseTestCase):
             is_public=True,
             is_active=True,
         )
-        self.profile._prefetched_intention = intention
+        self.profile._intention = intention
         serializer = ParticipantSerializer(
             self.profile,
             context={"fast_id": self.fast.id}

--- a/tests/unit/hub/test_fast_intention.py
+++ b/tests/unit/hub/test_fast_intention.py
@@ -67,7 +67,8 @@ class FastIntentionModelTests(BaseTestCase):
             text="Test",
             is_public=False,
         )
-        self.assertIn(self.user.email, str(intention))
+        self.assertIn(self.user.username, str(intention))
+        self.assertIn(self.fast.name, str(intention))
         self.assertIn("private", str(intention))
         self.assertIn("active", str(intention))
 

--- a/tests/unit/hub/test_fast_intention.py
+++ b/tests/unit/hub/test_fast_intention.py
@@ -1,0 +1,177 @@
+"""Unit tests for FastIntention model, serializer, and visibility rules."""
+
+from django.test import TestCase
+from django.contrib.auth.models import User
+from hub.models import Church, Fast, Profile, FastIntention
+from hub.serializers import FastIntentionSerializer, ParticipantSerializer
+from tests.base import BaseTestCase
+
+
+class FastIntentionModelTests(BaseTestCase):
+    """Tests for the FastIntention model."""
+
+    def setUp(self):
+        self.church = self.create_church()
+        self.fast = self.create_fast(church=self.church)
+        self.user = self.create_user()
+        self.profile = self.create_profile(user=self.user, church=self.church)
+        self.profile.fasts.add(self.fast)
+
+    def test_create_intention(self):
+        intention = FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Pray for peace",
+            is_public=True,
+        )
+        self.assertEqual(intention.text, "Pray for peace")
+        self.assertTrue(intention.is_public)
+        self.assertTrue(intention.is_active)
+
+    def test_unique_active_intention_per_user_fast(self):
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="First intention",
+            is_active=True,
+        )
+        with self.assertRaises(Exception):
+            FastIntention.objects.create(
+                user=self.user,
+                fast=self.fast,
+                text="Second intention",
+                is_active=True,
+            )
+
+    def test_soft_kept_allows_second_inactive(self):
+        FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="First intention",
+            is_active=True,
+        )
+        FastIntention.objects.filter(user=self.user, fast=self.fast).update(is_active=False)
+        # Should not raise
+        second = FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Second intention",
+            is_active=True,
+        )
+        self.assertTrue(second.is_active)
+
+    def test_str_representation(self):
+        intention = FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Test",
+            is_public=False,
+        )
+        self.assertIn(self.user.email, str(intention))
+        self.assertIn("private", str(intention))
+        self.assertIn("active", str(intention))
+
+
+class FastIntentionSerializerTests(BaseTestCase):
+    """Tests for FastIntentionSerializer validation."""
+
+    def test_valid_text(self):
+        serializer = FastIntentionSerializer(data={"text": "Pray for peace", "is_public": True})
+        self.assertTrue(serializer.is_valid())
+
+    def test_text_too_long(self):
+        serializer = FastIntentionSerializer(data={"text": "x" * 281})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("text", serializer.errors)
+
+    def test_profanity_rejected(self):
+        serializer = FastIntentionSerializer(data={"text": "shitty day"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("text", serializer.errors)
+
+    def test_blank_text_allowed(self):
+        serializer = FastIntentionSerializer(data={"text": "", "is_public": False})
+        self.assertTrue(serializer.is_valid())
+
+
+class ParticipantSerializerIntentionTests(BaseTestCase):
+    """Tests for ParticipantSerializer intention visibility."""
+
+    def setUp(self):
+        self.church = self.create_church()
+        self.fast = self.create_fast(church=self.church)
+        self.user = self.create_user()
+        self.profile = self.create_profile(user=self.user, church=self.church)
+
+    def test_public_intention_visible(self):
+        intention = FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Public prayer",
+            is_public=True,
+            is_active=True,
+        )
+        serializer = ParticipantSerializer(
+            self.profile,
+            context={"fast_id": self.fast.id}
+        )
+        # Attach intention manually to simulate prefetch
+        self.profile._prefetched_intention = intention
+        result = serializer.data
+        self.assertEqual(result["intention"], "Public prayer")
+
+    def test_private_intention_hidden(self):
+        intention = FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Private prayer",
+            is_public=False,
+            is_active=True,
+        )
+        self.profile._prefetched_intention = intention
+        serializer = ParticipantSerializer(
+            self.profile,
+            context={"fast_id": self.fast.id}
+        )
+        result = serializer.data
+        self.assertIsNone(result["intention"])
+
+    def test_inactive_intention_hidden(self):
+        intention = FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="Old prayer",
+            is_public=True,
+            is_active=False,
+        )
+        self.profile._prefetched_intention = intention
+        serializer = ParticipantSerializer(
+            self.profile,
+            context={"fast_id": self.fast.id}
+        )
+        result = serializer.data
+        self.assertIsNone(result["intention"])
+
+    def test_no_intention_returns_none(self):
+        serializer = ParticipantSerializer(
+            self.profile,
+            context={"fast_id": self.fast.id}
+        )
+        result = serializer.data
+        self.assertIsNone(result["intention"])
+
+    def test_empty_text_returns_none(self):
+        intention = FastIntention.objects.create(
+            user=self.user,
+            fast=self.fast,
+            text="",
+            is_public=True,
+            is_active=True,
+        )
+        self.profile._prefetched_intention = intention
+        serializer = ParticipantSerializer(
+            self.profile,
+            context={"fast_id": self.fast.id}
+        )
+        result = serializer.data
+        self.assertIsNone(result["intention"])


### PR DESCRIPTION
## Summary
Implements the backend for the Intentions feature (issue #382).

## What's New
- **FastIntention model** — stores user intentions for fasts with public/private visibility
- **Soft-delete on leave** — `is_active=False` preserves intention for rejoin restore
- **Join with intention** — `JoinFastView` accepts optional `intention_text` and `intention_is_public`
- **Standalone intention endpoints** — GET/PUT/DELETE at `fasts/<id>/intention/`
- **Participant payload** — public intentions visible on participant sheet, private hidden
- **Validation** — 280-char cap, profanity filter, 403 for non-participants
- **Performance** — N+1 avoided via hydration, cache invalidation on changes

## Test Plan
- 13 unit tests for model/serializer
- 22 integration tests for endpoints
- All existing tests pass (no regressions)

## API Changes
```
POST /api/hub/fasts/join/     → accepts intention_text, intention_is_public
POST /api/hub/fasts/leave/    → soft-keeps intention
GET  /fasts/<id>/intention/   → get user's intention
PUT  /fasts/<id>/intention/   → create/update intention
DELETE /fasts/<id>/intention/ → clear intention text
```

Closes #382

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted user-generated-content model and wires it into core join/leave and participant-list flows, which could impact data integrity and caching/visibility behavior if edge cases are missed.
> 
> **Overview**
> Introduces a new `FastIntention` model (with per-user/per-fast *single active* constraint, indexes, and admin support) to store optional intention text plus public/private visibility and soft-delete via `is_active`.
> 
> Extends `fasts/join/` and `fasts/leave/` to create/reactivate intentions on join and mark intentions inactive on leave, and adds a new `fasts/<fast_id>/intention/` GET/PUT/DELETE API to manage a participant’s intention with length + profanity validation and membership enforcement.
> 
> Updates participant payloads to optionally include a public intention (and hydrates intentions in participant list queries to avoid N+1), with cache invalidation triggered when intention visibility/content changes. **Adds unit + integration test coverage** for model constraints, validation, endpoints, and participant visibility rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f94c74089f085aaea52df192a4d0e74386c08a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->