### PR TITLE
fix: Existing Day rows get assigned to an arbitrary default church instead of their fast's church

### DIFF
--- a/hub/migrations/0012_fast_m2m_to_fk_mapping.py
+++ b/hub/migrations/0012_fast_m2m_to_fk_mapping.py
@@ -4,15 +4,16 @@ from django.db import migrations
 
 
 def save_fast_fk(apps, schema):
-    Fast = apps.get_model('hub', 'Fast')
     Day = apps.get_model('hub', 'Day')
     for day in Day.objects.all():
-        day._fast = day.fasts.all().first()
+        fast = day.fasts.all().first()
+        day._fast = fast
+        if fast:
+            day.church_id = fast.church_id
         day.save()
 
 
 def save_fast_m2m(apps, schema):
-    Fast = apps.get_model('hub', 'Fast')
     Day = apps.get_model('hub', 'Day')
     for day in Day.objects.all():
         if day._fast:

--- a/hub/migrations/0012_fast_m2m_to_fk_mapping.py
+++ b/hub/migrations/0012_fast_m2m_to_fk_mapping.py
@@ -4,7 +4,7 @@ from django.db import migrations
 
 
 def save_fast_fk(apps, schema):
-    Day = apps.get_model('hub', 'Day')
+    Day = apps.get_model("hub", "Day")
     for day in Day.objects.all():
         fast = day.fasts.all().first()
         day._fast = fast
@@ -14,18 +14,15 @@ def save_fast_fk(apps, schema):
 
 
 def save_fast_m2m(apps, schema):
-    Day = apps.get_model('hub', 'Day')
+    Day = apps.get_model("hub", "Day")
     for day in Day.objects.all():
         if day._fast:
             day.fasts.add(day._fast)
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('hub', '0011_add_day__fast_day_church_fk_day_date_not_unique'),
+        ("hub", "0011_add_day__fast_day_church_fk_day_date_not_unique"),
     ]
 
-    operations = [
-        migrations.RunPython(save_fast_fk, save_fast_m2m)
-    ]
+    operations = [migrations.RunPython(save_fast_fk, save_fast_m2m)]

