### PR TITLE
fix: close concurrency clawpatch findings

### DIFF
--- a/hub/tests/test_reading_context.py
+++ b/hub/tests/test_reading_context.py
@@ -208,6 +208,15 @@ class FeedbackEndpointTests(APITestCase):
         self.assertEqual(self.context.thumbs_up, 1)
         self.assertEqual(self.context.thumbs_down, 0)
 
+    def test_feedback_endpoint_up_preserves_multiple_votes(self):
+        first_response = self.client.post(self.url, {"feedback_type": "up"}, format="json")
+        second_response = self.client.post(self.url, {"feedback_type": "up"}, format="json")
+
+        self.assertEqual(first_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(second_response.status_code, status.HTTP_200_OK)
+        self.context.refresh_from_db()
+        self.assertEqual(self.context.thumbs_up, 2)
+
     @patch("hub.views.readings.generate_reading_context_task.delay")
     def test_feedback_endpoint_down_triggers_regeneration(self, mock_delay):
         # Start with one down vote

--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime
 
 from django.conf import settings
+from django.db.models import F
 from django.shortcuts import get_object_or_404
 from django.utils.translation import activate, get_language_from_request
 from rest_framework import generics, status
@@ -284,18 +285,21 @@ class ReadingContextFeedbackView(APIView):
 
         feedback_type = request.data.get("feedback_type")
         if feedback_type == "up":
-            active_context.thumbs_up += 1
-            active_context.save(update_fields=["thumbs_up"])
+            active_context.__class__.objects.filter(pk=active_context.pk).update(
+                thumbs_up=F("thumbs_up") + 1
+            )
             return Response({"status": "success", "regenerate": False})
         elif feedback_type == "down":
-            active_context.thumbs_down += 1
+            active_context.__class__.objects.filter(pk=active_context.pk).update(
+                thumbs_down=F("thumbs_down") + 1
+            )
+            active_context.refresh_from_db(fields=["thumbs_down"])
             threshold = getattr(settings, "READING_CONTEXT_REGENERATION_THRESHOLD", 5)
             regenerate = False
             if active_context.thumbs_down >= threshold:
                 regenerate = True
                 # Force regeneration via Celery task
                 generate_reading_context_task.delay(reading.id, force_regeneration=True)
-            active_context.save(update_fields=["thumbs_down"])
             return Response({"status": "success", "regenerate": regenerate})
         else:
             return Response(

--- a/notifications/management/commands/retry_failed_emails.py
+++ b/notifications/management/commands/retry_failed_emails.py
@@ -7,6 +7,15 @@ from notifications.tasks import send_promo_email_task
 class Command(BaseCommand):
     help = 'Retry sending failed promotional emails'
 
+    def claim_failed_promo(self, promo_id):
+        updated = PromoEmail.objects.filter(
+            id=promo_id,
+            status=PromoEmail.FAILED,
+        ).update(status=PromoEmail.DRAFT)
+        if updated != 1:
+            return None
+        return PromoEmail.objects.get(id=promo_id)
+
     def add_arguments(self, parser):
         parser.add_argument(
             '--promo-id',
@@ -37,11 +46,17 @@ class Command(BaseCommand):
                     self.stdout.write(f"Current status: {promo.status}")
                     self.stdout.write(f"Recipients: {promo.recipient_count()}")
                 else:
-                    self.stdout.write(f"Retrying PromoEmail {promo.id}: {promo.title}")
-                    promo.status = PromoEmail.DRAFT
-                    promo.save()
-                    send_promo_email_task.delay(promo.id)
-                    self.stdout.write(self.style.SUCCESS(f"Successfully queued retry for {promo.title}"))
+                    claimed_promo = self.claim_failed_promo(promo.id)
+                    if claimed_promo is None:
+                        self.stdout.write(
+                            self.style.ERROR(
+                                f"PromoEmail {promo.id} was already claimed or is no longer failed"
+                            )
+                        )
+                        return
+                    self.stdout.write(f"Retrying PromoEmail {claimed_promo.id}: {claimed_promo.title}")
+                    send_promo_email_task.delay(claimed_promo.id)
+                    self.stdout.write(self.style.SUCCESS(f"Successfully queued retry for {claimed_promo.title}"))
             except PromoEmail.DoesNotExist:
                 self.stdout.write(self.style.ERROR(f"PromoEmail with ID {options['promo_id']} not found"))
         else:
@@ -58,9 +73,10 @@ class Command(BaseCommand):
                     self.stdout.write(f"  - {promo.id}: {promo.title} ({promo.recipient_count()} recipients)")
             else:
                 count = 0
-                for promo in failed_emails:
-                    promo.status = PromoEmail.DRAFT
-                    promo.save()
+                for promo_id in failed_emails.values_list('id', flat=True):
+                    promo = self.claim_failed_promo(promo_id)
+                    if promo is None:
+                        continue
                     send_promo_email_task.delay(promo.id)
                     count += 1
                     self.stdout.write(f"Queued retry for: {promo.title}")

--- a/notifications/tests/test_retry_failed_emails_command.py
+++ b/notifications/tests/test_retry_failed_emails_command.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from django.core.management import call_command
 from django.test import TestCase
 
+from notifications.management.commands.retry_failed_emails import Command
 from notifications.models import PromoEmail
 
 
@@ -48,3 +49,31 @@ class RetryFailedEmailsCommandTests(TestCase):
         self.assertEqual(promo.status, PromoEmail.DRAFT)
         mock_delay.assert_called_once_with(promo.id)
         self.assertIn("Successfully queued retry", stdout.getvalue())
+
+    @patch("notifications.management.commands.retry_failed_emails.Command.claim_failed_promo")
+    @patch("notifications.management.commands.retry_failed_emails.send_promo_email_task.delay")
+    def test_specific_retry_skips_already_claimed_failed_promo(self, mock_delay, mock_claim):
+        promo = self.create_promo(PromoEmail.FAILED)
+        mock_claim.return_value = None
+        stdout = StringIO()
+
+        call_command("retry_failed_emails", promo_id=promo.id, stdout=stdout)
+
+        mock_claim.assert_called_once_with(promo.id)
+        mock_delay.assert_not_called()
+        self.assertIn("already claimed", stdout.getvalue())
+
+    def test_claim_failed_promo_only_transitions_failed_rows(self):
+        failed_promo = self.create_promo(PromoEmail.FAILED)
+        sent_promo = self.create_promo(PromoEmail.SENT)
+        command = Command()
+
+        claimed = command.claim_failed_promo(failed_promo.id)
+        skipped = command.claim_failed_promo(sent_promo.id)
+
+        failed_promo.refresh_from_db()
+        sent_promo.refresh_from_db()
+        self.assertEqual(claimed.id, failed_promo.id)
+        self.assertEqual(failed_promo.status, PromoEmail.DRAFT)
+        self.assertIsNone(skipped)
+        self.assertEqual(sent_promo.status, PromoEmail.SENT)

--- a/prayers/views.py
+++ b/prayers/views.py
@@ -1,5 +1,6 @@
 """Views for prayers app."""
 from django.db.models import Q
+from django.db import transaction
 from django.utils.translation import activate, get_language_from_request
 from rest_framework import generics
 from rest_framework.permissions import AllowAny
@@ -433,22 +434,18 @@ class PrayerRequestViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
-        # Check if already accepted
-        if PrayerRequestAcceptance.objects.filter(
-            prayer_request=prayer_request,
-            user=request.user
-        ).exists():
+        with transaction.atomic():
+            acceptance, created = PrayerRequestAcceptance.objects.get_or_create(
+                prayer_request=prayer_request,
+                user=request.user,
+                defaults={'counts_for_milestones': True},
+            )
+
+        if not created:
             return Response(
                 {'detail': 'You have already accepted this prayer request.'},
                 status=status.HTTP_400_BAD_REQUEST
             )
-
-        # Create acceptance
-        acceptance = PrayerRequestAcceptance.objects.create(
-            prayer_request=prayer_request,
-            user=request.user,
-            counts_for_milestones=True
-        )
 
         # Create event
         Event.create_event(

--- a/tests/test_prayer_requests.py
+++ b/tests/test_prayer_requests.py
@@ -173,6 +173,32 @@ class PrayerRequestAPITests(BaseAPITestCase):
         self.assertEqual(milestone_qs.count(), 1)
 
     @tag('integration')
+    def test_duplicate_accept_returns_validation_response(self):
+        """Duplicate accepts should return the existing client error, not a server error."""
+        intercessor = self.create_user(email='duplicate-pray@example.com')
+        requester = self.create_user(email='duplicate-requester@example.com')
+        self.authenticate(intercessor)
+        prayer_request = self.create_prayer_request(requester, title='Community need')
+        accept_url = f'/api/prayer-requests/{prayer_request.id}/accept/'
+
+        first_response = self.client.post(accept_url)
+        second_response = self.client.post(accept_url)
+
+        self.assertEqual(first_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(second_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            second_response.data,
+            {'detail': 'You have already accepted this prayer request.'},
+        )
+        self.assertEqual(
+            PrayerRequestAcceptance.objects.filter(
+                prayer_request=prayer_request,
+                user=intercessor,
+            ).count(),
+            1,
+        )
+
+    @tag('integration')
     def test_mark_prayed_requires_acceptance_and_prevents_duplicates(self):
         """Users must accept a request before logging prayer, and can only log once per day."""
         requester = self.create_user(email='requester2@example.com')


### PR DESCRIPTION
## Summary
- use atomic F() updates for reading-context feedback counters
- claim failed promo retries with conditional FAILED -> DRAFT updates before queueing send tasks
- use get_or_create in prayer request acceptances so duplicate accepts return the existing client error instead of racing into IntegrityError

## Clawpatch
- fnd_sig-feat-library-ba626d612c-21c6_decc74a139: fixed by revalidation
- fnd_sig-feat-library-71509af936-f0a0_9ff7599c46: fixed by revalidation
- fnd_sig-feat-library-c60ee9a366-2a39_77cf563c18: fixed by revalidation

## Validation
- .venv/bin/ruff check hub/views/readings.py hub/tests/test_reading_context.py notifications/management/commands/retry_failed_emails.py notifications/tests/test_retry_failed_emails_command.py prayers/views.py tests/test_prayer_requests.py
- .venv/bin/python manage.py test hub.tests.test_reading_context.FeedbackEndpointTests notifications.tests.test_retry_failed_emails_command tests.test_prayer_requests.PrayerRequestAPITests.test_duplicate_accept_returns_validation_response --settings=tests.test_settings --noinput
- scripts/crabbox-validate.sh ci
- clawpatch revalidate for all three concurrency findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing write paths (feedback counts, acceptances) and promo send queueing; behavior is intentionally stricter but wrong claims could skip retries if misused.
> 
> **Overview**
> Hardens three race-prone paths so concurrent requests don’t lose votes, double-queue emails, or 500 on duplicate prayer accepts.
> 
> **Reading context feedback** now increments `thumbs_up` / `thumbs_down` with database-level `F()` updates instead of load-increment-save. Down-vote regeneration still reads the refreshed count before comparing to `READING_CONTEXT_REGENERATION_THRESHOLD`. A test confirms repeated “up” votes accumulate correctly.
> 
> **Failed promo email retries** (`retry_failed_emails`) claim a row by updating only when `status` is still `FAILED` → `DRAFT`; if another worker already claimed it, the command skips queueing and reports that. Bulk retry iterates IDs through the same claim helper.
> 
> **Prayer request accept** uses `get_or_create` inside `transaction.atomic()` so a second accept from the same user returns the existing **400** “already accepted” response instead of racing into an integrity error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79cd96a19f8a356b86399fd1a36d0667824d3897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->