### PR TITLE
fix: Test-user cleanup can delete unrelated real accounts

### DIFF
--- a/hub/management/commands/remove_test_users_for_fast.py
+++ b/hub/management/commands/remove_test_users_for_fast.py
@@ -6,6 +6,9 @@ from django.db import transaction
 from django.contrib.auth.models import User
 from hub.models import Fast, Profile
 
+GENERATED_TEST_USER_USERNAME_REGEX = r"^testuser_[0-9a-f]{8}_[0-9]+_[0-9]+@example\.com$"
+
+
 class Command(BaseCommand):
     help = "Removes test users that were created for a specific fast"
 
@@ -26,7 +29,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--all_test_users',
             action='store_true',
-            help='Remove all users with "testuser" in their username, regardless of fast association'
+            help='Remove all generated test users, regardless of fast association'
         )
 
     @transaction.atomic
@@ -45,15 +48,17 @@ class Command(BaseCommand):
         
         # Find test users
         if all_test_users:
-            # Find all users with "testuser" in their username
-            test_users = User.objects.filter(username__contains="testuser")
+            # Find all users created by create_test_users_for_fast.
+            test_users = User.objects.filter(
+                username__regex=GENERATED_TEST_USER_USERNAME_REGEX
+            )
             fast_name = "all fasts"
         else:
             # Find users associated with the specific fast through their profiles
             profiles = Profile.objects.filter(fasts__id=fast_id)
             test_users = User.objects.filter(
                 profile__in=profiles,
-                username__contains="testuser"
+                username__regex=GENERATED_TEST_USER_USERNAME_REGEX
             )
             fast_name = fast.name
         

--- a/tests/unit/hub/test_remove_test_users_command.py
+++ b/tests/unit/hub/test_remove_test_users_command.py
@@ -1,0 +1,48 @@
+from django.contrib.auth.models import User
+from django.core.management import call_command
+
+from tests.base import BaseTestCase
+
+
+class RemoveTestUsersForFastCommandTests(BaseTestCase):
+    def setUp(self):
+        self.church = self.create_church()
+        self.fast = self.create_fast(church=self.church)
+
+    def _create_user_for_fast(self, username):
+        user = User.objects.create_user(
+            username=username,
+            email=username,
+            password="testpass123",
+        )
+        profile = self.create_profile(user=user, church=self.church)
+        profile.fasts.add(self.fast)
+        return user
+
+    def test_fast_scoped_delete_keeps_non_generated_usernames(self):
+        generated_user = self._create_user_for_fast(
+            f"testuser_1234abcd_{self.fast.id}_1@example.com"
+        )
+        real_user = self._create_user_for_fast("contestuser@example.com")
+
+        call_command("remove_test_users_for_fast", fast_id=self.fast.id)
+
+        self.assertFalse(User.objects.filter(pk=generated_user.pk).exists())
+        self.assertTrue(User.objects.filter(pk=real_user.pk).exists())
+
+    def test_all_test_users_delete_keeps_non_generated_usernames(self):
+        generated_user = User.objects.create_user(
+            username=f"testuser_1234abcd_{self.fast.id}_1@example.com",
+            email=f"testuser_1234abcd_{self.fast.id}_1@example.com",
+            password="testpass123",
+        )
+        real_user = User.objects.create_user(
+            username="mytestuser@example.com",
+            email="mytestuser@example.com",
+            password="testpass123",
+        )
+
+        call_command("remove_test_users_for_fast", all_test_users=True)
+
+        self.assertFalse(User.objects.filter(pk=generated_user.pk).exists())
+        self.assertTrue(User.objects.filter(pk=real_user.pk).exists())


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-ed9532a194-_3a72f5b758`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-library-ed9532a194-e112_b834c868f6`: Test-user cleanup can delete unrelated real accounts (high)

## Changed Files

- `hub/management/commands/remove_test_users_for_fast.py`
- `tests/unit/hub/test_remove_test_users_command.py`

## Validation

- `ruff format --check .` => 1
- `ruff check .` => 0
- `npm run test` => 1

## Plan

Constrained test-user cleanup to the exact generated username shape and added focused regressions proving embedded-substring real users survive both fast-scoped and all-test-user cleanup modes. Focused Django tests could not run because Docker was unavailable; changed files passed local Python syntax compilation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The command still bulk-deletes User rows, but narrowing the match reduces accidental deletion of production accounts that was possible with substring matching.
> 
> **Overview**
> **`remove_test_users_for_fast`** no longer deletes every user whose username contains `testuser`. It only targets accounts matching the **`create_test_users_for_fast`** pattern (`testuser_{8 hex}_{fast_id}_{n}@example.com`) via a shared regex, for both fast-scoped and `--all_test_users` runs. Help text is updated accordingly.
> 
> New unit tests assert that fast-scoped cleanup and global cleanup still remove generated fixtures but **leave real users** whose usernames merely embed `testuser` (e.g. `contestuser@example.com`, `mytestuser@example.com`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2be3dbff73d0793e40e47b73cedb7a44c1574733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->