### PR TITLE
fix: Authenticated users can read other users' event data

### DIFF
--- a/events/tests/tests.py
+++ b/events/tests/tests.py
@@ -313,8 +313,9 @@ class EventAPITest(APITestCase):
         response = self.client.get(url)
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Account for the FAST_CREATED event from signal + 2 manually created events
-        self.assertEqual(len(response.data['results']), 3)
+        self.assertEqual(len(response.data['results']), 2)
+        for event in response.data['results']:
+            self.assertEqual(event['user_username'], self.user.username)
     
     def test_event_detail(self):
         """Test event detail endpoint."""
@@ -326,6 +327,76 @@ class EventAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['id'], self.event1.pk)
         self.assertEqual(response.data['event_type_code'], EventType.USER_LOGGED_IN)
+
+    def test_event_list_does_not_expose_other_users_events(self):
+        """Regular users cannot list another user's events."""
+        other_user = User.objects.create_user(
+            username='otheruser',
+            email='other@example.com'
+        )
+        Profile.objects.create(user=other_user)
+        other_event = Event.create_event(
+            event_type_code=EventType.USER_LOGGED_IN,
+            user=other_user
+        )
+
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse('events:event-list')
+        response = self.client.get(url, {'user': other_user.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result_ids = {event['id'] for event in response.data['results']}
+        self.assertNotIn(other_event.id, result_ids)
+        self.assertEqual(result_ids, set())
+
+    def test_event_detail_does_not_expose_other_users_events(self):
+        """Regular users cannot retrieve another user's event by ID."""
+        other_user = User.objects.create_user(
+            username='otheruser',
+            email='other@example.com'
+        )
+        Profile.objects.create(user=other_user)
+        other_event = Event.create_event(
+            event_type_code=EventType.USER_LOGGED_IN,
+            user=other_user
+        )
+
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse('events:event-detail', kwargs={'pk': other_event.pk})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_staff_can_query_and_retrieve_other_users_events(self):
+        """Staff users can still inspect arbitrary user events."""
+        other_user = User.objects.create_user(
+            username='otheruser',
+            email='other@example.com'
+        )
+        Profile.objects.create(user=other_user)
+        other_event = Event.create_event(
+            event_type_code=EventType.USER_LOGGED_IN,
+            user=other_user
+        )
+        staff_user = User.objects.create_user(
+            username='staffuser',
+            email='staff@example.com',
+            is_staff=True
+        )
+
+        self.client.force_authenticate(user=staff_user)
+
+        list_url = reverse('events:event-list')
+        list_response = self.client.get(list_url, {'user': other_user.id})
+        self.assertEqual(list_response.status_code, status.HTTP_200_OK)
+        self.assertIn(other_event.id, {event['id'] for event in list_response.data['results']})
+
+        detail_url = reverse('events:event-detail', kwargs={'pk': other_event.pk})
+        detail_response = self.client.get(detail_url)
+        self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(detail_response.data['id'], other_event.id)
     
     def test_my_events(self):
         """Test my events endpoint."""

--- a/events/views.py
+++ b/events/views.py
@@ -96,6 +96,9 @@ class EventListView(generics.ListAPIView):
                 queryset = queryset.filter(timestamp__lte=parsed)
             except ValueError:
                 pass
+
+        if not self.request.user.is_staff:
+            queryset = queryset.filter(user=self.request.user)
         
         return queryset
 
@@ -104,9 +107,14 @@ class EventDetailView(generics.RetrieveAPIView):
     """
     Retrieve a specific event.
     """
-    queryset = Event.objects.select_related('event_type', 'user', 'content_type')
     serializer_class = EventSerializer
     permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        queryset = Event.objects.select_related('event_type', 'user', 'content_type')
+        if not self.request.user.is_staff:
+            queryset = queryset.filter(user=self.request.user)
+        return queryset
     
     def get(self, request, *args, **kwargs):
         lang = request.query_params.get('lang') or get_language_from_request(request) or 'en'


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-cad5f68928-_e81be5ada6`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-library-cad5f68928-2ceb_d844cef1be`: Authenticated users can read other users' event data (high)

## Changed Files

- `events/tests/tests.py`
- `events/views.py`

## Validation

- `ruff format --check .` => 1
- `pytest` => 127
- `ruff check .` => 0
- `npm run test` => 1

## Plan

Scoped event list and detail querysets so non-staff users only see their own events, while staff users retain arbitrary event access. Updated focused API tests to cover cross-user list filtering, cross-user detail retrieval, and staff access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes a high-severity data exposure bug in user-scoped APIs; behavior change may affect any client that relied on cross-user event reads without staff privileges.
> 
> **Overview**
> This PR **closes an authorization gap** on the events list and detail APIs: non-staff authenticated users were able to read other users’ events (e.g. via `user` query params or by event ID).
> 
> **`EventListView`** and **`EventDetailView`** now restrict querysets to `request.user` unless `is_staff` is true, so staff can still filter and inspect any user’s events. **`EventAPITest`** was updated to expect only the caller’s events on list, and new tests cover cross-user list/detail denial for regular users and preserved staff access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4696908a72fdf7ea9faa6656cbeea814444b2b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->