### PR TITLE
fix: clawpatch bugs — event analytics & milestone fixes (4 findings)

### DIFF
--- a/events/analytics_optimizer.py
+++ b/events/analytics_optimizer.py
@@ -99,7 +99,7 @@ class AnalyticsQueryOptimizer:
         fast_joins_by_day = {}
         fast_leaves_by_day = {}
         
-        for i in range(num_days + 1):
+        for i in range(num_days):
             day = start_of_window + timedelta(days=i)
             date_str = day.strftime('%Y-%m-%d')
             events_by_day[date_str] = 0
@@ -208,7 +208,7 @@ class AnalyticsQueryOptimizer:
             # Note: A rolling window of N days can span N+1 calendar days
             daily_joins = {}
             daily_leaves = {}
-            for i in range(num_days + 1):
+            for i in range(num_days):
                 day = start_of_window + timedelta(days=i)
                 date_str = day.strftime('%Y-%m-%d')
                 daily_joins[date_str] = 0

--- a/events/management/commands/award_retroactive_milestones.py
+++ b/events/management/commands/award_retroactive_milestones.py
@@ -159,12 +159,11 @@ class Command(BaseCommand):
                 # Get all fasts this user has participated in that have ended
                 today = timezone.now().date()
                 user_completed_fasts = Fast.objects.filter(
-                    profiles=user.profile,
-                    days__date__lt=today  # Only fasts that have ended
+                    profiles=user.profile
                 ).annotate(
                     end_date=models.Max('days__date')
                 ).filter(
-                    end_date__lt=today  # Ensure the fast has actually ended
+                    end_date__lt=today  # Fast's latest day is in the past
                 ).distinct().order_by('end_date')
                 
                 # Filter out weekly fasts and find the first non-weekly completed fast

--- a/events/management/commands/engagement_report.py
+++ b/events/management/commands/engagement_report.py
@@ -399,13 +399,17 @@ class Command(BaseCommand):
         # Get all join events
         join_events = Event.objects.filter(
             event_type__code=EventType.USER_JOINED_FAST,
-            content_type=fast_content_type
+            content_type=fast_content_type,
+            timestamp__gte=start_dt,
+            timestamp__lte=end_dt
         ).select_related('user').order_by('user_id', 'object_id', 'timestamp')
         
         # Get all leave events
         leave_events = Event.objects.filter(
             event_type__code=EventType.USER_LEFT_FAST,
-            content_type=fast_content_type
+            content_type=fast_content_type,
+            timestamp__gte=start_dt,
+            timestamp__lte=end_dt
         ).select_related('user').order_by('user_id', 'object_id', 'timestamp')
         
         # Build chronological event sequences for each user-fast combination

--- a/events/signals.py
+++ b/events/signals.py
@@ -524,10 +524,11 @@ def check_and_track_participation_milestones(fast):
     """
     try:
         current_count = fast.profiles.count()
-        track_fast_participant_milestone(fast, current_count)
+        return track_fast_participant_milestone(fast, current_count)
         
     except Exception as e:
         logger.error(f"Error checking participation milestones for fast {fast}: {e}")
+        return False
 
 
 @receiver(post_save, sender=Event)

--- a/events/tasks.py
+++ b/events/tasks.py
@@ -706,8 +706,7 @@ def check_completed_fast_milestones_task():
                     # Check if this is their first completed non-weekly fast
                     # Get all fasts this user has participated in that have ended before today
                     user_completed_fasts = Fast.objects.filter(
-                        profiles=profile,
-                        days__date__lt=timezone.now().date()
+                        profiles=profile
                     ).annotate(
                         end_date=models.Max('days__date')
                     ).filter(


### PR DESCRIPTION
## Summary

Group 1 of 7 — Event/Milestone Analytics bugs.

### Fixed
- **Analytics daily buckets extra day**: `range(num_days + 1)` → `range(num_days)` in `events/analytics_optimizer.py`
- **Ongoing fasts awarded milestones**: Moved `Max('days__date')` annotation before date filter so ongoing fasts with future days aren't counted as completed — fixed in both retroactive command and scheduled task path
- **Participation report ignores date range**: Added `timestamp__gte/lte` filters to join/leave event queries in `_compute_user_fast_participation`
- **Milestone sweep reports zero**: `check_and_track_participation_milestones` now returns the bool from `track_fast_participant_milestone`, with `return False` on exceptions

### Validation
- ruff ✅
- All 4 findings revalidated as fixed via clawpatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect milestone awards and engagement metrics used for reporting; logic is targeted but incorrect prior behavior could have skewed production analytics and retroactive awards.
> 
> **Overview**
> Fixes **event analytics and milestone reporting** so daily charts, engagement exports, and scheduled milestone jobs match the intended time windows and completion rules.
> 
> **Daily analytics** in `analytics_optimizer.py` now initializes **exactly `num_days` buckets** (`range(num_days)` instead of `num_days + 1`), matching queries that use `timestamp__lt` on the window end so charts no longer show an extra empty day.
> 
> **First non-weekly fast completion** (retroactive command and `check_completed_fast_milestones_task`) no longer treats **ongoing fasts** as completed: completion is determined by annotating **`Max('days__date')`** and requiring **`end_date__lt` today**, instead of filtering on any past day row while future days still exist.
> 
> **Engagement report** `_compute_user_fast_participation` scopes join/leave **Event** queries to **`start_dt`–`end_dt`**, so participation rows reflect the report range instead of all-time history.
> 
> **Participation milestone sweep** (`check_and_track_participation_milestones`) **returns** whether a milestone was recorded (and **`False` on errors**), so `check_participation_milestones_task` can count **`milestones_created`** correctly instead of always reporting zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 134e430cb1d4a291d16e210dbb784790ebfaa41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->