### PR TITLE
fix: ignore failed geocode cache entries

### DIFF
--- a/hub/tasks/geocoding_tasks.py
+++ b/hub/tasks/geocoding_tasks.py
@@ -157,7 +157,7 @@ def batch_geocode_profiles(self, update_all=False):
                 entry.location_text: (entry.latitude, entry.longitude) 
                 for entry in GeocodingCache.objects.filter(
                     location_text__in=normalized_locations,
-                    error_count__lt=5
+                    error_count=0
                 )
             }
             
@@ -235,4 +235,4 @@ def batch_geocode_profiles(self, update_all=False):
         return {
             "status": "error",
             "message": str(e)
-        } 
+        }

--- a/hub/tests/test_geocoding_tasks.py
+++ b/hub/tests/test_geocoding_tasks.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from hub.models import GeocodingCache
+from hub.tasks.geocoding_tasks import batch_geocode_profiles
+from tests.fixtures.test_data import TestDataFactory
+
+
+class BatchGeocodeProfilesTests(TestCase):
+    def test_failed_batch_geocode_does_not_write_zero_coordinates_to_profile(self):
+        profile = TestDataFactory.create_profile(location="Atlantis")
+
+        with patch(
+            "hub.tasks.geocoding_tasks.geocoder.batch_geocode",
+            return_value={"Atlantis": None},
+        ):
+            result = batch_geocode_profiles.apply(kwargs={"update_all": False}).get()
+
+        profile.refresh_from_db()
+        self.assertEqual(result["status"], "success")
+        self.assertIsNone(profile.latitude)
+        self.assertIsNone(profile.longitude)
+
+        cache_entry = GeocodingCache.objects.get(location_text="atlantis")
+        self.assertEqual(cache_entry.latitude, 0)
+        self.assertEqual(cache_entry.longitude, 0)
+        self.assertEqual(cache_entry.error_count, 1)
+
+    def test_failed_cache_entry_is_not_reused_as_profile_coordinates(self):
+        profile = TestDataFactory.create_profile(location="Atlantis")
+        GeocodingCache.objects.create(
+            location_text="atlantis",
+            latitude=0,
+            longitude=0,
+            error_count=1,
+        )
+
+        with patch(
+            "hub.tasks.geocoding_tasks.geocoder.batch_geocode",
+            return_value={},
+        ):
+            result = batch_geocode_profiles.apply(kwargs={"update_all": False}).get()
+
+        profile.refresh_from_db()
+        self.assertEqual(result["status"], "success")
+        self.assertIsNone(profile.latitude)
+        self.assertIsNone(profile.longitude)


### PR DESCRIPTION
## Summary
- only reuse batch geocoding cache entries with `error_count=0`
- keep failed lookups recorded, but prevent their `(0, 0)` placeholder from being written to profiles
- add regression tests for failed batch geocode results and pre-existing failed cache entries

## Clawpatch
- fixes `fnd_sig-feat-library-a41fac0e7e-6872_0dabaf6a05`

## Validation
- `.venv/bin/ruff check hub/tasks/geocoding_tasks.py hub/tests/test_geocoding_tasks.py`
- `.venv/bin/python manage.py test hub.tests.test_geocoding_tasks --settings=tests.test_settings --noinput`
- `clawpatch revalidate --include-dirty --finding fnd_sig-feat-library-a41fac0e7e-6872_0dabaf6a05`
- `git diff --check && scripts/crabbox-validate.sh ci` (1,075 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows cache reuse for batch profile updates to successful entries only, improving location data quality without touching auth or payment flows.
> 
> **Overview**
> **Batch profile geocoding** no longer treats failed lookup cache rows as valid coordinates. When loading existing `GeocodingCache` entries for a batch, the filter changes from `error_count__lt=5` to **`error_count=0`**, so only successful geocodes are reused when updating profiles.
> 
> Failed locations can still be recorded in the cache (including `(0, 0)` placeholders and incremented `error_count`), but those entries are **excluded** from the in-memory map used to set `Profile.latitude` / `Profile.longitude`. **Regression tests** cover a failed `batch_geocode` result and a pre-existing failed cache row, asserting profiles stay `null` for coordinates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db2f85b5280e306d94fcdbc04adebba55e089e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->