### PR TITLE
fix: harden auth security findings

### DIFF
--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -18,6 +18,7 @@ import ssl
 
 from pathlib import Path
 from decouple import config, Csv
+from django.core.exceptions import ImproperlyConfigured
 from ssl import CERT_NONE
 
 # Sentry SDK for error and performance monitoring
@@ -98,18 +99,23 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Default church name (used if user is not logged in)
 DEFAULT_CHURCH_NAME = "Armenian Apostolic Church"
 
+# Determine if we are running in production
+IS_PRODUCTION = config('IS_PRODUCTION', default=False, cast=bool)
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = config('SECRET_KEY', default='django-insecure-340y5$yaevl3%&50ob@)r@6htxve-6b0161m03j$)4r_%g8djq')
+SECRET_KEY = config('SECRET_KEY', default=None)
+if not SECRET_KEY:
+    if IS_PRODUCTION:
+        raise ImproperlyConfigured("SECRET_KEY must be configured in production.")
+    SECRET_KEY = 'django-insecure-340y5$yaevl3%&50ob@)r@6htxve-6b0161m03j$)4r_%g8djq'
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DEBUG', default=False, cast=bool)
 
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='localhost,127.0.0.1', cast=Csv())
-
-# Determine if we are running in production
-IS_PRODUCTION = config('IS_PRODUCTION', default=False, cast=bool)
 
 # Enable/disable rate limiting on the icon feedback endpoint
 ENABLE_FEEDBACK_THROTTLING = config('ENABLE_FEEDBACK_THROTTLING', default=True, cast=bool)
@@ -301,9 +307,10 @@ REST_FRAMEWORK = {
 # Analytics settings
 ANALYTICS_SESSION_TIMEOUT_MINUTES = int(config('ANALYTICS_SESSION_TIMEOUT_MINUTES', default=30))
 
-# extend lifetime of JWT refresh tokens
 SIMPLE_JWT = {
-    'REFRESH_TOKEN_LIFETIME': datetime.timedelta(days=100*365)  # set to expire in 100 years (~forever)
+    'REFRESH_TOKEN_LIFETIME': datetime.timedelta(
+        days=config('JWT_REFRESH_TOKEN_LIFETIME_DAYS', default=30, cast=int)
+    )
 }
 
 # path to backend for authenticating users by email

--- a/bahk/urls.py
+++ b/bahk/urls.py
@@ -13,6 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+import logging
+
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
@@ -26,6 +28,8 @@ from rest_framework_simplejwt.views import TokenObtainPairView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import status
+
+logger = logging.getLogger(__name__)
 
 
 class HealthCheckView(APIView):
@@ -93,7 +97,7 @@ class TrackingTokenObtainPairView(TokenObtainPairView):
                     request=request,
                 )
             except Exception:
-                pass
+                logger.exception("Failed to record JWT login audit event", extra={"user_id": user.pk})
 
         return Response(serializer.validated_data, status=200)
 

--- a/events/tests/test_jwt_login_tracking.py
+++ b/events/tests/test_jwt_login_tracking.py
@@ -267,6 +267,25 @@ class JWTLoginTrackingTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('access', response.data)
         self.assertIn('refresh', response.data)
+
+    def test_jwt_login_audit_failure_is_logged_without_blocking_token_response(self):
+        """Audit write failures should be visible while token issuance still succeeds."""
+        url = reverse('token_obtain_pair')
+        data = {
+            'username': self.user.email,
+            'password': 'testpass123'
+        }
+
+        with patch('events.models.Event.create_event', side_effect=RuntimeError('audit unavailable')):
+            with self.assertLogs('bahk.urls', level='ERROR') as captured_logs:
+                response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+        self.assertIn('refresh', response.data)
+        self.assertTrue(
+            any('Failed to record JWT login audit event' in message for message in captured_logs.output)
+        )
     
     def test_jwt_login_response_format(self):
         """Test that JWT login response format is correct."""

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -512,10 +512,6 @@ class PasswordResetSerializer(serializers.Serializer):
     email = serializers.EmailField()
 
     def validate_email(self, value):
