### PR TITLE
fix: support prayer bookmark filters

### DIFF
--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -16,6 +16,17 @@ from hub.models import DevotionalSet
 from django.utils.translation import activate, get_language_from_request
 
 
+def _get_bookmark_content_type(content_type):
+    model_name = content_type.lower()
+    if model_name == 'devotionalset':
+        return ContentType.objects.get(app_label='hub', model='devotionalset')
+    if model_name in ['devotional', 'fast', 'reading']:
+        return ContentType.objects.get(app_label='hub', model=model_name)
+    if model_name in ['prayer', 'prayerset']:
+        return ContentType.objects.get(app_label='prayers', model=model_name)
+    return ContentType.objects.get(app_label='learning_resources', model=model_name)
+
+
 class BookmarkOptimizedMixin:
     """
     Mixin to optimize bookmark queries using Redis caching.
@@ -505,14 +516,7 @@ class BookmarkListView(generics.ListAPIView):
         content_type = self.request.query_params.get('content_type')
         if content_type:
             try:
-                if content_type.lower() == 'devotionalset':
-                    ct = ContentType.objects.get(app_label='hub', model='devotionalset')
-                elif content_type.lower() in ['devotional', 'fast', 'reading']:
-                    ct = ContentType.objects.get(app_label='hub', model=content_type.lower())
-                else:
-                    ct = ContentType.objects.get(
-                        app_label='learning_resources', model=content_type.lower()
-                    )
+                ct = _get_bookmark_content_type(content_type)
                 queryset = queryset.filter(content_type=ct)
             except ContentType.DoesNotExist:
                 # Return empty queryset for invalid content types
@@ -626,16 +630,7 @@ def bookmark_delete_view(request, content_type, object_id):
     
     # Get the content type with specific error handling
     try:
-        if content_type.lower() == 'devotionalset':
-            ct = ContentType.objects.get(app_label='hub', model='devotionalset')
-        elif content_type.lower() in ['devotional', 'fast', 'reading']:
-            ct = ContentType.objects.get(app_label='hub', model=content_type.lower())
-        elif content_type.lower() in ['prayer', 'prayerset']:
-            ct = ContentType.objects.get(app_label='prayers', model=content_type.lower())
-        else:
-            ct = ContentType.objects.get(
-                app_label='learning_resources', model=content_type.lower()
-            )
+        ct = _get_bookmark_content_type(content_type)
     except ContentType.DoesNotExist:
         return Response(
             {'error': f'Invalid content type: {content_type}'}, 
@@ -721,16 +716,7 @@ def bookmark_check_view(request, content_type, object_id):
     
     # Get the content type with specific error handling
     try:
-        if content_type.lower() == 'devotionalset':
-            ct = ContentType.objects.get(app_label='hub', model='devotionalset')
-        elif content_type.lower() in ['devotional', 'fast', 'reading']:
-            ct = ContentType.objects.get(app_label='hub', model=content_type.lower())
-        elif content_type.lower() in ['prayer', 'prayerset']:
-            ct = ContentType.objects.get(app_label='prayers', model=content_type.lower())
-        else:
-            ct = ContentType.objects.get(
-                app_label='learning_resources', model=content_type.lower()
-            )
+        ct = _get_bookmark_content_type(content_type)
     except ContentType.DoesNotExist:
         return Response(
             {'error': f'Invalid content type: {content_type}'}, 

--- a/prayers/tests.py
+++ b/prayers/tests.py
@@ -685,6 +685,29 @@ class PrayerBookmarkTests(APITestCase):
         self.assertEqual(content['type'], 'prayer')
         self.assertEqual(content['title'], 'Morning Prayer')
         self.assertIn('Lord, bless this day.', content['description'])
+
+    def test_bookmark_list_filters_prayers(self):
+        """Test filtering bookmark list to prayer bookmarks."""
+        Bookmark.objects.create(
+            user=self.user,
+            content_type=ContentType.objects.get_for_model(Prayer),
+            object_id=self.prayer.id,
+            note='My favorite prayer'
+        )
+        Bookmark.objects.create(
+            user=self.user,
+            content_type=ContentType.objects.get_for_model(PrayerSet),
+            object_id=self.prayer_set.id,
+            note='Essential prayers'
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse('bookmark-list'), {'content_type': 'prayer'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['content_type_name'], 'prayer')
+        self.assertEqual(response.data['results'][0]['object_id'], self.prayer.id)
     
     def test_bookmark_list_includes_prayersets(self):
         """Test that bookmark list endpoint includes bookmarked prayer sets."""
@@ -713,6 +736,31 @@ class PrayerBookmarkTests(APITestCase):
         self.assertEqual(content['type'], 'prayerset')
         self.assertEqual(content['title'], 'Daily Prayers')
         self.assertEqual(content['description'], 'A collection of daily prayers')
+
+    def test_bookmark_list_filters_prayersets(self):
+        """Test filtering bookmark list to prayer set bookmarks."""
+        Bookmark.objects.create(
+            user=self.user,
+            content_type=ContentType.objects.get_for_model(Prayer),
+            object_id=self.prayer.id,
+            note='My favorite prayer'
+        )
+        Bookmark.objects.create(
+            user=self.user,
+            content_type=ContentType.objects.get_for_model(PrayerSet),
+            object_id=self.prayer_set.id,
+            note='Essential prayers'
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            reverse('bookmark-list'), {'content_type': 'prayerset'}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['content_type_name'], 'prayerset')
+        self.assertEqual(response.data['results'][0]['object_id'], self.prayer_set.id)
     
     def test_bookmark_requires_authentication(self):
         """Test that creating bookmarks requires authentication."""
@@ -725,4 +773,3 @@ class PrayerBookmarkTests(APITestCase):
         response = self.client.post(url, data, format='json')
         
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-


### PR DESCRIPTION
## Summary
- share bookmark content-type resolution across list/delete/check paths
- make `?content_type=prayer` and `?content_type=prayerset` filter against the `prayers` app instead of returning empty results
- add regression coverage for filtered prayer and prayer-set bookmark lists

## Clawpatch
- fixes `fnd_sig-feat-library-603013f017-c494_1caf791540`

## Validation
- `.venv/bin/ruff check learning_resources/views.py prayers/tests.py`
- `.venv/bin/python manage.py test prayers.tests.PrayerBookmarkTests --settings=tests.test_settings --noinput`
- `clawpatch revalidate --include-dirty --finding fnd_sig-feat-library-603013f017-c494_1caf791540`
- `git diff --check && scripts/crabbox-validate.sh ci` (1,075 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor plus correct ContentType mapping for bookmark list filtering; behavior change is limited to prayer-related query params and is covered by new tests.
> 
> **Overview**
> **Centralizes bookmark `ContentType` resolution** in `_get_bookmark_content_type` and uses it for bookmark **list**, **delete**, and **check** instead of duplicated branching.
> 
> **Fixes list filtering** for `?content_type=prayer` and `?content_type=prayerset`: those types now resolve to the `prayers` app (matching create/delete/check), so filtered lists return real results instead of empty sets from looking under `learning_resources`.
> 
> Adds **regression tests** in `prayers/tests.py` for prayer-only and prayer-set-only bookmark list filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c388d2c7032360ad95ce8e89814e66a03a310b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->