### PR TITLE
fix: disambiguate legacy fast routes

### DIFF
--- a/hub/tests/test_admin_compare_reading_prompts.py
+++ b/hub/tests/test_admin_compare_reading_prompts.py
@@ -48,13 +48,13 @@ class CompareReadingPromptsRouteTests(TestCase):
         self.client.force_login(self.admin_user)
 
         url = reverse("hub_reading_compare_prompts", args=[self.reading.pk])
-        mounted_url = f"/hub/hub/reading/{self.reading.pk}/compare-prompts/"
+        mounted_url = f"/hub/reading/{self.reading.pk}/compare-prompts/"
         response = self.client.get(url)
         mounted_response = self.client.get(mounted_url)
         match = resolve(url)
         mounted_match = resolve(mounted_url)
 
-        self.assertEqual(url, f"/api/hub/reading/{self.reading.pk}/compare-prompts/")
+        self.assertEqual(url, f"/api/reading/{self.reading.pk}/compare-prompts/")
         self.assertEqual(match.func, compare_reading_prompts)
         self.assertEqual(match.url_name, "hub_reading_compare_prompts")
         self.assertEqual(match.kwargs["reading_id"], self.reading.pk)

--- a/hub/tests/test_urlconf.py
+++ b/hub/tests/test_urlconf.py
@@ -1,4 +1,5 @@
 from django.test import SimpleTestCase
+from django.urls import resolve, reverse
 from django.urls.resolvers import URLPattern, URLResolver
 
 from hub.urls import urlpatterns
@@ -20,3 +21,9 @@ class HubURLConfTests(SimpleTestCase):
 
         self.assertEqual(routes.count(('user-list', '^users/$')), 1)
         self.assertEqual(routes.count(('group-list', '^groups/$')), 1)
+
+    def test_legacy_fast_routes_have_distinct_names(self):
+        self.assertEqual(reverse("fast_on_date"), "/api/user/fasts/")
+        self.assertEqual(reverse("fast_on_date_without_user"), "/api/fast/")
+        self.assertEqual(resolve("/api/user/fasts/").url_name, "fast_on_date")
+        self.assertEqual(resolve("/api/fast/").url_name, "fast_on_date_without_user")

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -75,7 +75,7 @@ urlpatterns = [
 
     # TODO: Remove these legacy endpoints after frontend is updated
     path('user/fasts/', FastOnDate.as_view(), name="fast_on_date"),
-    path("fast/", FastOnDateWithoutUser.as_view(), name="fast_on_date"),
+    path("fast/", FastOnDateWithoutUser.as_view(), name="fast_on_date_without_user"),
    
     # Day endpoints
     path('fasts/<int:fast_id>/days/', FastDaysListView.as_view(), name='fast-days-list'),
@@ -115,7 +115,7 @@ urlpatterns = [
 
     # Admin endpoints
     path(
-        "hub/reading/<int:reading_id>/compare-prompts/",
+        "reading/<int:reading_id>/compare-prompts/",
         compare_reading_prompts,
         name="hub_reading_compare_prompts",
     ),


### PR DESCRIPTION
## Summary
- remove the extra `hub/` segment from the compare-prompts route inside `hub.urls`
- give the no-user legacy fast route its own `fast_on_date_without_user` URL name
- add URLConf coverage for distinct legacy fast route names and updated compare-prompts paths

## Clawpatch
- fixes `fnd_sig-feat-route-7839abfd8a-562610_07d314c7ee`
- fixes `fnd_sig-feat-route-b203b71d06-b87bbe_b97f556468`
- fixes `fnd_sig-feat-route-07f3abca53-67d484_a079d47e6d`
- fixes `fnd_sig-feat-route-c0305b6b1c-cece61_37d1201372`
- fixes `fnd_sig-feat-route-1b3bad763c-c7e392_ceafdee6d2`
- fixes `fnd_sig-feat-route-a05bf1baae-ba8097_413097321e`

## Validation
- `.venv/bin/ruff check hub/urls.py hub/tests/test_urlconf.py hub/tests/test_admin_compare_reading_prompts.py`
- `.venv/bin/python manage.py test hub.tests.test_urlconf hub.tests.test_admin_compare_reading_prompts tests.integration.test_endpoints.FastOnDateEndpointTests tests.integration.test_auth.AuthenticationTest --settings=tests.test_settings --noinput`
- `clawpatch revalidate --include-dirty --category api-contract --status open` (5 fixed; plus prior single revalidate fixed)
- `git diff --check && scripts/crabbox-validate.sh ci` (1,072 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing and URL-name fixes only; low risk if clients already use path-based URLs, but anything reversing the old duplicate `fast_on_date` for `/api/fast/` must update.
> 
> **Overview**
> Fixes **duplicate Django URL names** and a **double `hub/` segment** on API-mounted routes in `hub.urls`.
> 
> The legacy no-user fast endpoint at `/api/fast/` is renamed from `fast_on_date` to **`fast_on_date_without_user`**, so it no longer collides with `/api/user/fasts/` (`fast_on_date`). Callers that used `reverse("fast_on_date")` for the anonymous route must switch to the new name.
> 
> The staff **compare-prompts** route pattern moves from `hub/reading/<id>/compare-prompts/` to **`reading/<id>/compare-prompts/`**, so under the `/api/` include the canonical path is **`/api/reading/...`** instead of `/api/hub/reading/...`. The URL name `hub_reading_compare_prompts` is unchanged.
> 
> Tests in `test_urlconf.py` and `test_admin_compare_reading_prompts.py` assert the new names and paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93ef133581c193f23781532b4da6fb0bda5c779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->