### PR TITLE
fix: close remaining security findings

### DIFF
--- a/bahk/urls.py
+++ b/bahk/urls.py
@@ -18,8 +18,10 @@ import logging
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.admin.views.decorators import staff_member_required
 from django.urls import include, path
 from django.views.generic import RedirectView
+from markdownx.views import ImageUploadView, MarkdownifyView
 #Apply Simple JSON Web Token (SimpleJWT) Authentication Routes to the API
 from rest_framework_simplejwt.views import (
     TokenRefreshView,
@@ -112,7 +114,16 @@ urlpatterns = [
     path('api/token/', TrackingTokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 
-    path('markdownx/', include('markdownx.urls')),  # Include markdownx URLs
+    path(
+        'markdownx/upload/',
+        staff_member_required(ImageUploadView.as_view()),
+        name='markdownx_upload',
+    ),
+    path(
+        'markdownx/markdownify/',
+        staff_member_required(MarkdownifyView.as_view()),
+        name='markdownx_markdownify',
+    ),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 # add account authentication urls

--- a/icons/tests.py
+++ b/icons/tests.py
@@ -347,6 +347,30 @@ class IconFeedbackAPITests(APITestCase):
         feedback = IconFeedback.objects.first()
         self.assertIsNone(feedback.ip_address)
 
+    def test_malformed_ip_is_not_stored(self):
+        """Test that malformed IP addresses are discarded."""
+        response = self.client.post(
+            self.feedback_url,
+            self._valid_payload(),
+            format='json',
+            REMOTE_ADDR='not.an.ip'
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        feedback = IconFeedback.objects.first()
+        self.assertIsNone(feedback.ip_address)
+
+    def test_proxy_style_ip_list_is_not_stored(self):
+        """Test that comma-separated proxy-style address lists are discarded."""
+        response = self.client.post(
+            self.feedback_url,
+            self._valid_payload(),
+            format='json',
+            REMOTE_ADDR='203.0.113.42, 10.0.0.5'
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        feedback = IconFeedback.objects.first()
+        self.assertIsNone(feedback.ip_address)
+
     def test_user_agent_captured(self):
         """Test that HTTP_USER_AGENT is captured on submission."""
         response = self.client.post(

--- a/icons/views.py
+++ b/icons/views.py
@@ -24,6 +24,30 @@ class IsAdminOrReadOnly(BasePermission):
 logger = logging.getLogger(__name__)
 
 
+def anonymize_ip_address(raw_ip):
+    """Anonymize a valid client IP address, or discard invalid/proxy-style values."""
+    if not raw_ip:
+        return None
+
+    raw_ip = raw_ip.strip()
+    if ',' in raw_ip:
+        return None
+
+    try:
+        addr = ipaddress.ip_address(raw_ip)
+    except ValueError:
+        return None
+
+    if addr.version == 4:
+        network = ipaddress.ip_network(f"{addr}/24", strict=False)
+        return str(network.network_address)
+
+    masked = ipaddress.IPv6Address(
+        int(addr) & 0xffff_ffff_ffff_0000_0000_0000_0000_0000
+    )
+    return str(masked)
+
+
 class IconPagination(PageNumberPagination):
     """Larger page size for icon grid browsing."""
     page_size = 15
@@ -538,24 +562,7 @@ class IconFeedbackCreateView(views.APIView):
         tags_string = ', '.join(tag.name for tag in icon.tags.all())
 
         # 4. Anonymize IP
-        raw_ip = request.META.get('REMOTE_ADDR', '')
-        anonymized_ip = None
-        if raw_ip:
-            if '.' in raw_ip:
-                # IPv4 — zero out last octet
-                parts = raw_ip.split('.')
-                parts[-1] = '0'
-                anonymized_ip = '.'.join(parts)
-            else:
-                # IPv6 — preserve /48 prefix, zero out the rest
-                try:
-                    addr = ipaddress.IPv6Address(raw_ip)
-                    masked = ipaddress.IPv6Address(
-                        int(addr) & 0xffff_ffff_ffff_0000_0000_0000_0000_0000
-                    )
-                    anonymized_ip = str(masked)
-                except (ipaddress.AddressValueError, ValueError):
-                    anonymized_ip = raw_ip
+        anonymized_ip = anonymize_ip_address(request.META.get('REMOTE_ADDR', ''))
 
         # 5. Create feedback record
         IconFeedback.objects.create(

--- a/tests/test_markdownx_security.py
+++ b/tests/test_markdownx_security.py
@@ -1,0 +1,30 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+
+class MarkdownXSecurityTests(TestCase):
+    def test_anonymous_users_cannot_access_markdownx_upload(self):
+        response = self.client.post(reverse('markdownx_upload'))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/admin/login/', response['Location'])
+
+    def test_anonymous_users_cannot_access_markdownx_markdownify(self):
+        response = self.client.post(reverse('markdownx_markdownify'), {'content': '**test**'})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/admin/login/', response['Location'])
+
+    def test_staff_users_can_access_markdownx_markdownify(self):
+        staff_user = User.objects.create_user(
+            username='editor@example.com',
+            email='editor@example.com',
+            password='testpass123',
+            is_staff=True,
+        )
+        self.client.force_login(staff_user)
+
+        response = self.client.post(reverse('markdownx_markdownify'), {'content': '**test**'})
+
+        self.assertNotEqual(response.status_code, 302)


### PR DESCRIPTION
## Summary
- replace the raw MarkdownX URL include with explicit staff-protected upload and markdownify endpoints
- add route tests proving anonymous users are redirected and staff users can still use MarkdownX markdownify
- validate feedback REMOTE_ADDR values with ipaddress before anonymizing; discard malformed and proxy-style values

## Clawpatch
- fnd_sig-feat-route-ee541bd261-1766f3_50ccb9431a: fixed by revalidation
- fnd_sig-feat-library-8552b82b12-614c_60cd3df582: fixed by revalidation
- security report now shows 0 open findings

## Validation
- .venv/bin/ruff check bahk/urls.py icons/views.py icons/tests.py tests/test_markdownx_security.py
- .venv/bin/python manage.py test tests.test_markdownx_security icons.tests.IconFeedbackAPITests --settings=tests.test_settings --noinput
- scripts/crabbox-validate.sh ci
- clawpatch revalidate for both A3 findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication boundaries for MarkdownX upload/markdownify and alter what client IPs are stored on a public feedback endpoint; behavior is covered by new tests but affects privacy and admin-only access paths.
> 
> **Overview**
> Locks down **MarkdownX** by replacing the blanket `markdownx.urls` include with explicit **`markdownx/upload/`** and **`markdownx/markdownify/`** routes wrapped in **`staff_member_required`**, so anonymous clients are redirected to admin login instead of hitting upload/markdownify openly. New **`tests/test_markdownx_security.py`** asserts that behavior and that staff can still use markdownify.
> 
> Icon feedback IP handling moves into **`anonymize_ip_address`**, which parses addresses with **`ipaddress`**, anonymizes IPv4 to the **/24 network** and IPv6 with the existing **/48-style mask**, and **drops** empty, malformed, or **comma-separated proxy-style** `REMOTE_ADDR` values instead of storing them. Matching API tests cover those rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b580c4b8f8507864f776a1c968ce6e61a91a6e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->