### PR TITLE
fix: Specific retry can resend non-failed promotional emails

### DIFF
--- a/notifications/management/commands/retry_failed_emails.py
+++ b/notifications/management/commands/retry_failed_emails.py
@@ -24,6 +24,14 @@ class Command(BaseCommand):
             # Retry specific email
             try:
                 promo = PromoEmail.objects.get(id=options['promo_id'])
+                if promo.status != PromoEmail.FAILED:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"PromoEmail {promo.id} has status {promo.status}; only failed emails can be retried"
+                        )
+                    )
+                    return
+
                 if options['dry_run']:
                     self.stdout.write(f"Would retry PromoEmail {promo.id}: {promo.title}")
                     self.stdout.write(f"Current status: {promo.status}")

--- a/notifications/tests/test_retry_failed_emails_command.py
+++ b/notifications/tests/test_retry_failed_emails_command.py
@@ -1,0 +1,50 @@
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from notifications.models import PromoEmail
+
+
+class RetryFailedEmailsCommandTests(TestCase):
+    def create_promo(self, status):
+        return PromoEmail.objects.create(
+            title=f"{status.title()} Promo",
+            subject="Test Subject",
+            content_html="<p>Test content</p>",
+            content_text="Test content",
+            status=status,
+        )
+
+    @patch("notifications.management.commands.retry_failed_emails.send_promo_email_task.delay")
+    def test_specific_retry_rejects_non_failed_promos(self, mock_delay):
+        for status in [
+            PromoEmail.SENT,
+            PromoEmail.SCHEDULED,
+            PromoEmail.SENDING,
+            PromoEmail.DRAFT,
+        ]:
+            with self.subTest(status=status):
+                promo = self.create_promo(status)
+                stdout = StringIO()
+
+                call_command("retry_failed_emails", promo_id=promo.id, stdout=stdout)
+
+                promo.refresh_from_db()
+                self.assertEqual(promo.status, status)
+                self.assertIn("only failed emails can be retried", stdout.getvalue())
+
+        mock_delay.assert_not_called()
+
+    @patch("notifications.management.commands.retry_failed_emails.send_promo_email_task.delay")
+    def test_specific_retry_queues_failed_promo(self, mock_delay):
+        promo = self.create_promo(PromoEmail.FAILED)
+        stdout = StringIO()
+
+        call_command("retry_failed_emails", promo_id=promo.id, stdout=stdout)
+
+        promo.refresh_from_db()
+        self.assertEqual(promo.status, PromoEmail.DRAFT)
+        mock_delay.assert_called_once_with(promo.id)
+        self.assertIn("Successfully queued retry", stdout.getvalue())


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-71509af936-_d866d873e9`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-library-71509af936-3b04_4417d00bc7`: Specific retry can resend non-failed promotional emails (high)

## Changed Files

- `notifications/management/commands/retry_failed_emails.py`
- `notifications/tests/test_retry_failed_emails_command.py`

## Validation

- `ruff format --check .` => 1
- `ruff check .` => 0
- `npm run test` => 1

## Plan

Added a FAILED-status guard to the specific --promo-id retry path so non-failed promotional emails are rejected before any status mutation or task enqueue. Added focused management-command tests covering non-failed rejection and successful FAILED retry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a status check and tests before enqueueing sends; reduces risk of duplicate promotional email blasts with no new send paths.
> 
> **Overview**
> The **`retry_failed_emails`** management command’s **`--promo-id`** path now refuses promos that are not **`FAILED`**, printing an error and exiting before status is set to draft or **`send_promo_email_task`** is queued. That closes a gap where a targeted retry could re-queue already sent, scheduled, sending, or draft campaigns. Bulk retry (last 24 hours) was already limited to failed rows; only the single-ID flow changed.
> 
> New tests in **`test_retry_failed_emails_command.py`** cover rejection for non-failed statuses and the happy path for a failed promo (draft + one delayed task call).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f08231765e075a3ed08fd491cbc7a8f46676c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->