### PR TITLE
feat: add duplicate devotional set admin action

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -1,6 +1,7 @@
 """Admin forms."""
 
 import datetime
+import re
 
 from django.contrib import admin
 from django.db import models
@@ -265,6 +266,7 @@ class DevotionalSetAdmin(admin.ModelAdmin):
     list_filter = ('fast', 'created_at', 'updated_at')
     readonly_fields = ('created_at', 'updated_at', 'image_preview', 'number_of_days')
     raw_id_fields = ('fast',)
+    actions = ['duplicate_devotional_sets']
     fieldsets = (
         (None, {
             'fields': ('title', 'description', 'fast')
@@ -306,6 +308,102 @@ class DevotionalSetAdmin(admin.ModelAdmin):
     def number_of_days(self, obj):
         return obj.number_of_days
     number_of_days.short_description = 'Number of Days'
+
+    def duplicate_devotional_sets(self, request, queryset):
+        success_count = 0
+        for devotional_set in queryset:
+            try:
+                self._duplicate_devotional_set(devotional_set)
+                success_count += 1
+            except ValueError as e:
+                self.message_user(
+                    request,
+                    f'Error duplicating "{devotional_set.title}": {e}',
+                    level=messages.ERROR,
+                )
+                return
+        self.message_user(
+            request,
+            f"Successfully duplicated {success_count} devotional set(s).",
+            level=messages.SUCCESS,
+        )
+
+    duplicate_devotional_sets.short_description = (
+        "Duplicate selected devotional sets to current year's fast"
+    )
+
+    def _find_target_fast(self, old_fast):
+        """Auto-detect the target fast for duplication.
+
+        Looks for a fast in the current year for the same church that has the
+        same number of days as the original and no DevotionalSet linked yet.
+        Raises ValueError if zero or multiple candidates are found.
+        """
+        current_year = datetime.date.today().year
+        old_day_count = Day.objects.filter(fast=old_fast).count()
+
+        fasts_with_sets = DevotionalSet.objects.values_list('fast_id', flat=True)
+        candidates = (
+            Fast.objects.filter(church=old_fast.church, year=current_year)
+            .exclude(pk__in=fasts_with_sets)
+            .annotate(day_count=models.Count('days'))
+            .filter(day_count=old_day_count)
+        )
+
+        count = candidates.count()
+        if count == 1:
+            return candidates.first()
+        if count == 0:
+            raise ValueError(
+                f"No eligible {current_year} fast found for {old_fast.church} "
+                f"with {old_day_count} days and no existing DevotionalSet."
+            )
+        raise ValueError(
+            f"Multiple eligible {current_year} fasts found for {old_fast.church}; "
+            "cannot auto-detect target. Ensure only one matches."
+        )
+
+    def _duplicate_devotional_set(self, devotional_set):
+        """Duplicate a DevotionalSet and its Devotionals to the auto-detected target fast."""
+        old_fast = devotional_set.fast
+        target_fast = self._find_target_fast(old_fast)
+
+        current_year = str(datetime.date.today().year)
+        year_re = re.compile(r'\b(19|20)\d{2}\b')
+
+        def _update_year(text):
+            return year_re.sub(current_year, text) if text else text
+
+        with transaction.atomic():
+            DevotionalSet.objects.create(
+                title_en=_update_year(devotional_set.title_en),
+                title_hy=_update_year(devotional_set.title_hy),
+                description_en=devotional_set.description_en,
+                description_hy=devotional_set.description_hy,
+                image=devotional_set.image,
+                fast=target_fast,
+            )
+
+            old_days = list(Day.objects.filter(fast=old_fast).order_by('date'))
+            new_days = list(Day.objects.filter(fast=target_fast).order_by('date'))
+            day_mapping = {old.pk: new for old, new in zip(old_days, new_days)}
+
+            old_devotionals = (
+                Devotional.objects.filter(day__fast=old_fast)
+                .select_related('day', 'video')
+                .order_by('day__date', 'order', 'language_code')
+            )
+            for old_dev in old_devotionals:
+                new_day = day_mapping.get(old_dev.day_id)
+                if new_day:
+                    Devotional.objects.create(
+                        day=new_day,
+                        video=old_dev.video,
+                        order=old_dev.order,
+                        language_code=old_dev.language_code,
+                        description_en=old_dev.description_en,
+                        description_hy=old_dev.description_hy,
+                    )
 
 
 @admin.register(Fast, site=admin.site)

--- a/hub/management/commands/seed.py
+++ b/hub/management/commands/seed.py
@@ -209,6 +209,10 @@ class Command(BaseCommand):
         # Create Devotional Sets and Devotionals
         devotional_sets = self._create_devotional_sets_and_devotionals(all_days, videos, fasts)
 
+        # Create 2025 Apostles Fast data for duplicate-devotional-set testing
+        apostles_set = self._create_apostles_fast_seed_data(churches[0])
+        devotional_sets.append(apostles_set)
+
         # Create Bookmarks
         users = [up[0] for up in users_and_profiles]
         self._create_bookmarks(users, videos, articles, recipes, devotional_sets)
@@ -423,6 +427,89 @@ class Command(BaseCommand):
             )
 
         return devotional_sets
+
+    def _create_apostles_fast_seed_data(self, church):
+        """Create a 2025 Apostles Fast with a full DevotionalSet, plus a matching
+        2026 fast (no DevotionalSet) so the duplicate-devotional-set admin action
+        can be tested end-to-end."""
+
+        # --- 2025 fast: source for duplication ---
+        fast_2025 = models.Fast.objects.create(
+            name="Fast of the Apostles",
+            church=church,
+            description="Fast honoring the holy apostles before the Feast of Saints Peter and Paul",
+            culmination_feast="Feast of Saints Peter and Paul",
+        )
+        days_2025 = [
+            models.Day.objects.create(date=date(2025, 6, 16 + i), fast=fast_2025, church=church)
+            for i in range(5)
+        ]
+        fast_2025.save(update_fields=["year"])  # auto-sets year=2025
+
+        apostles_videos = [
+            Video.objects.create(title=title, description=desc, category="devotional")
+            for title, desc in [
+                (
+                    "Apostles Fast Day 1: The Call",
+                    "Jesus calls his disciples to leave everything and follow him",
+                ),
+                (
+                    "Apostles Fast Day 2: Peter's Confession",
+                    "Peter declares Jesus as the Christ, the Son of the living God",
+                ),
+                (
+                    "Apostles Fast Day 3: The Transfiguration",
+                    "Jesus is transfigured on the mountain before Peter, James, and John",
+                ),
+                (
+                    "Apostles Fast Day 4: The Great Commission",
+                    "The risen Christ sends the apostles to make disciples of all nations",
+                ),
+                (
+                    "Apostles Fast Day 5: Pentecost",
+                    "The Holy Spirit descends on the apostles and the church is born",
+                ),
+            ]
+        ]
+
+        devotional_set_2025 = models.DevotionalSet.objects.create(
+            title="Fast of the Apostles 2025",
+            description=(
+                "Daily devotionals for the Fast of the Apostles, reflecting on the "
+                "lives and witness of Christ's chosen messengers."
+            ),
+            fast=fast_2025,
+        )
+
+        for i, (day, video) in enumerate(zip(days_2025, apostles_videos)):
+            models.Devotional.objects.create(
+                day=day,
+                video=video,
+                order=1,
+                language_code="en",
+                description=(
+                    f"Day {i + 1}: Reflect on the apostles' calling and witness "
+                    "as we prepare for the feast."
+                ),
+            )
+
+        # --- 2026 counterpart: same church, same 5-day count, no DevotionalSet ---
+        # Auto-detection in the duplicate action will find exactly this fast.
+        fast_2026 = models.Fast.objects.create(
+            name="Fast of the Apostles",
+            church=church,
+            description="Fast honoring the holy apostles before the Feast of Saints Peter and Paul",
+            culmination_feast="Feast of Saints Peter and Paul",
+        )
+        for i in range(5):
+            models.Day.objects.create(date=date(2026, 8, 1 + i), fast=fast_2026, church=church)
+        fast_2026.save(update_fields=["year"])  # auto-sets year=2026
+
+        self.stdout.write(
+            f"Created Apostles Fast seed data: "
+            f"{fast_2025} (with DevotionalSet + 5 devotionals) and {fast_2026} (target for duplication)"
+        )
+        return devotional_set_2025
 
     def _create_readings(self, days):
         """Create Bible readings for days with sample text pre-populated.


### PR DESCRIPTION
## Summary

- Adds a **"Duplicate selected devotional sets to current year's fast"** action to `DevotionalSetAdmin` in `hub/admin.py`
- Auto-detects the target fast: same church, current year, same day count, no existing `DevotionalSet` — fails with a clear error if zero or multiple candidates are found
- Creates a new `DevotionalSet` (4-digit year in the title is bumped to the current year) and new `Devotional` objects mapped positionally by date order to the target fast's `Day` rows, reusing the same `Video` objects
- All writes happen inside a single `transaction.atomic()` so a partial failure leaves nothing behind
- Adds seed data (a 2025 and 2026 Fast of the Apostles pair) to exercise the action end-to-end
- Includes migration `0052` for a `FastIntention` index rename detected by `makemigrations`

## Test plan

- [x] **Seed the database**
  ```
  docker exec bahk_devcontainer-app-1 python manage.py seed
  ```

- [x] **Run the action**
  1. Log in to `http://localhost:8000/admin/` as a superuser
  2. Navigate to **Hub → Devotional sets**
  3. Select **"Fast of the Apostles 2025"** (the row whose Fast column shows "Fast of the Apostles (2025)")
  4. Choose **"Duplicate selected devotional sets to current year's fast"** from the Action dropdown and click **Go**
  5. Confirm a green success message: *"Successfully duplicated 1 devotional set(s)."*

- [x] **Verify the new DevotionalSet**
  - A new entry **"Fast of the Apostles 2026"** appears in the DevotionalSet list
  - Its **Fast** column links to "Fast of the Apostles (2026)"
  - Its **Number of Days** reads **5**

- [x] **Verify Devotionals were created**
  - Navigate to **Hub → Devotionals** and filter by fast "Fast of the Apostles (2026)"
  - Confirm 5 new `Devotional` rows exist, one per day (Aug 1–5, 2026)
  - Each Devotional's video title matches the corresponding day in the 2025 series (same `Video` object, same `id`)

- [x] **Verify videos and images are reused (not duplicated)**
  - Open one of the new Devotionals; its **Video** raw-id field should point to the same `Video` pk as the matching 2025 Devotional
  - No new `Video` rows should have been created — `learning_resources_video` count stays the same after duplication

- [x] **Test error cases**
  - Select the newly created "Fast of the Apostles 2026" DevotionalSet and run the action again — expect an error: *"No eligible 2026 fast found…"* (target fast now has a DevotionalSet)
  - Run unit tests: `docker exec bahk_devcontainer-app-1 python manage.py test tests.unit.hub --settings=tests.test_settings --keepdb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)