### PR TITLE
fix: fail regenerate commands on errors

### DIFF
--- a/hub/management/commands/regenerate_feast_contexts.py
+++ b/hub/management/commands/regenerate_feast_contexts.py
@@ -1,6 +1,6 @@
 """Regenerate feast contexts to apply new parsing logic."""
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from hub.models import Feast
 from hub.tasks import generate_feast_context_task
@@ -30,8 +30,7 @@ class Command(BaseCommand):
                 generate_feast_context_task.delay(feast.id, force_regeneration=True)
                 self.stdout.write(self.style.SUCCESS(f"✓ Queued regeneration for feast {feast.id}"))
             except Feast.DoesNotExist:
-                self.stdout.write(self.style.ERROR(f"Feast with ID {options['feast_id']} not found"))
-                return
+                raise CommandError(f"Feast with ID {options['feast_id']} not found")
         
         elif options.get("all"):
             # Regenerate for all feasts
@@ -51,7 +50,6 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS(f"\n✓ Queued regeneration for {count} feasts"))
         
         else:
-            self.stdout.write(self.style.ERROR(
+            raise CommandError(
                 "Please specify either --all to regenerate all feasts or --feast-id <ID> for a specific feast"
-            ))
-
+            )

--- a/hub/management/commands/regenerate_map.py
+++ b/hub/management/commands/regenerate_map.py
@@ -52,11 +52,11 @@ class Command(BaseCommand):
                     f'Participants: {result.get("participants")}'
                 ))
             else:
-                self.stdout.write(self.style.ERROR(
-                    f'\nMap generation failed: {result.get("message")}'
-                ))
+                raise CommandError(
+                    f'Map generation failed: {result.get("message")}'
+                )
         else:
             self.stdout.write(self.style.WARNING(
                 'Map generation is running in the background. '
                 'Check the map URL in a few minutes.'
-            )) 
+            ))

--- a/hub/tests/test_management_commands.py
+++ b/hub/tests/test_management_commands.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock, patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from hub.models import Church, Fast
+
+
+class RegenerateCommandErrorTests(TestCase):
+    def test_regenerate_feast_contexts_requires_target(self):
+        with self.assertRaisesMessage(CommandError, "Please specify either --all"):
+            call_command("regenerate_feast_contexts")
+
+    def test_regenerate_feast_contexts_missing_feast_raises(self):
+        with self.assertRaisesMessage(CommandError, "Feast with ID 999 not found"):
+            call_command("regenerate_feast_contexts", feast_id=999)
+
+    def test_regenerate_map_wait_failure_raises(self):
+        church = Church.objects.create(name="Test Church")
+        fast = Fast.objects.create(name="Test Fast", church=church)
+        task = Mock()
+        task.id = "task-1"
+        task.ready.return_value = True
+        task.get.return_value = {"status": "error", "message": "render failed"}
+
+        with patch(
+            "hub.management.commands.regenerate_map.generate_participant_map.delay",
+            return_value=task,
+        ):
+            with self.assertRaisesMessage(
+                CommandError, "Map generation failed: render failed"
+            ):
+                call_command("regenerate_map", fast.id, wait=True)


### PR DESCRIPTION
## Summary
- make `regenerate_feast_contexts` raise `CommandError` for missing target options and nonexistent feast IDs
- make waited `regenerate_map` failures raise `CommandError` instead of exiting successfully
- add command-level regression tests for non-zero failure behavior

## Clawpatch
- fixes `fnd_sig-feat-library-4ab1946284-ffad_646bce3b51`

## Validation
- `.venv/bin/ruff check hub/management/commands/regenerate_feast_contexts.py hub/management/commands/regenerate_map.py hub/tests/test_management_commands.py`
- `.venv/bin/python manage.py test hub.tests.test_management_commands --settings=tests.test_settings --noinput`
- `clawpatch revalidate --include-dirty --finding fnd_sig-feat-library-4ab1946284-ffad_646bce3b51`
- `git diff --check && scripts/crabbox-validate.sh ci` (1,076 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational CLI exit-code fixes and small test additions only; no auth, data model, or runtime API changes.
> 
> **Overview**
> **Regenerate management commands now fail with a non-zero exit code** when invoked incorrectly or when background work fails, instead of printing errors and exiting successfully.
> 
> `regenerate_feast_contexts` now raises `CommandError` when neither `--all` nor `--feast-id` is given, and when the requested feast ID does not exist. `regenerate_map` with `--wait` raises `CommandError` when the Celery task returns a non-success status, so CI and scripts can detect failures.
> 
> New tests in `hub/tests/test_management_commands.py` cover these three failure paths via `call_command` and `assertRaisesMessage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c77f618aded2dde49296f5de48714883f68029b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->