### PR TITLE
fix: clawpatch remaining hub bugs

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -545,6 +545,8 @@ class FastAdmin(admin.ModelAdmin):
                     Day.objects.create(date=date, fast=fast, church=data["church"])
 
                 # Derive year from the first created day
+                if dates:
+                    fast.year = dates[0].year
                 fast.save(update_fields=["year"])
 
                 # go back to fast admin page

--- a/hub/models.py
+++ b/hub/models.py
@@ -169,8 +169,10 @@ class Fast(models.Model):
 
         # Update year if days exist
         if self.days.exists():
-            self.year = self.days.first().date.year
-            super().save(update_fields=["year"])
+            first_day = self.days.order_by("date").first()
+            if first_day and self.year != first_day.date.year:
+                self.year = first_day.date.year
+                super().save(update_fields=["year"])
 
         # Invalidate the cache for this church's fast list
         from hub.views.fast import FastListView

--- a/hub/tests/test_devotional_list_api.py
+++ b/hub/tests/test_devotional_list_api.py
@@ -147,6 +147,44 @@ class DevotionalListAPITests(TestCase):
         self.assertEqual(response.data["date"], "2026-01-03")
         self.assertEqual(response.data["fast_id"], self.fast.id)
 
+    def test_devotional_by_date_uses_deterministic_fallback_for_multiple_languages(self):
+        fallback_day = Day.objects.create(
+            date=date(2026, 2, 1),
+            fast=self.fast,
+            church=self.church,
+        )
+        es_video = Video.objects.create(
+            title="Spanish fallback",
+            description="Fallback devotional",
+            category="devotional",
+            language_code="es",
+        )
+        hy_video = Video.objects.create(
+            title="Armenian fallback",
+            description="Fallback devotional",
+            category="devotional",
+            language_code="hy",
+        )
+        Devotional.objects.create(
+            day=fallback_day,
+            description="Spanish text",
+            video=es_video,
+            order=1,
+            language_code="es",
+        )
+        Devotional.objects.create(
+            day=fallback_day,
+            description="Armenian text",
+            video=hy_video,
+            order=1,
+            language_code="hy",
+        )
+
+        response = self._get_by_date(date="2026-02-01", lang="fr")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["title"], "Spanish fallback")
+
     def test_devotional_list_default_behavior_still_works(self):
         response = self._get_list()
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/hub/tests/test_fast_views.py
+++ b/hub/tests/test_fast_views.py
@@ -19,6 +19,7 @@ from rest_framework import status
 from rest_framework.test import APIRequestFactory
 from rest_framework.test import force_authenticate
 from datetime import timedelta
+from unittest.mock import patch
 from django.core.cache import cache
 from events.models import Event, EventType
 from tests.fixtures.test_data import TestDataFactory
@@ -61,15 +62,17 @@ class JoinFastViewTest(TestCase):
     def test_join_fast_adds_membership(self):
         self.client.force_login(self.user)
 
