### PR TITLE
fix: clawpatch cache and timezone bug fixes

### DIFF
--- a/hub/management/commands/update_user_timezones.py
+++ b/hub/management/commands/update_user_timezones.py
@@ -70,13 +70,18 @@ class Command(BaseCommand):
             )
             self.stdout.write(f"Will update {profiles_to_update.count()} profiles with UTC/empty timezone")
 
-        if profiles_to_update.count() == 0:
+        profile_ids = list(
+            profiles_to_update.order_by('pk').values_list('pk', flat=True)
+        )
+        total_profiles = len(profile_ids)
+
+        if total_profiles == 0:
             self.stdout.write(self.style.SUCCESS("No profiles need timezone updates!"))
             return
 
         # Track statistics
         stats = {
-            'total': profiles_to_update.count(),
+            'total': total_profiles,
             'successful': 0,
             'failed': 0,
             'skipped': 0,
@@ -87,7 +92,13 @@ class Command(BaseCommand):
         batch_size = 100
         
         for i in range(0, stats['total'], batch_size):
-            batch = profiles_to_update[i:i+batch_size]
+            batch_ids = profile_ids[i:i + batch_size]
+            batch = (
+                Profile.objects
+                .filter(pk__in=batch_ids)
+                .select_related('user')
+                .order_by('pk')
+            )
             self.stdout.write(f"Processing batch {i//batch_size + 1}: profiles {i+1} to {min(i+batch_size, stats['total'])}")
             
             batch_updates = []

--- a/hub/tests/test_timezone_functionality.py
+++ b/hub/tests/test_timezone_functionality.py
@@ -1,8 +1,13 @@
 """
 Tests for timezone functionality in user profiles.
 """
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
 from django.test import TestCase, RequestFactory
 from django.http import HttpResponse
+from hub.models import Profile
 from hub.serializers import ProfileSerializer
 from hub.middleware import TimezoneUpdateMiddleware
 from tests.fixtures.test_data import TestDataFactory
@@ -195,3 +200,39 @@ class TimezoneIntegrationTest(TestCase):
         # Save and check tracking resets
         self.profile.save()
         self.assertFalse(self.profile.tracker.has_changed('timezone'))
+
+
+class UpdateUserTimezonesCommandTest(TestCase):
+    """Test the timezone backfill management command."""
+
+    def test_updates_all_initially_eligible_profiles_across_batches(self):
+        """Updating earlier rows should not make later offset batches disappear."""
+        profile_ids = []
+        church = TestDataFactory.create_church()
+
+        for index in range(105):
+            user = TestDataFactory.create_user(email=f'timezone-{index}@example.com')
+            profile = TestDataFactory.create_profile(
+                user=user,
+                church=church,
+                location='San Francisco',
+                latitude=37.7749,
+                longitude=-122.4194,
+                timezone='UTC' if index % 2 == 0 else '',
+            )
+            profile_ids.append(profile.id)
+
+        fake_timezone_finder = type(
+            'FakeTimezoneFinder',
+            (),
+            {'timezone_at': lambda self, lng, lat: 'America/Los_Angeles'},
+        )
+
+        with patch('timezonefinder.TimezoneFinder', return_value=fake_timezone_finder()):
+            call_command('update_user_timezones', stdout=StringIO())
+
+        updated_count = Profile.objects.filter(
+            id__in=profile_ids,
+            timezone='America/Los_Angeles',
+        ).count()
+        self.assertEqual(updated_count, len(profile_ids))

--- a/learning_resources/signals.py
+++ b/learning_resources/signals.py
@@ -46,11 +46,18 @@ def bookmark_created_signal(sender, instance, created, **kwargs):
     any method (API, admin, Django shell, etc.).
     """
     if created:
-        BookmarkCacheManager.bookmark_created(
-            user=instance.user,
-            content_type=instance.content_type,
-            object_id=instance.object_id
-        )
+        try:
+            BookmarkCacheManager.bookmark_created(
+                user=instance.user,
+                content_type=instance.content_type,
+                object_id=instance.object_id
+            )
+        except Exception as cache_error:
+            logger.warning(
+                f"Cache update failed during bookmark creation signal for user {instance.user.id}, "
+                f"content_type {instance.content_type_id}, object_id {instance.object_id}: {cache_error}"
+            )
+            return
         logger.debug(f"Signal: Bookmark created for user {instance.user.id}, "
                     f"content_type {instance.content_type.id}, object {instance.object_id}")
 

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -572,12 +572,20 @@ class BookmarkCreateView(generics.CreateAPIView):
         serializer.is_valid(raise_exception=True)
         bookmark = serializer.save()
         
-        # Update Redis cache - add bookmark
-        BookmarkCacheManager.bookmark_created(
-            user=request.user,
-            content_type=bookmark.content_type,
-            object_id=bookmark.object_id
-        )
+        # Update Redis cache - add bookmark. Cache failures should not turn a
+        # successful database create into a 500 response.
+        try:
+            BookmarkCacheManager.bookmark_created(
+                user=request.user,
+                content_type=bookmark.content_type,
+                object_id=bookmark.object_id
+            )
+        except Exception as cache_error:
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                f"Cache update failed during bookmark creation for user {request.user.id}, "
+                f"content_type {bookmark.content_type_id}, object_id {bookmark.object_id}: {cache_error}"
+            )
         
         # Return the full bookmark representation
         response_serializer = BookmarkSerializer(bookmark)

--- a/tests/integration/test_bookmark_api.py
+++ b/tests/integration/test_bookmark_api.py
@@ -1,5 +1,7 @@
 """Integration tests for bookmark API endpoints."""
 
+from unittest.mock import patch
+
 from django.urls import reverse
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import status
@@ -48,6 +50,35 @@ class BookmarkAPITests(BaseAPITestCase):
         # Check database
         bookmark = Bookmark.objects.get(user=self.user, object_id=self.video.id)
         self.assertEqual(bookmark.note, 'Great video!')
+
+    def test_create_bookmark_succeeds_when_cache_update_fails(self):
+        """Cache failures should not fail an otherwise successful bookmark create."""
+        url = reverse('bookmark-create')
+        data = {
+            'content_type': 'video',
+            'object_id': self.video.id,
+            'note': 'Save despite cache outage'
+        }
+
+        with patch(
+            'learning_resources.views.BookmarkCacheManager.bookmark_created',
+            side_effect=RuntimeError('redis unavailable')
+        ), self.assertLogs('learning_resources', level='WARNING') as logs:
+            response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['content_type_name'], 'video')
+        self.assertTrue(
+            Bookmark.objects.filter(
+                user=self.user,
+                content_type=ContentType.objects.get_for_model(Video),
+                object_id=self.video.id
+            ).exists()
+        )
+        self.assertIn(
+            'Cache update failed during bookmark creation',
+            '\n'.join(logs.output)
+        )
     
     def test_create_article_bookmark(self):
         """Test creating a bookmark for an article."""


### PR DESCRIPTION
## Summary
- keep bookmark creation successful when Redis/bookmark cache updates fail
- log cache failures from both the API path and bookmark-created signal
- snapshot timezone backfill profile IDs before bulk updates so batching cannot skip eligible profiles

## Validation
- scripts/crabbox-validate.sh ci
- clawpatch revalidate --finding fnd_sig-feat-library-603013f017-8f4d_e3506c0a50
- clawpatch revalidate --finding fnd_sig-feat-library-b777d2711f-9309_ffb6c1871c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are defensive (graceful cache degradation) and a targeted backfill correctness fix with new tests; no auth or schema changes.
> 
> **Overview**
> Bookmark creation now **decouples Redis cache updates from API success**: the create endpoint and the `post_save` signal wrap `BookmarkCacheManager.bookmark_created` in try/except, log warnings on failure, and still return **201** / complete the DB write. Integration coverage asserts a bookmark is persisted when the cache layer raises.
> 
> The **`update_user_timezones`** management command no longer slices a live queryset across batches (which could skip profiles once earlier rows left the UTC/empty filter). It **snapshots eligible profile PKs up front**, then loads each batch by ID with `select_related('user')`. A new test runs the command over **105** eligible profiles to prove full backfill across batch boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65bf19fb721a9934199edf01626f76d7af9d4d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->