### PR TITLE
fix: Reading.create_url references an undefined lookup constant

### DIFF
--- a/hub/tests/test_bible_api.py
+++ b/hub/tests/test_bible_api.py
@@ -145,6 +145,19 @@ class BookNameMappingTests(TestCase):
         self.assertIn("heb", url)
         self.assertNotEqual(url, CATENA_HOME_PAGE_URL)
 
+    def test_create_url_with_straight_apostrophe_book_name(self):
+        """Reading.create_url() should handle standard apostrophe book names."""
+        reading = Reading(
+            book="St. Paul's Epistle to the Hebrews",
+            start_chapter=1,
+            start_verse=1,
+            end_chapter=1,
+            end_verse=5,
+        )
+        url = reading.create_url()
+        self.assertIn("heb", url)
+        self.assertNotEqual(url, CATENA_HOME_PAGE_URL)
+
     def test_create_url_with_unknown_book_returns_home(self):
         """Unknown book should return CATENA_HOME_PAGE_URL."""
         reading = Reading(


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-129f95bc51-_e44f1f65d4`
- status: `applied`
- files changed: 1

## Findings

- `fnd_sig-feat-library-129f95bc51-bed5_0a5acbf7eb`: Reading.create_url references an undefined lookup constant (high)

## Changed Files

- `hub/tests/test_bible_api.py`

## Validation

- `ruff format --check .` => 1
- `pytest` => 127
- `ruff check .` => 0
- `npm run test` => 1

## Plan

Verified `Reading.create_url` already references `CATENA_ABBREV_FOR_BOOK_NORMALIZED` in `hub/models.py`; added focused regression coverage for a standard straight-apostrophe book name in `hub/tests/test_bible_api.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no runtime behavior modified in the diff.
> 
> **Overview**
> Adds a **regression test** so `Reading.create_url()` is verified for liturgical book titles that use a **straight apostrophe** (e.g. `St. Paul's Epistle to the Hebrews`), matching the existing curly-quote case: the URL should include the `heb` abbreviation and must not fall back to `CATENA_HOME_PAGE_URL`.
> 
> No production code changes in this diff—only `hub/tests/test_bible_api.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949d98900f2ea094a65248128a1427cb6009d4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->