### PR TITLE
fix: clawpatch icon and LLM bug fixes

### DIFF
--- a/hub/tasks/icon_tasks.py
+++ b/hub/tasks/icon_tasks.py
@@ -105,10 +105,10 @@ If unsure whether an icon is relevant:
 DO NOT RETURN IT.
 """
     
-    allowed_ids = [icon.id for icon in icons]
+    allowed_ids = {icon.id for icon in icons}
     
     user_message = f"""User request: "{prompt}"
-Allowed icon IDs: {allowed_ids}
+Allowed icon IDs: {sorted(allowed_ids)}
 
 Available icons (ID, Title, Tags):
 {chr(10).join(icon_descriptions)}
@@ -230,19 +230,35 @@ Return up to {max_results} most relevant icons as a JSON array of objects with "
                 if isinstance(item, dict):
                     # New format: {"id": 3, "confidence": "high"}
                     if 'id' in item:
+                        try:
+                            icon_id = int(item['id'])
+                        except (TypeError, ValueError):
+                            logger.warning("Skipping invalid icon ID from LLM response: %r", item['id'])
+                            continue
+                        if icon_id not in allowed_ids:
+                            logger.warning("Skipping out-of-scope icon ID from LLM response: %s", icon_id)
+                            continue
                         confidence = item.get('confidence', 'medium')
                         # Validate confidence level
                         if confidence not in valid_confidence_levels:
                             logger.warning(f"Invalid confidence '{confidence}', defaulting to 'medium'")
                             confidence = 'medium'
                         matched_results.append({
-                            'id': item['id'],
+                            'id': icon_id,
                             'confidence': confidence
                         })
                 elif isinstance(item, (int, str)):
                     # Backward compatibility: just an ID
+                    try:
+                        icon_id = int(item)
+                    except (TypeError, ValueError):
+                        logger.warning("Skipping invalid icon ID from LLM response: %r", item)
+                        continue
+                    if icon_id not in allowed_ids:
+                        logger.warning("Skipping out-of-scope icon ID from LLM response: %s", icon_id)
+                        continue
                     matched_results.append({
-                        'id': int(item),
+                        'id': icon_id,
                         'confidence': 'medium'  # Default if not provided
                     })
             
@@ -253,6 +269,7 @@ Return up to {max_results} most relevant icons as a JSON array of objects with "
         except json.JSONDecodeError:
             # Fallback: extract numbers from response
             matched_ids = [int(x) for x in re.findall(r'\d+', llm_response)]
