### PR TITLE
fix: Test settings still import required production secrets before overriding them

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,8 +1,14 @@
 """Test-specific settings to override production settings."""
-from bahk.settings import *  # Import all default settings
 from datetime import timedelta
 import os
 import tempfile
+
+os.environ.setdefault('MAILGUN_DOMAIN', 'example.test')
+os.environ.setdefault('MAILGUN_API_KEY', 'test-mailgun-api-key')
+os.environ.setdefault('ANTHROPIC_API_KEY', 'test-anthropic-api-key')
+os.environ.setdefault('OPENAI_API_KEY', 'test-openai-api-key')
+
+from bahk.settings import *  # Import all default settings
 
 # Override cache to use local memory instead of Redis for tests
 CACHES = {

--- a/tests/test_settings_import.py
+++ b/tests/test_settings_import.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import sys
+import unittest
+
+
+class TestSettingsImportTests(unittest.TestCase):
+    def test_test_settings_import_without_external_service_secrets(self):
+        env = os.environ.copy()
+        for key in (
+            'MAILGUN_DOMAIN',
+            'MAILGUN_API_KEY',
+            'ANTHROPIC_API_KEY',
+            'OPENAI_API_KEY',
+        ):
+            env.pop(key, None)
+
+        subprocess.run(
+            [
+                sys.executable,
+                '-c',
+                (
+                    'import tests.test_settings as settings; '
+                    'assert settings.EMAIL_HOST_USER == "postmaster@example.test"; '
+                    'assert settings.ANYMAIL["MAILGUN_API_KEY"] == "test-mailgun-api-key"; '
+                    'assert settings.OPENAI_API_KEY == ""; '
+                    'assert settings.ANTHROPIC_API_KEY == ""'
+                ),
+            ],
+            check=True,
+            cwd=os.getcwd(),
+            env=env,
+        )


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-90559adc1c-_aadf4a7728`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-library-90559adc1c-0db5_e37d40b510`: Test settings still import required production secrets before overriding them (high)

## Changed Files

- `tests/test_settings.py`
- `tests/test_settings_import.py`

## Validation

- `ruff format --check .` => 1
- `pytest` => 127
- `ruff check .` => 0
- `npm run test` => 1

## Plan

Seeded harmless external-service defaults in tests/test_settings.py before importing bahk.settings, so clean test environments no longer need production Mailgun/LLM secrets just to import test settings. Added a focused subprocess smoke test for importing tests.test_settings with those env vars unset. Docker validation could not run because the Docker socket is unavailable; local runtime validation was blocked by missing celery, but syntax validation passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only settings and import-order change; no production runtime or auth/data path changes.
> 
> **Overview**
> **Test settings** no longer require real Mailgun or LLM secrets in the environment just to import `tests.test_settings`. Harmless defaults are applied with `os.environ.setdefault` **before** `from bahk.settings import *`, so production `config()` calls succeed in clean CI/local runs. Existing overrides that blank out `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` for tests are unchanged.
> 
> A new **subprocess smoke test** imports `tests.test_settings` with those env vars removed and asserts Mailgun-related values come from the seeded defaults while LLM keys stay empty after test overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dcf34a7cd5249116c43a323db767a0a1d0d0477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->