### PR TITLE
fix: remove duplicate router URL inclusion

### DIFF
--- a/hub/tests/test_urlconf.py
+++ b/hub/tests/test_urlconf.py
@@ -1,0 +1,22 @@
+from django.test import SimpleTestCase
+from django.urls.resolvers import URLPattern, URLResolver
+
+from hub.urls import urlpatterns
+
+
+def _url_routes(patterns):
+    routes = []
+    for pattern in patterns:
+        if isinstance(pattern, URLPattern):
+            routes.append((pattern.name, str(pattern.pattern)))
+        elif isinstance(pattern, URLResolver):
+            routes.extend(_url_routes(pattern.url_patterns))
+    return routes
+
+
+class HubURLConfTests(SimpleTestCase):
+    def test_router_urls_are_included_once(self):
+        routes = _url_routes(urlpatterns)
+
+        self.assertEqual(routes.count(('user-list', '^users/$')), 1)
+        self.assertEqual(routes.count(('group-list', '^groups/$')), 1)

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -120,5 +120,3 @@ urlpatterns = [
         name="hub_reading_compare_prompts",
     ),
 ]
-
-urlpatterns += router.urls


### PR DESCRIPTION
## Summary
- remove the duplicate DRF router URL inclusion from `hub.urls`
- add URLConf coverage proving the base router routes are registered once

## Clawpatch
- fixes `fnd_sig-feat-route-1b3bad763c-f0eec0_a253bf5017`

## Validation
- `.venv/bin/ruff check hub/urls.py hub/tests/test_urlconf.py`
- `.venv/bin/python manage.py test hub.tests.test_urlconf --settings=tests.test_settings --noinput`
- `git diff --check && scripts/crabbox-validate.sh ci` (1,071 tests)
- `clawpatch revalidate --include-dirty --finding fnd_sig-feat-route-1b3bad763c-f0eec0_a253bf5017` (fixed)