+            matched_ids = [icon_id for icon_id in matched_ids if icon_id in allowed_ids]
             return [
                 {'id': icon_id, 'confidence': 'medium'}
                 for icon_id in matched_ids[:max_results]
@@ -329,7 +346,7 @@ def match_icon_to_feast_task(self, feast_id: int):
             # Found a high confidence match, save it
             icon_id = first_match['id']
             try:
-                icon = Icon.objects.get(pk=icon_id)
+                icon = Icon.objects.get(pk=icon_id, church=church)
                 feast.icon = icon
                 feast.save(update_fields=['icon'])
                 logger.info(
@@ -348,4 +365,3 @@ def match_icon_to_feast_task(self, feast_id: int):
         logger.error(f"Error matching icon to feast {feast_id}: {e}", exc_info=True)
         # Don't retry on general exceptions, just log the error
         # Feasts can exist without icons, so this is not a critical failure
-

--- a/hub/tests/test_feast_icon_matching.py
+++ b/hub/tests/test_feast_icon_matching.py
@@ -8,7 +8,11 @@ from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from hub.models import Church, Day, Feast
-from hub.tasks.icon_tasks import match_icon_to_feast_task, _simple_match_icons
+from hub.tasks.icon_tasks import (
+    match_icon_to_feast_task,
+    _match_icons_with_llm,
+    _simple_match_icons,
+)
 from hub.signals import handle_feast_save
 from icons.models import Icon
 
@@ -247,6 +251,87 @@ class FeastIconMatchingTaskTests(TestCase):
         # Test no match
         result = _simple_match_icons(icons, "Christmas", max_results=1)
         self.assertEqual(len(result), 0)
+
+
+class FeastIconMatchingScopeTests(TestCase):
+    """Tests for church scoping in icon matching."""
+
+    def setUp(self):
+        self.church = Church.objects.get(pk=Church.get_default_pk())
+        self.other_church = Church.objects.create(name="Other Church")
+        self.test_date = date(2025, 12, 25)
+        self.test_image = SimpleUploadedFile(
+            name='icon.jpg',
+            content=b'fake image content',
+            content_type='image/jpeg'
+        )
+
+    def _create_feast_without_signal(self, **kwargs):
+        """Create Feast fixtures without eager post-save task side effects."""
+        post_save.disconnect(handle_feast_save, sender=Feast)
+        try:
+            return Feast.objects.create(**kwargs)
+        finally:
+            post_save.connect(handle_feast_save, sender=Feast)
+
+    def test_match_icon_task_rejects_icon_from_another_church(self):
+        """Task must not assign a matched icon outside the feast church."""
+        day = Day.objects.create(date=self.test_date, church=self.church)
+        feast = self._create_feast_without_signal(
+            day=day,
+            name="Nativity of Christ",
+        )
+        Icon.objects.create(
+            title="Local Nativity Icon",
+            church=self.church,
+            image=self.test_image,
+        )
+        other_icon = Icon.objects.create(
+            title="Other Church Nativity Icon",
+            church=self.other_church,
+            image=SimpleUploadedFile(
+                name='other_icon.jpg',
+                content=b'fake image content',
+                content_type='image/jpeg'
+            ),
+        )
+
+        with patch('hub.tasks.icon_tasks._match_icons_with_llm') as mock_match:
+            mock_match.return_value = [
+                {'id': other_icon.id, 'confidence': 'high'}
+            ]
+            match_icon_to_feast_task(feast.id)
+
+        feast.refresh_from_db()
+        self.assertIsNone(feast.icon)
+
+    @override_settings(OPENAI_API_KEY='test-key')
+    @patch('openai.OpenAI')
+    def test_llm_parser_filters_out_of_scope_icon_ids(self, mock_openai):
+        """LLM parser should only return IDs from the provided icon list."""
+        icon = Icon.objects.create(
+            title="Local Nativity Icon",
+            church=self.church,
+            image=self.test_image,
+        )
+        other_icon = Icon.objects.create(
+            title="Other Church Nativity Icon",
+            church=self.other_church,
+            image=SimpleUploadedFile(
+                name='other_icon_parser.jpg',
+                content=b'fake image content',
+                content_type='image/jpeg'
+            ),
+        )
+        mock_choice = mock_openai.return_value.chat.completions.create.return_value.choices[0]
+        mock_choice.message.content = (
+            f'[{{"id": {other_icon.id}, "confidence": "high"}}, '
+            f'{{"id": {icon.id}, "confidence": "high"}}]'
+        )
+
+        matches = _match_icons_with_llm([icon], "Nativity", max_results=2)
+
+        self.assertEqual(matches, [{'id': icon.id, 'confidence': 'high'}])
 
 
 @tag('slow', 'integration')

--- a/icons/tests.py
+++ b/icons/tests.py
@@ -146,6 +146,40 @@ class IconAPITests(APITestCase):
         response = self.client.post('/api/icons/match/', data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('matches', response.data)
+
+    def test_icon_match_accepts_form_encoded_max_results_string(self):
+        """Test that numeric form max_results is normalized before matching."""
+        data = {
+            'prompt': 'nativity',
+            'return_format': 'id',
+            'max_results': '2'
+        }
+        response = self.client.post('/api/icons/match/', data, format='multipart')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('matches', response.data)
+        self.assertLessEqual(len(response.data['matches']), 2)
+
+    def test_icon_match_rejects_negative_max_results(self):
+        """Test that negative max_results is rejected."""
+        data = {
+            'prompt': 'nativity',
+            'return_format': 'id',
+            'max_results': -1
+        }
+        response = self.client.post('/api/icons/match/', data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('max_results', response.data['error'])
+
+    def test_icon_match_rejects_non_numeric_max_results(self):
+        """Test that non-numeric max_results is rejected."""
+        data = {
+            'prompt': 'nativity',
+            'return_format': 'id',
+            'max_results': 'two'
+        }
+        response = self.client.post('/api/icons/match/', data, format='multipart')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('max_results', response.data['error'])
     
     def test_icon_match_requires_prompt(self):
         """Test that icon matching requires a prompt."""

--- a/icons/views.py
+++ b/icons/views.py
@@ -163,7 +163,7 @@ class IconMatchView(views.APIView):
         prompt = request.data.get('prompt')
         church_id = request.data.get('church_id')
         return_format = request.data.get('return_format', 'full')
-        max_results = request.data.get('max_results', 3)
+        raw_max_results = request.data.get('max_results', 3)
         
         # Validate prompt
         if not prompt:
@@ -176,6 +176,22 @@ class IconMatchView(views.APIView):
         if return_format not in ['id', 'full']:
             return Response(
                 {'error': 'return_format must be "id" or "full"'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            if isinstance(raw_max_results, (bool, float)):
+                raise ValueError
+            max_results = int(raw_max_results)
+        except (TypeError, ValueError):
+            return Response(
+                {'error': 'max_results must be an integer'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if max_results < 1 or max_results > 100:
+            return Response(
+                {'error': 'max_results must be between 1 and 100'},
                 status=status.HTTP_400_BAD_REQUEST
             )
         

--- a/prayers/tasks.py
+++ b/prayers/tasks.py
@@ -369,12 +369,23 @@ def moderate_prayer_request_task(self, prayer_request_id):
         except Exception as llm_error:
             logger.error(f"LLM moderation error for prayer request {prayer_request_id}: {llm_error}")
             # If LLM fails, mark as pending and send email to admin
+            prayer_request.status = 'pending_moderation'
+            prayer_request.requires_human_review = True
+            prayer_request.moderation_severity = 'high'
             prayer_request.moderation_result = {
                 'profanity_check': {'passed': True},
                 'llm_check': {'error': str(llm_error)},
                 'reason': 'LLM moderation failed, requires manual review'
             }
-            prayer_request.save()
+            prayer_request.save(
+                update_fields=[
+                    'status',
+                    'requires_human_review',
+                    'moderation_severity',
+                    'moderation_result',
+                    'updated_at',
+                ]
+            )
 
             # Send email to admin for manual review
             _send_moderation_alert_email(prayer_request, 'llm_error')

--- a/tests/test_prayer_requests.py
+++ b/tests/test_prayer_requests.py
@@ -1187,6 +1187,39 @@ class PrayerRequestAPITests(BaseAPITestCase):
         self.assertTrue(prayer_request.requires_human_review)
         mock_email.assert_called_once()
 
+    def test_moderation_task_llm_error_sets_manual_review_flag(self):
+        """LLM failures should leave the request visible in the manual-review queue."""
+        requester = self.create_user(email='llmerror@example.com')
+        prayer_request = PrayerRequest.objects.create(
+            title='Prayer needing moderation',
+            description='Please pray for wisdom.',
+            requester=requester,
+            duration_days=3,
+            status='pending_moderation',
+            reviewed=False,
+            requires_human_review=False,
+            expiration_date=timezone.now() + timedelta(days=3),
+        )
+
+        with patch('anthropic.Anthropic') as mock_anthropic, \
+             patch('prayers.tasks._send_moderation_alert_email') as mock_email:
+            mock_client = mock_anthropic.return_value
+            mock_client.messages.create.side_effect = RuntimeError('service down')
+            result = moderate_prayer_request_task(prayer_request.id)
+
+        prayer_request.refresh_from_db()
+        self.assertFalse(result['success'])
+        self.assertTrue(result['requires_manual_review'])
+        self.assertEqual(prayer_request.status, 'pending_moderation')
+        self.assertTrue(prayer_request.requires_human_review)
+        self.assertEqual(prayer_request.moderation_severity, 'high')
+        self.assertIn('service down', prayer_request.moderation_result['llm_check']['error'])
+        self.assertEqual(
+            prayer_request.moderation_result['reason'],
+            'LLM moderation failed, requires manual review',
+        )
+        mock_email.assert_called_once_with(prayer_request, 'llm_error')
+
     @tag('integration')
     def test_api_exposes_moderation_severity(self):
         """API should expose moderation_severity field."""


### PR DESCRIPTION
## Summary

Fixes Group 5: Icon/LLM clawpatch bug findings.

- Fix icon match max_results validation so form strings are normalized and invalid/out-of-range values return 400
- Scope LLM icon matches to the provided church icon set and fetch feast icons by both id and church
- Mark LLM moderation failures as pending manual review in saved PrayerRequest state

## Clawpatch findings

- fnd_sig-feat-library-8552b82b12-c4e8_67c9f878f7
- fnd_sig-feat-library-a41fac0e7e-fd9a_46f7e47df1
- fnd_sig-feat-library-c60ee9a366-41ec_2fbb22028d

## Validation

- scripts/crabbox-validate.sh ci: passed after each finding
- clawpatch revalidate: all 3 findings fixed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect multi-tenant icon assignment and moderation queue state on LLM outages; fixes are defensive but touch user-visible content workflows.
> 
> **Overview**
> This PR hardens **icon/LLM matching** and **prayer moderation** so bad or out-of-scope inputs cannot slip through.
> 
> **Icon matching:** Feast auto-assignment now loads icons with **`pk` + `church`**, so a high-confidence LLM match cannot attach another church’s icon. LLM parsing in `hub/tasks/icon_tasks.py` coerces IDs to integers, drops invalid or IDs not in the candidate set (including regex fallback), and uses a set for allowed IDs. The **`/api/icons/match/`** endpoint validates **`max_results`** as an integer in **1–100** (accepts form-encoded numeric strings; rejects negatives and non-numeric values with **400**).
> 
> **Prayer moderation:** When the moderation LLM call fails, the task now persists **`pending_moderation`**, **`requires_human_review=True`**, and **`moderation_severity='high'`** (with targeted `update_fields`) so requests stay in the manual-review queue instead of leaving stale flags.
> 
> Tests cover church scoping, LLM ID filtering, `max_results` validation, and LLM-error moderation state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80cbcdb1c5d500e71d59ac1a85df03b9cfe7920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->