--- a/hub/migrations/0056_backfill_day_church_from_fast.py
+++ b/hub/migrations/0056_backfill_day_church_from_fast.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+def backfill_day_church_from_fast(apps, schema_editor):
+    """Repair Day.church for rows mis-assigned the default church.
+
+    Migration 0011 stamped every existing Day with the default church, and the
+    original 0012 data copy only populated ``_fast`` without correcting the
+    church. Because 0012 has long since been applied everywhere, editing it does
+    not re-run on existing databases -- so this forward-only migration backfills
+    church_id from each Day's fast for rows that never got the right value.
+    """
+    Day = apps.get_model("hub", "Day")
+    for day in Day.objects.filter(fast__isnull=False).select_related("fast"):
+        if day.church_id != day.fast.church_id:
+            day.church_id = day.fast.church_id
+            day.save(update_fields=["church_id"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("hub", "0055_sync_day_church_and_fastintention_indexes"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_day_church_from_fast,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/tests/unit/hub/test_day_migration.py
+++ b/tests/unit/hub/test_day_migration.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 
 migration_0012 = importlib.import_module("hub.migrations.0012_fast_m2m_to_fk_mapping")
+migration_0056 = importlib.import_module("hub.migrations.0056_backfill_day_church_from_fast")
 
 
 class RelatedFasts:
@@ -58,3 +59,75 @@ class DayFastMigrationTests(TestCase):
         self.assertIs(day._fast, fast)
         self.assertEqual(day.church_id, fast.church_id)
         self.assertTrue(day.saved)
+
+    def test_save_fast_fk_leaves_church_untouched_when_no_fast(self):
+        day = HistoricalDay(fast=None, church_id=7)
+
+        migration_0012.save_fast_fk(HistoricalApps([day]), schema=None)
+
+        self.assertIsNone(day._fast)
+        self.assertEqual(day.church_id, 7)
+        self.assertTrue(day.saved)
+
+
+class BackfillDayRow:
+    def __init__(self, fast, church_id):
+        self.fast = fast
+        self.church_id = church_id
+        self.saved_fields = None
+
+    def save(self, update_fields=None):
+        self.saved_fields = update_fields
+
+
+class BackfillManager:
+    """Minimal stub for ``Day.objects`` supporting the migration's query chain.
+
+    The real migration calls ``.filter(fast__isnull=False).select_related("fast")``
+    then iterates; only rows with a fast are yielded, mirroring the ORM.
+    """
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, **kwargs):
+        assert kwargs == {"fast__isnull": False}
+        return BackfillManager([r for r in self._rows if r.fast is not None])
+
+    def select_related(self, *args):
+        return self
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class BackfillApps:
+    def __init__(self, days):
+        self.day_model = SimpleNamespace(objects=BackfillManager(days))
+
+    def get_model(self, app_label, model_name):
+        if (app_label, model_name) == ("hub", "Day"):
+            return self.day_model
+        raise LookupError(f"Unexpected historical model: {app_label}.{model_name}")
+
+
+class BackfillDayChurchTests(TestCase):
+    def test_backfill_updates_only_mismatched_rows(self):
+        mismatched = BackfillDayRow(fast=SimpleNamespace(church_id=42), church_id=1)
+        already_correct = BackfillDayRow(fast=SimpleNamespace(church_id=5), church_id=5)
+
+        migration_0056.backfill_day_church_from_fast(BackfillApps([mismatched, already_correct]), schema_editor=None)
+
+        self.assertEqual(mismatched.church_id, 42)
+        self.assertEqual(mismatched.saved_fields, ["church_id"])
+        # Row already matching its fast is left untouched (no write).
+        self.assertEqual(already_correct.church_id, 5)
+        self.assertIsNone(already_correct.saved_fields)
+
+    def test_backfill_skips_days_without_a_fast(self):
+        no_fast = BackfillDayRow(fast=None, church_id=1)
+
+        migration_0056.backfill_day_church_from_fast(BackfillApps([no_fast]), schema_editor=None)
+
+        self.assertEqual(no_fast.church_id, 1)
+        self.assertIsNone(no_fast.saved_fields)

--- a/tests/unit/hub/test_day_migration.py
+++ b/tests/unit/hub/test_day_migration.py
@@ -1,0 +1,60 @@
+"""Tests for Day migration data-copy helpers."""
+
+import importlib
+from types import SimpleNamespace
+from unittest import TestCase
+
+
+migration_0012 = importlib.import_module("hub.migrations.0012_fast_m2m_to_fk_mapping")
+
+
+class RelatedFasts:
+    def __init__(self, fast):
+        self.fast = fast
+
+    def all(self):
+        return self
+
+    def first(self):
+        return self.fast
+
+
+class HistoricalDay:
+    def __init__(self, fast, church_id):
+        self._fast = None
+        self.church_id = church_id
+        self.fasts = RelatedFasts(fast)
+        self.saved = False
+
+    def save(self):
+        self.saved = True
+
+
+class HistoricalManager:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def all(self):
+        return self.rows
+
+
+class HistoricalApps:
+    def __init__(self, days):
+        self.day_model = SimpleNamespace(objects=HistoricalManager(days))
+
+    def get_model(self, app_label, model_name):
+        if (app_label, model_name) == ("hub", "Day"):
+            return self.day_model
+        raise LookupError(f"Unexpected historical model: {app_label}.{model_name}")
+
+
+class DayFastMigrationTests(TestCase):
+    def test_save_fast_fk_copies_church_from_selected_fast(self):
+        fast = SimpleNamespace(church_id=42)
+        day = HistoricalDay(fast=fast, church_id=1)
+
+        migration_0012.save_fast_fk(HistoricalApps([day]), schema=None)
+
+        self.assertIs(day._fast, fast)
+        self.assertEqual(day.church_id, fast.church_id)
+        self.assertTrue(day.saved)


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-acc0efd1cf-_d7d641f65a`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-library-acc0efd1cf-49e2_20924ab2cb`: Existing Day rows get assigned to an arbitrary default church instead of their fast's church (high)

## Changed Files

- `hub/migrations/0012_fast_m2m_to_fk_mapping.py`
- `tests/unit/hub/test_day_migration.py`

## Validation

- `ruff format --check .` => 1
- `ruff check .` => 0
- `npm run test` => 1

## Plan

Updated migration 0012 so existing Day rows copy church_id from the same related Fast selected for _fast, instead of keeping the default church assigned by 0011. Added a focused unit test for the migration helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production migration data backfill for church assignment; incorrect logic could mis-associate days to churches on deploy.
> 
> **Overview**
> Fixes **data migration 0012** so when each `Day` gets its `_fast` from the old M2M, it also sets **`church_id` from that fast** instead of leaving the default church from migration 0011.
> 
> Adds a **unit test** for `save_fast_fk` that asserts `_fast`, `church_id`, and `save()` behavior using lightweight historical model stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce35636b82fc7a2435197dfc27a1f7ffccdda98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->