-        response = self.client.put(
-            self.url,
-            data={"fast_id": self.fast.id},
-            content_type="application/json",
-        )
+        with patch("hub.views.fast.FastListView.invalidate_cache") as mock_invalidate:
+            response = self.client.put(
+                self.url,
+                data={"fast_id": self.fast.id},
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(self.profile.fasts.filter(id=self.fast.id).exists())
         self.assertEqual(self.profile.fasts.filter(id=self.fast.id).count(), 1)
+        mock_invalidate.assert_called_once_with(self.fast.church_id)
 
     def test_join_fast_requires_authentication(self):
         response = self.client.put(
@@ -136,15 +139,17 @@ class LeaveFastViewTest(TestCase):
         self.profile.fasts.add(self.fast)
         self.client.force_login(self.user)
 
-        response = self.client.put(
-            self.url,
-            data={"fast_id": self.fast.id},
-            content_type="application/json",
-        )
+        with patch("hub.views.fast.FastListView.invalidate_cache") as mock_invalidate:
+            response = self.client.put(
+                self.url,
+                data={"fast_id": self.fast.id},
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["detail"], "Successfully left the fast.")
         self.assertFalse(self.profile.fasts.filter(id=self.fast.id).exists())
+        mock_invalidate.assert_called_once_with(self.fast.church_id)
 
     def test_leave_fast_requires_authentication(self):
         self.profile.fasts.add(self.fast)

--- a/hub/tests/test_feast_model.py
+++ b/hub/tests/test_feast_model.py
@@ -1,7 +1,6 @@
 """Tests for the Feast model."""
 from datetime import date
 
-from django.db import IntegrityError
 from django.test import TestCase
 from django.test.utils import tag
 
@@ -44,20 +43,20 @@ class FeastModelTests(TestCase):
         self.assertEqual(feast.name, "Christmas")
         self.assertEqual(feast.name_hy, "Սուրբ Ծնունդ")
 
-    def test_feast_unique_constraint(self):
-        """Test that the unique constraint on day works."""
+    def test_multiple_feasts_can_share_the_same_day(self):
+        """Test that distinct commemorations can be stored for the same day."""
         day = Day.objects.create(date=self.test_date, church=self.church)
-        Feast.objects.create(
+        first_feast = Feast.objects.create(
             day=day,
             name="First Feast",
         )
+        second_feast = Feast.objects.create(
+            day=day,
+            name="Second Feast",
+        )
 
-        # Try to create another feast on same day - should fail
-        with self.assertRaises(IntegrityError):
-            Feast.objects.create(
-                day=day,
-                name="Second Feast",
-            )
+        self.assertNotEqual(first_feast.id, second_feast.id)
+        self.assertEqual(Feast.objects.filter(day=day).count(), 2)
 
     def test_feast_different_churches_same_date(self):
         """Test that different churches can have feasts on the same date."""

--- a/hub/views/fast.py
+++ b/hub/views/fast.py
@@ -527,7 +527,7 @@ class JoinFastView(generics.UpdateAPIView):
         invalidate_fast_stats_cache(self.request.user)
         
         # Invalidate fast list caches for this church
-        cache.delete(f'church_{fast.church_id}_participant_count')
+        FastListView().invalidate_cache(fast.church_id)
 
 
 class LeaveFastView(generics.UpdateAPIView):
@@ -613,7 +613,7 @@ class LeaveFastView(generics.UpdateAPIView):
         invalidate_fast_stats_cache(self.request.user)
         
         # Invalidate fast list caches for this church
-        cache.delete(f'church_{fast.church_id}_participant_count')
+        FastListView().invalidate_cache(fast.church_id)
 
 
 def vary_on_query_params(*params):


### PR DESCRIPTION
## Summary
- derive fast year from the first created day when admin-created dates arrive out of order
- invalidate full fast list caches after join/leave changes
- add deterministic devotional fallback coverage for multiple fallback languages
- update feast regression coverage for multiple feasts on one day

## Validation
- scripts/crabbox-validate.sh ci
- clawpatch revalidate --include-dirty --finding fnd_sig-feat-library-129f95bc51-10e2_5b7dd29502
- clawpatch revalidate --include-dirty --finding fnd_sig-feat-library-ba626d612c-b87f_e163473933
- clawpatch revalidate --include-dirty --finding fnd_sig-feat-library-ba626d612c-bb38_372bade4f3

Note: the feast uniqueness finding was no longer open on current main; this PR keeps the regression expectation aligned with the migration that removed the unique constraint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bugfixes and test alignment in hub admin/models/views; no auth or payment changes, with moderate user-visible impact on fast year and cached fast lists.
> 
> **Overview**
> This PR tightens **fast year** handling and **fast list cache** invalidation, and adds regression tests for devotional language fallback and multiple feasts per day.
> 
> **Fast year:** Admin fast creation only sets `year` from the first generated day when dates exist. On `Fast.save`, `year` is taken from the **earliest** related day by date and persisted only when it differs—avoiding wrong years when days are unordered or redundant writes.
> 
> **Caching:** Join and leave fast now call `FastListView().invalidate_cache(church_id)` instead of deleting only the church participant-count key, so list query caches refresh when membership changes.
> 
> **Tests:** Devotional-by-date asserts that when the requested language is missing, fallback picks a stable option (e.g. Spanish before Armenian via `language_code` ordering). Join/leave tests assert full list cache invalidation. Feast model test expects multiple feasts on one day (aligned with removed unique constraint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1dd0f1509043079f43d016b58640cdebfce0be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->