-        try:
-            user = User.objects.get(email=value)
-        except User.DoesNotExist:
-            raise serializers.ValidationError("User with this email address does not exist.")
         return value
 
 class PasswordResetConfirmSerializer(serializers.Serializer):

--- a/hub/views/user.py
+++ b/hub/views/user.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User, Group
 from rest_framework import viewsets, permissions, generics
 from hub import serializers
@@ -34,13 +35,15 @@ class RegisterView(generics.CreateAPIView):
 class PasswordResetView(APIView):
     permission_classes = [permissions.AllowAny]
     serializer_class = serializers.PasswordResetSerializer
+    success_response = {"detail": "If an account exists for this email, a password reset email has been sent."}
 
     def post(self, request):
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid():
             email = serializer.validated_data['email']
+            user_model = get_user_model()
             try:
-                user = User.objects.get(email=email)
+                user = user_model.objects.get(email=email)
                 
                 # Generate password reset token
                 token = default_token_generator.make_token(user)
@@ -71,15 +74,9 @@ class PasswordResetView(APIView):
                 email.attach_alternative(html_content, "text/html")
                 email.send()
             
-                return Response(
-                    {"detail": "Password reset email has been sent."},
-                    status=status.HTTP_200_OK
-                )
-            except User.DoesNotExist:
-                return Response(
-                    {"detail": "Email address not found."},
-                    status=status.HTTP_400_BAD_REQUEST
-                )
+                return Response(self.success_response, status=status.HTTP_200_OK)
+            except user_model.DoesNotExist:
+                return Response(self.success_response, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class PasswordResetConfirmView(APIView):

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -44,8 +44,7 @@ class PasswordResetTests(APITestCase):
 
     def test_password_reset_serializer_invalid_email(self):
         serializer = PasswordResetSerializer(data={'email': 'nonexistent@example.com'})
-        self.assertFalse(serializer.is_valid())
-        self.assertIn('email', serializer.errors)
+        self.assertTrue(serializer.is_valid())
 
     def test_password_reset_confirm_serializer_passwords_match(self):
         # Generate valid token and uidb64
@@ -78,16 +77,27 @@ class PasswordResetTests(APITestCase):
     def test_password_reset_endpoint(self):
         response = self.client.post(self.password_reset_url, {'email': 'test@example.com'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {'detail': 'Password reset email has been sent.'})
+        self.assertEqual(response.data, PasswordResetView.success_response)
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn('test@example.com', mail.outbox[0].to)
         self.assertEqual(mail.outbox[0].subject, 'Password Reset Request')
 
     def test_password_reset_endpoint_invalid_email(self):
         response = self.client.post(self.password_reset_url, {'email': 'nonexistent@example.com'})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, PasswordResetView.success_response)
         self.assertEqual(len(mail.outbox), 0)
-        self.assertIn('email', response.data)
+
+    def test_password_reset_endpoint_returns_same_response_for_existing_and_unknown_email(self):
+        existing_response = self.client.post(self.password_reset_url, {'email': 'test@example.com'})
+        outbox_after_existing = len(mail.outbox)
+
+        unknown_response = self.client.post(self.password_reset_url, {'email': 'unknown@example.com'})
+
+        self.assertEqual(existing_response.status_code, unknown_response.status_code)
+        self.assertEqual(existing_response.data, unknown_response.data)
+        self.assertEqual(outbox_after_existing, 1)
+        self.assertEqual(len(mail.outbox), 1)
 
     def test_password_reset_endpoint_rejects_malformed_input(self):
         response = self.client.post(self.password_reset_url, {'email': 'not-an-email'})

--- a/tests/test_settings_import.py
+++ b/tests/test_settings_import.py
@@ -2,11 +2,25 @@ import os
 import subprocess
 import sys
 import unittest
+from textwrap import dedent
 
 
 class TestSettingsImportTests(unittest.TestCase):
-    def test_test_settings_import_without_external_service_secrets(self):
+    def _settings_env(self):
         env = os.environ.copy()
+        env.update(
+            {
+                'CI': 'true',
+                'MAILGUN_DOMAIN': 'example.test',
+                'MAILGUN_API_KEY': 'test-mailgun-api-key',
+                'ANTHROPIC_API_KEY': 'test-anthropic-api-key',
+                'OPENAI_API_KEY': 'test-openai-api-key',
+            }
+        )
+        return env
+
+    def test_test_settings_import_without_external_service_secrets(self):
+        env = self._settings_env()
         for key in (
             'MAILGUN_DOMAIN',
             'MAILGUN_API_KEY',
@@ -25,6 +39,47 @@ class TestSettingsImportTests(unittest.TestCase):
                     'assert settings.ANYMAIL["MAILGUN_API_KEY"] == "test-mailgun-api-key"; '
                     'assert settings.OPENAI_API_KEY == ""; '
                     'assert settings.ANTHROPIC_API_KEY == ""'
+                ),
+            ],
+            check=True,
+            cwd=os.getcwd(),
+            env=env,
+        )
+
+    def test_production_settings_require_secret_key(self):
+        env = self._settings_env()
+        env['IS_PRODUCTION'] = 'true'
+        env.pop('SECRET_KEY', None)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                '-c',
+                'import bahk.settings',
+            ],
+            cwd=os.getcwd(),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('SECRET_KEY must be configured in production', result.stderr)
+
+    def test_default_refresh_token_lifetime_is_bounded(self):
+        env = self._settings_env()
+        env.pop('SECRET_KEY', None)
+        env.pop('JWT_REFRESH_TOKEN_LIFETIME_DAYS', None)
+
+        subprocess.run(
+            [
+                sys.executable,
+                '-c',
+                dedent(
+                    """
+                    import bahk.settings as settings
+                    assert settings.SIMPLE_JWT['REFRESH_TOKEN_LIFETIME'].days == 30
+                    """
                 ),
             ],
             check=True,


### PR DESCRIPTION
## Summary
- return a generic password-reset response for existing and unknown emails while preserving malformed email validation
- require SECRET_KEY in production and bound the default JWT refresh lifetime to 30 days, configurable with JWT_REFRESH_TOKEN_LIFETIME_DAYS
- log JWT login audit write failures without blocking token issuance

## Clawpatch
- fnd_sig-feat-library-129f95bc51-32ed_a7f0fce62e: fixed
- fnd_sig-feat-library-ba626d612c-0a17_14f0e5e22e: fixed
- fnd_sig-feat-library-90559adc1c-05d2_8da04ff7d5: fixed
- fnd_sig-feat-route-b2cbadc6c9-7ea1d9_efae31a578: fixed

## Validation
- .venv/bin/python manage.py test tests.test_password_reset events.tests.test_jwt_login_tracking tests.test_settings_import --settings=tests.test_settings --noinput
- scripts/crabbox-validate.sh ci
- clawpatch revalidate --include-dirty for all four findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication secrets, token lifetimes, and password-reset behavior; existing refresh tokens may expire sooner and clients must tolerate the new reset messaging.
> 
> **Overview**
> This PR tightens **auth and deployment security** in several targeted areas.
> 
> **Password reset** no longer reveals whether an email is registered: the serializer stops rejecting unknown addresses, and the API always returns the same generic 200 message (malformed emails still 400). Reset emails are only sent when a user exists.
> 
> **Production configuration** now fails fast if `SECRET_KEY` is missing when `IS_PRODUCTION` is true; non-production can still fall back to the insecure dev key. **JWT refresh tokens** default to **30 days** instead of ~100 years, overridable via `JWT_REFRESH_TOKEN_LIFETIME_DAYS`.
> 
> **JWT login** still issues tokens when audit/event writes fail, but failures are **logged** (`logger.exception` on `bahk.urls`) instead of being swallowed silently; tests cover that behavior.
> 
> Settings import tests were extended to assert production `SECRET_KEY` enforcement and the bounded refresh lifetime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be96e6289797d0333d3b0a00f893fb8da3b1bd81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->