### PR TITLE
fix: scope bookmark cache clear

### DIFF
--- a/learning_resources/cache.py
+++ b/learning_resources/cache.py
@@ -41,6 +41,11 @@ class BookmarkCacheService:
     def _get_user_cache_pattern(cls, user_id: int) -> str:
         """Generate cache key pattern for all user bookmarks."""
         return f"{cls.CACHE_PREFIX}:user:{user_id}:ct:*"
+
+    @classmethod
+    def _get_all_cache_pattern(cls) -> str:
+        """Generate cache key pattern for all bookmark caches."""
+        return f"{cls.CACHE_PREFIX}:user:*:ct:*"
     
     @classmethod
     def get_user_bookmarks(cls, user: User, content_type: ContentType) -> Optional[Set[int]]:
@@ -204,6 +209,45 @@ class BookmarkCacheService:
         except Exception as e:
             logger.warning(f"Redis cache invalidation failed for user {user.id}: {e}")
             return False
+
+    @classmethod
+    def clear_all_bookmark_caches(cls) -> int:
+        """
+        Clear bookmark cache entries without touching unrelated cache keys.
+
+        Redis-backed deployments can delete by key pattern. Test and fallback
+        cache backends do not support pattern deletion, so they delete the
+        known bookmark key space generated from current bookmark users and
+        supported content types.
+        """
+        try:
+            if hasattr(cache, "delete_pattern"):
+                deleted_count = cache.delete_pattern(cls._get_all_cache_pattern())
+                return int(deleted_count or 0)
+
+            from learning_resources.models import Bookmark, Video, Article, Recipe
+            from hub.models import DevotionalSet, Fast, Devotional, Reading
+
+            content_types = [
+                ContentType.objects.get_for_model(Video),
+                ContentType.objects.get_for_model(Article),
+                ContentType.objects.get_for_model(Recipe),
+                ContentType.objects.get_for_model(DevotionalSet),
+                ContentType.objects.get_for_model(Fast),
+                ContentType.objects.get_for_model(Devotional),
+                ContentType.objects.get_for_model(Reading),
+            ]
+            user_ids = Bookmark.objects.values_list("user_id", flat=True).distinct()
+            cache_keys = [
+                cls._get_cache_key(user_id, content_type.id)
+                for user_id in user_ids
+                for content_type in content_types
+            ]
+            cache.delete_many(cache_keys)
+            return len(cache_keys)
+        except Exception as e:
+            logger.warning(f"Redis bookmark cache clear failed: {e}")
+            return 0
     
     @classmethod
     def preload_user_bookmarks(cls, user: User, content_type: ContentType) -> Set[int]:

--- a/learning_resources/management/commands/bookmark_cache.py
+++ b/learning_resources/management/commands/bookmark_cache.py
@@ -113,14 +113,12 @@ class Command(BaseCommand):
                     self.style.ERROR(f"❌ User {user_id} not found")
                 )
         else:
-            # Clear all bookmark caches (this is a simplified approach)
-            # In production, you might want to use Redis SCAN for pattern deletion
             try:
-                from django.core.cache import cache
-                # This clears the entire cache - use with caution
-                cache.clear()
+                cleared_count = BookmarkCacheService.clear_all_bookmark_caches()
                 self.stdout.write(
-                    self.style.WARNING("🧹 Cleared entire cache (all bookmark caches removed)")
+                    self.style.WARNING(
+                        f"🧹 Cleared bookmark cache entries ({cleared_count} keys targeted)"
+                    )
                 )
             except Exception as e:
                 self.stdout.write(

--- a/tests/unit/learning_resources/test_bookmark_cache.py
+++ b/tests/unit/learning_resources/test_bookmark_cache.py
@@ -2,6 +2,7 @@
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
+from django.core.management import call_command
 from learning_resources.models import Video, Article, Bookmark
 from learning_resources.cache import BookmarkCacheService, BookmarkCacheManager
 from tests.base import BaseTestCase
@@ -151,6 +152,25 @@ class BookmarkCacheServiceTests(BaseTestCase):
             self.user, self.article_ct
         )
         self.assertEqual(article_cached, article_bookmarks)
+
+    def test_bookmark_cache_clear_command_preserves_unrelated_cache(self):
+        """The global clear command should only remove bookmark cache keys."""
+        Bookmark.objects.create(
+            user=self.user,
+            content_type=self.video_ct,
+            object_id=self.video1.id
+        )
+        BookmarkCacheService.set_user_bookmarks(
+            self.user, self.video_ct, {self.video1.id}
+        )
+        cache.set("unrelated-cache-key", "keep-me", 3600)
+
+        call_command("bookmark_cache", "clear")
+
+        self.assertIsNone(
+            BookmarkCacheService.get_user_bookmarks(self.user, self.video_ct)
+        )
+        self.assertEqual(cache.get("unrelated-cache-key"), "keep-me")
     
     def test_preload_user_bookmarks(self):
         """Test preloading user bookmarks from database."""


### PR DESCRIPTION
## Summary
- replace bookmark_cache clear's cache.clear() with bookmark-key scoped clearing
- add Redis delete_pattern support with a safe fallback for non-pattern cache backends
- add regression coverage that unrelated cache keys survive the clear command

## Clawpatch
- Fixes fnd_sig-feat-library-49caef493d-0cbb_a4b8901108

## Validation
- scripts/crabbox-validate.sh ci (ruff + 1,074 tests)
- clawpatch revalidate --finding fnd_sig-feat-library-49caef493d-0cbb_a4b8901108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational cache-management fix with a safe non-Redis fallback; no auth or data-path changes.
> 
> **Overview**
> The **`bookmark_cache` clear** action no longer calls **`cache.clear()`**, which wiped the entire Django cache. Global clears now go through **`BookmarkCacheService.clear_all_bookmark_caches()`**, which only targets keys under the bookmark prefix.
> 
> On Redis backends that expose **`delete_pattern`**, it deletes **`bookmarks:user:*:ct:*`**. Otherwise it builds keys from distinct bookmark users and the same supported content types used for per-user invalidation, then **`delete_many`**. The management command reports how many keys were targeted.
> 
> A unit test runs **`bookmark_cache clear`** and asserts bookmark entries are gone while an unrelated cache key remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0af03b659ffd87b1be228e027c2bc535e3c5223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->