### PR TITLE
fix: preserve icon save API contract

### DIFF
--- a/icons/models.py
+++ b/icons/models.py
@@ -59,16 +59,20 @@ class Icon(models.Model):
     def __str__(self):
         return self.title
     
-    def save(self, **kwargs):
+    def save(self, *args, **kwargs):
         """Save method with thumbnail caching logic."""
+        update_fields = kwargs.get('update_fields')
+        if len(args) >= 4:
+            update_fields = args[3]
+
         # First check if this is a new instance or if the image field has changed
         is_new_image = (
             self._state.adding
-            or 'image' in kwargs.get('update_fields', [])
+            or 'image' in (update_fields or [])
             or (not self._state.adding and self.tracker.has_changed('image'))
         )
         
-        super().save(**kwargs)
+        super().save(*args, **kwargs)
         
         # Handle thumbnail URL caching after the instance and image are fully saved to S3
         if self.image:

--- a/icons/tests.py
+++ b/icons/tests.py
@@ -51,6 +51,26 @@ class IconModelTests(TestCase):
         )
         
         self.assertEqual(str(icon), "Test Icon")
+
+    def test_icon_save_accepts_model_save_positional_arguments(self):
+        """Test direct compatibility with Django Model.save positional args."""
+        test_image = SimpleUploadedFile(
+            name='test_icon.jpg',
+            content=b'fake image content',
+            content_type='image/jpeg'
+        )
+
+        icon = Icon.objects.create(
+            title="Test Icon",
+            church=self.church,
+            image=test_image
+        )
+
+        icon.title = "Updated Icon"
+        icon.save(False, False, None, ['title'])
+
+        icon.refresh_from_db()
+        self.assertEqual(icon.title, "Updated Icon")
     
     def test_icon_tags(self):
         """Test adding tags to an icon."""


### PR DESCRIPTION
## Summary
- update `Icon.save()` to accept and forward Django model save positional arguments
- account for positional `update_fields` when deciding whether thumbnail cache refresh is needed
- add a regression test for `icon.save(False, False, None, ['title'])`

## Clawpatch
- fixes `fnd_sig-feat-library-8552b82b12-4ea8_8ecd20201c`

## Validation
- `.venv/bin/ruff check icons/models.py icons/tests.py`
- `.venv/bin/python manage.py test icons.tests.IconModelTests --settings=tests.test_settings --noinput`
- `clawpatch revalidate --include-dirty --finding fnd_sig-feat-library-8552b82b12-4ea8_8ecd20201c`
- `git diff --check && scripts/crabbox-validate.sh ci` (1,073 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow model-layer fix with a regression test; no auth, security, or broad API surface changes.
> 
> **Overview**
> **`Icon.save()`** now matches Django’s `Model.save` signature: it accepts `*args`, forwards them to `super().save()`, and treats positional `update_fields` (4th argument) the same as the keyword when deciding whether the image changed and thumbnail cache should refresh.
> 
> A regression test covers **`icon.save(False, False, None, ['title'])`** so partial updates via positional args persist without breaking the custom save path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a6b66bebc440ebaa62fa08f8e2fc5f0641cf6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->