### PR TITLE
fix: add replaces to 0003_promoemail migration

### DIFF
--- a/notifications/migrations/0003_promoemail.py
+++ b/notifications/migrations/0003_promoemail.py
@@ -6,6 +6,8 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
+    replaces = [('notifications', '0003_promoemail_emailsubscriptionpreference')]
+
     dependencies = [
         ('hub', '0026_profile_receive_promotional_emails'),
         ('notifications', '0002_devicetoken_user_alter_devicetoken_device_type'),


### PR DESCRIPTION
Without `replaces`, Django treats the renamed migration as a brand new migration and tries to create the PromoEmail table again — which would crash on any database that already ran the old `0003_promoemail_emailsubscriptionpreference`.

Adds `replaces = [('notifications', '0003_promoemail_emailsubscriptionpreference')]` so Django knows this is a rename, not a new migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Django migration metadata fix; prevents duplicate apply on upgraded DBs with no runtime behavior change.
> 
> **Overview**
> Adds `replaces = [('notifications', '0003_promoemail_emailsubscriptionpreference')]` to `notifications/migrations/0003_promoemail.py` so Django treats the file as a **rename** of the old migration, not a new one.
> 
> Without this, environments that already applied `0003_promoemail_emailsubscriptionpreference` would try to run `CreateModel` for `PromoEmail` again and fail on duplicate table creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e7043204173ecb318818482b0a8681aad8ef56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->