### PR TITLE
fix: close safe data loss findings

### DIFF
--- a/cleanup_test_media.py
+++ b/cleanup_test_media.py
@@ -1,6 +1,30 @@
 #!/usr/bin/env python
 """Standalone script to clean up test media files."""
 import os
+from pathlib import Path
+
+
+def _is_allowed_test_media_dir(media_dir):
+    """Return true only for the real project-local test_media directory."""
+    candidate = Path(media_dir)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+
+    expected_dir = Path.cwd().resolve() / 'test_media'
+    if candidate.is_symlink():
+        print(f"⚠️  Refusing to clean symlinked test media directory: {media_dir}")
+        return False
+
+    try:
+        resolved_candidate = candidate.resolve(strict=True)
+    except FileNotFoundError:
+        return False
+
+    if resolved_candidate != expected_dir:
+        print(f"⚠️  Refusing to clean unexpected test media path: {media_dir}")
+        return False
+
+    return candidate.is_dir()
 
 
 def cleanup_test_media():
@@ -13,7 +37,7 @@ def cleanup_test_media():
     
     cleaned = False
     for media_dir in test_media_dirs:
-        if os.path.exists(media_dir) and 'test_media' in media_dir:
+        if os.path.exists(media_dir) and _is_allowed_test_media_dir(media_dir):
             try:
                 # Instead of removing the entire directory, remove its contents
                 for root, dirs, files in os.walk(media_dir, topdown=False):

--- a/hub/management/commands/regenerate_map.py
+++ b/hub/management/commands/regenerate_map.py
@@ -2,7 +2,7 @@
 Management command to regenerate a participant map for a specific fast.
 """
 from django.core.management.base import BaseCommand, CommandError
-from hub.models import Fast, FastParticipantMap
+from hub.models import Fast
 from hub.tasks import generate_participant_map
 import time
 
@@ -22,11 +22,6 @@ class Command(BaseCommand):
             fast = Fast.objects.get(id=fast_id)
         except Fast.DoesNotExist:
             raise CommandError(f'Fast with ID {fast_id} does not exist')
-        
-        # Delete existing map if it exists
-        FastParticipantMap.objects.filter(fast=fast).delete()
-        
-        self.stdout.write(self.style.SUCCESS(f'Deleted existing map for fast "{fast}"'))
         
         # Trigger map generation
         task = generate_participant_map.delay(fast_id)

--- a/hub/management/commands/seed_multilingual_data.py
+++ b/hub/management/commands/seed_multilingual_data.py
@@ -14,13 +14,17 @@ class Command(BaseCommand):
 
         church, _ = Church.objects.get_or_create(name="Armenian Apostolic Church")
 
-        # Create Fast with translations
-        fast = Fast.objects.create(
+        # Create or update Fast with translations
+        fast, _ = Fast.objects.update_or_create(
             name="Great Lent",
-            description="A period of fasting and prayer before Easter.",
-            culmination_feast="Easter",
-            culmination_feast_date=timezone.now().date() + timezone.timedelta(days=40),
             church=church,
+            defaults={
+                "description": "A period of fasting and prayer before Easter.",
+                "culmination_feast": "Easter",
+                "culmination_feast_date": (
+                    timezone.now().date() + timezone.timedelta(days=40)
+                ),
+            },
         )
         # Armenian translations
         fast.name_hy = "Մեծ Պահք"
@@ -30,78 +34,88 @@ class Command(BaseCommand):
 
         # Create days
         base_date = timezone.now().date()
-        day1 = Day.objects.create(date=base_date, fast=fast, church=church)
+        day1, _ = Day.objects.get_or_create(date=base_date, fast=fast, church=church)
         fast.save(update_fields=["year"])
 
         # DevotionalSet with translations
-        dset = DevotionalSet.objects.create(
+        dset, _ = DevotionalSet.objects.update_or_create(
             title="Daily Devotionals",
-            description="Short daily reflections",
             fast=fast,
+            defaults={"description": "Short daily reflections"},
         )
         dset.title_hy = "Օրական Նվիրումներ"
         dset.description_hy = "Կարճ ամենօրյա խորհրդածություններ"
         dset.save()
 
         # Videos EN and HY
-        video_en = Video.objects.create(
-            title="Day 1 Reflection",
-            description="Introduction to the fast",
+        video_en, _ = Video.objects.update_or_create(
             category='devotional',
             language_code='en',
+            defaults={
+                "title": "Day 1 Reflection",
+                "description": "Introduction to the fast",
+            },
         )
         video_en.title_hy = "Օր 1 Խորհրդածություն"
         video_en.description_hy = "Ներածություն պահքին"
         video_en.save()
 
-        video_hy = Video.objects.create(
-            title="Օր 1 Խորհրդածություն",
-            description="Ներածություն պահքին (HY)",
+        video_hy, _ = Video.objects.update_or_create(
             category='devotional',
             language_code='hy',
+            defaults={
+                "title": "Օր 1 Խորհրդածություն",
+                "description": "Ներածություն պահքին (HY)",
+            },
         )
         video_hy.title_en = "Day 1 Reflection (HY)"
         video_hy.description_en = "Introduction to the fast"
         video_hy.save()
 
         # Devotionals EN and HY
-        devo_en = Devotional.objects.create(
+        devo_en, _ = Devotional.objects.update_or_create(
             day=day1,
-            description="Blessed are those who fast with a pure heart.",
-            video=video_en,
             order=1,
             language_code='en',
+            defaults={
+                "description": "Blessed are those who fast with a pure heart.",
+                "video": video_en,
+            },
         )
         devo_en.description_hy = "Երափակված են նրանք, ովքեր պահք են պահում մաքուր սրտով։"
         devo_en.save()
 
-        devo_hy = Devotional.objects.create(
+        devo_hy, _ = Devotional.objects.update_or_create(
             day=day1,
-            description="Երափակված են նրանք, ովքեր պահք են պահում մաքուր սրտով։",
-            video=video_hy,
             order=1,
             language_code='hy',
+            defaults={
+                "description": "Երափակված են նրանք, ովքեր պահք են պահում մաքուր սրտով։",
+                "video": video_hy,
+            },
         )
         devo_hy.description_en = "Blessed are those who fast with a pure heart."
         devo_hy.save()
 
         # Article with translations
-        article = Article.objects.create(
+        article, _ = Article.objects.update_or_create(
             title="Fasting Basics",
-            body="Markdown: Fasting is a spiritual discipline...",
+            defaults={"body": "Markdown: Fasting is a spiritual discipline..."},
         )
         article.title_hy = "Պահքի հիմունքներ"
         article.body_hy = "Markdown: Պահքն հոգևոր կարգապահություն է..."
         article.save()
 
         # Recipe with translations
-        recipe = Recipe.objects.create(
+        recipe, _ = Recipe.objects.update_or_create(
             title="Lentil Soup",
-            description="A hearty soup.",
-            time_required="30 minutes",
-            serves="4",
-            ingredients="- Lentils\n- Onion\n- Water",
-            directions="Boil and season.",
+            defaults={
+                "description": "A hearty soup.",
+                "time_required": "30 minutes",
+                "serves": "4",
+                "ingredients": "- Lentils\n- Onion\n- Water",
+                "directions": "Boil and season.",
+            },
         )
         recipe.title_hy = "Ոսպի ապուր"
         recipe.description_hy = "Հագեցած ապուր։"
@@ -112,10 +126,12 @@ class Command(BaseCommand):
         recipe.save()
 
         # Announcement and Activity Feed with translations
-        announcement = Announcement.objects.create(
+        announcement, _ = Announcement.objects.update_or_create(
             title="Welcome to Great Lent",
-            description="Join us in prayer and fasting.",
-            status='published',
+            defaults={
+                "description": "Join us in prayer and fasting.",
+                "status": 'published',
+            },
         )
         announcement.title_hy = "Բարի գալուստ Մեծ Պահք"
         announcement.description_hy = "Միացե՛ք մեզ աղոթքի և պահքի մեջ։"

--- a/hub/management/commands/seed_multilingual_data.py
+++ b/hub/management/commands/seed_multilingual_data.py
@@ -1,9 +1,27 @@
+from datetime import date, timedelta
+
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 from django.utils.translation import activate
 from hub.models import Church, Fast, Day, DevotionalSet, Devotional
 from learning_resources.models import Video, Article, Recipe
 from events.models import Announcement
+
+
+SEED_FAST_YEAR = 2025
+SEED_FAST_START_DATE = date(SEED_FAST_YEAR, 3, 3)
+SEED_FAST_FEAST_DATE = date(SEED_FAST_YEAR, 4, 20)
+
+
+def update_first_or_create(model, lookup, defaults):
+    instance = model.objects.filter(**lookup).order_by("pk").first()
+    if instance is None:
+        values = {**lookup, **defaults}
+        return model.objects.create(**values), True
+
+    for field, value in defaults.items():
+        setattr(instance, field, value)
+    instance.save()
+    return instance, False
 
 
 class Command(BaseCommand):
@@ -13,17 +31,25 @@ class Command(BaseCommand):
         activate('en')
 
         church, _ = Church.objects.get_or_create(name="Armenian Apostolic Church")
+        feast_date = SEED_FAST_FEAST_DATE
+        while (
+            Fast.objects.filter(
+                church=church, culmination_feast_date=feast_date
+            )
+            .exclude(name="Great Lent", year=SEED_FAST_YEAR)
+            .exists()
+        ):
+            feast_date += timedelta(days=1)
 
         # Create or update Fast with translations
         fast, _ = Fast.objects.update_or_create(
             name="Great Lent",
             church=church,
+            year=SEED_FAST_YEAR,
             defaults={
                 "description": "A period of fasting and prayer before Easter.",
                 "culmination_feast": "Easter",
-                "culmination_feast_date": (
-                    timezone.now().date() + timezone.timedelta(days=40)
-                ),
+                "culmination_feast_date": feast_date,
             },
         )
         # Armenian translations
@@ -33,8 +59,9 @@ class Command(BaseCommand):
         fast.save()
 
         # Create days
-        base_date = timezone.now().date()
-        day1, _ = Day.objects.get_or_create(date=base_date, fast=fast, church=church)
+        day1, _ = Day.objects.get_or_create(
+            date=SEED_FAST_START_DATE, fast=fast, church=church
+        )
         fast.save(update_fields=["year"])
 
         # DevotionalSet with translations
@@ -48,28 +75,36 @@ class Command(BaseCommand):
         dset.save()
 
         # Videos EN and HY
-        video_en, _ = Video.objects.update_or_create(
-            category='devotional',
-            language_code='en',
-            defaults={
-                "title": "Day 1 Reflection",
+        video_en, _ = update_first_or_create(
+            Video,
+            {
+                "category": "devotional",
+                "language_code": "en",
                 "description": "Introduction to the fast",
+            },
+            {
+                "title": "Day 1 Reflection",
             },
         )
         video_en.title_hy = "Օր 1 Խորհրդածություն"
         video_en.description_hy = "Ներածություն պահքին"
         video_en.save()
 
-        video_hy, _ = Video.objects.update_or_create(
-            category='devotional',
-            language_code='hy',
-            defaults={
-                "title": "Օր 1 Խորհրդածություն",
-                "description": "Ներածություն պահքին (HY)",
+        video_hy, _ = update_first_or_create(
+            Video,
+            {
+                "category": "devotional",
+                "language_code": "hy",
+                "title_en": "Day 1 Reflection (HY)",
+            },
+            {
+                "description_en": "Introduction to the fast",
             },
         )
         video_hy.title_en = "Day 1 Reflection (HY)"
         video_hy.description_en = "Introduction to the fast"
+        video_hy.title_hy = "Օր 1 Խորհրդածություն"
+        video_hy.description_hy = "Ներածություն պահքին (HY)"
         video_hy.save()
 
         # Devotionals EN and HY
@@ -98,22 +133,29 @@ class Command(BaseCommand):
         devo_hy.save()
 
         # Article with translations
-        article, _ = Article.objects.update_or_create(
-            title="Fasting Basics",
-            defaults={"body": "Markdown: Fasting is a spiritual discipline..."},
+        article, _ = update_first_or_create(
+            Article,
+            {
+                "title": "Fasting Basics",
+                "body": "Markdown: Fasting is a spiritual discipline...",
+            },
+            {},
         )
         article.title_hy = "Պահքի հիմունքներ"
         article.body_hy = "Markdown: Պահքն հոգևոր կարգապահություն է..."
         article.save()
 
         # Recipe with translations
-        recipe, _ = Recipe.objects.update_or_create(
-            title="Lentil Soup",
-            defaults={
+        recipe, _ = update_first_or_create(
+            Recipe,
+            {
+                "title": "Lentil Soup",
+                "ingredients": "- Lentils\n- Onion\n- Water",
+            },
+            {
                 "description": "A hearty soup.",
                 "time_required": "30 minutes",
                 "serves": "4",
-                "ingredients": "- Lentils\n- Onion\n- Water",
                 "directions": "Boil and season.",
             },
         )
@@ -126,9 +168,13 @@ class Command(BaseCommand):
         recipe.save()
 
         # Announcement and Activity Feed with translations
-        announcement, _ = Announcement.objects.update_or_create(
-            title="Welcome to Great Lent",
-            defaults={
+        announcement, _ = update_first_or_create(
+            Announcement,
+            {
+                "title": "Welcome to Great Lent",
+                "description": "Join us in prayer and fasting.",
+            },
+            {
                 "description": "Join us in prayer and fasting.",
                 "status": 'published',
             },

--- a/hub/tasks/mapping_tasks.py
+++ b/hub/tasks/mapping_tasks.py
@@ -427,8 +427,18 @@ def generate_participant_map(self, fast_id, delay=0):
         # Generate the map (always SVG)
         map_file, participant_count = create_map(fast_id)
         
-        # Save to database
-        participant_map, created = FastParticipantMap.objects.get_or_create(fast=fast)
+        # Save to database after rendering so a failed generation preserves old maps.
+        participant_map = (
+            FastParticipantMap.objects.filter(fast=fast)
+            .order_by("-last_updated", "-id")
+            .first()
+        )
+        if participant_map is None:
+            participant_map = FastParticipantMap(fast=fast)
+        else:
+            FastParticipantMap.objects.filter(fast=fast).exclude(
+                pk=participant_map.pk
+            ).delete()
         participant_map.map_file = map_file
         participant_map.participant_count = participant_count
         participant_map.save()
@@ -514,4 +524,4 @@ def update_current_fast_maps():
 if __name__ == "__main__":
     # This allows testing the map generation directly by running this file
     output_path = generate_sample_map()
-    print(f"Sample map generated at: {output_path}") 
+    print(f"Sample map generated at: {output_path}")

--- a/hub/tests/test_management_commands.py
+++ b/hub/tests/test_management_commands.py
@@ -4,7 +4,9 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
-from hub.models import Church, Fast
+from events.models import Announcement
+from hub.models import Church, Fast, FastParticipantMap, Day, DevotionalSet, Devotional
+from learning_resources.models import Article, Recipe, Video
 
 
 class RegenerateCommandErrorTests(TestCase):
@@ -19,6 +21,11 @@ class RegenerateCommandErrorTests(TestCase):
     def test_regenerate_map_wait_failure_raises(self):
         church = Church.objects.create(name="Test Church")
         fast = Fast.objects.create(name="Test Fast", church=church)
+        existing_map = FastParticipantMap.objects.create(
+            fast=fast,
+            map_file="fast_maps/existing.svg",
+            participant_count=12,
+        )
         task = Mock()
         task.id = "task-1"
         task.ready.return_value = True
@@ -32,3 +39,35 @@ class RegenerateCommandErrorTests(TestCase):
                 CommandError, "Map generation failed: render failed"
             ):
                 call_command("regenerate_map", fast.id, wait=True)
+
+        existing_map.refresh_from_db()
+        self.assertEqual(existing_map.participant_count, 12)
+        self.assertEqual(FastParticipantMap.objects.filter(fast=fast).count(), 1)
+
+
+class SeedMultilingualDataTests(TestCase):
+    def test_seed_multilingual_data_is_rerunnable(self):
+        call_command("seed_multilingual_data")
+        call_command("seed_multilingual_data")
+
+        church = Church.objects.get(name="Armenian Apostolic Church")
+        fast = Fast.objects.get(name="Great Lent", church=church)
+
+        self.assertEqual(Fast.objects.filter(name="Great Lent", church=church).count(), 1)
+        self.assertEqual(Day.objects.filter(fast=fast).count(), 1)
+        self.assertEqual(DevotionalSet.objects.filter(fast=fast).count(), 1)
+        self.assertEqual(Devotional.objects.filter(day__fast=fast).count(), 2)
+        self.assertEqual(
+            Video.objects.filter(category="devotional", language_code="en").count(),
+            1,
+        )
+        self.assertEqual(
+            Video.objects.filter(category="devotional", language_code="hy").count(),
+            1,
+        )
+        self.assertEqual(Article.objects.filter(title="Fasting Basics").count(), 1)
+        self.assertEqual(Recipe.objects.filter(title="Lentil Soup").count(), 1)
+        self.assertEqual(
+            Announcement.objects.filter(title="Welcome to Great Lent").count(),
+            1,
+        )

--- a/hub/tests/test_management_commands.py
+++ b/hub/tests/test_management_commands.py
@@ -1,14 +1,20 @@
+from datetime import date, timedelta
 from unittest.mock import Mock, patch
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from events.models import Announcement
 from hub.models import Church, Fast, FastParticipantMap, Day, DevotionalSet, Devotional
+from hub.tasks.mapping_tasks import generate_participant_map
 from learning_resources.models import Article, Recipe, Video
 
 
+TEST_CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+
+
+@override_settings(CACHES=TEST_CACHES)
 class RegenerateCommandErrorTests(TestCase):
     def test_regenerate_feast_contexts_requires_target(self):
         with self.assertRaisesMessage(CommandError, "Please specify either --all"):
@@ -44,7 +50,32 @@ class RegenerateCommandErrorTests(TestCase):
         self.assertEqual(existing_map.participant_count, 12)
         self.assertEqual(FastParticipantMap.objects.filter(fast=fast).count(), 1)
 
+    @patch("hub.tasks.mapping_tasks.create_map", return_value=("fast_maps/new.svg", 4))
+    def test_generate_participant_map_replaces_duplicate_maps_after_render(self, _):
+        church = Church.objects.create(name="Test Church")
+        fast = Fast.objects.create(name="Test Fast", church=church)
+        older_map = FastParticipantMap.objects.create(
+            fast=fast,
+            map_file="fast_maps/old.svg",
+            participant_count=12,
+        )
+        newer_map = FastParticipantMap.objects.create(
+            fast=fast,
+            map_file="fast_maps/newer.svg",
+            participant_count=13,
+        )
 
+        result = generate_participant_map.run(fast.id)
+
+        self.assertEqual(result["status"], "success")
+        self.assertFalse(FastParticipantMap.objects.filter(pk=older_map.pk).exists())
+        newer_map.refresh_from_db()
+        self.assertEqual(newer_map.map_file.name, "fast_maps/new.svg")
+        self.assertEqual(newer_map.participant_count, 4)
+        self.assertEqual(FastParticipantMap.objects.filter(fast=fast).count(), 1)
+
+
+@override_settings(CACHES=TEST_CACHES)
 class SeedMultilingualDataTests(TestCase):
     def test_seed_multilingual_data_is_rerunnable(self):
         call_command("seed_multilingual_data")
@@ -69,5 +100,78 @@ class SeedMultilingualDataTests(TestCase):
         self.assertEqual(Recipe.objects.filter(title="Lentil Soup").count(), 1)
         self.assertEqual(
             Announcement.objects.filter(title="Welcome to Great Lent").count(),
+            1,
+        )
+
+    def test_seed_multilingual_data_does_not_mutate_unrelated_rows(self):
+        church, _ = Church.objects.get_or_create(name="Armenian Apostolic Church")
+        same_name_date = date(2025, 4, 19)
+        while Fast.objects.filter(
+            church=church, culmination_feast_date=same_name_date
+        ).exists() or same_name_date == date(2025, 4, 20):
+            same_name_date += timedelta(days=1)
+        other_fast = Fast.objects.create(
+            name="Great Lent",
+            church=church,
+            year=2024,
+            culmination_feast_date=same_name_date,
+            description="Leave me alone.",
+        )
+        conflict_fast = (
+            Fast.objects.filter(church=church, culmination_feast_date="2025-04-20")
+            .exclude(name="Great Lent", year=2025)
+            .first()
+        )
+        if conflict_fast is None:
+            conflict_fast = Fast.objects.create(
+                name="Other Seed Date Fast",
+                church=church,
+                year=2024,
+                culmination_feast_date="2025-04-20",
+                description="Keep my feast date.",
+            )
+        else:
+            conflict_fast.description = "Keep my feast date."
+            conflict_fast.save(update_fields=["description"])
+        unrelated_video = Video.objects.create(
+            category="devotional",
+            language_code="en",
+            title="Unrelated video",
+            description="Not the seed video",
+        )
+        unrelated_article = Article.objects.create(
+            title="Fasting Basics",
+            body="Existing parish article",
+        )
+
+        call_command("seed_multilingual_data")
+
+        other_fast.refresh_from_db()
+        unrelated_video.refresh_from_db()
+        unrelated_article.refresh_from_db()
+        seed_fast = Fast.objects.get(name="Great Lent", church=church, year=2025)
+
+        self.assertEqual(other_fast.description, "Leave me alone.")
+        self.assertEqual(other_fast.culmination_feast_date, same_name_date)
+        conflict_fast.refresh_from_db()
+        self.assertEqual(conflict_fast.description, "Keep my feast date.")
+        self.assertEqual(conflict_fast.culmination_feast_date.isoformat(), "2025-04-20")
+        self.assertNotEqual(seed_fast.culmination_feast_date.isoformat(), "2025-04-20")
+        self.assertEqual(unrelated_video.title, "Unrelated video")
+        self.assertEqual(unrelated_video.description, "Not the seed video")
+        self.assertEqual(unrelated_article.body, "Existing parish article")
+        self.assertEqual(
+            Video.objects.filter(
+                category="devotional",
+                language_code="en",
+                description="Introduction to the fast",
+            ).count(),
+            1,
+        )
+        self.assertEqual(
+            Article.objects.filter(
+                title="Fasting Basics",
+                body="Markdown: Fasting is a spiritual discipline...",
+            ).count(),
             1,
         )

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -79,16 +79,19 @@ def cleanup_orphaned_bookmarks_async(
             }
         )
         
-        batch_start = 0
-        while batch_start < total_bookmarks:
-            batch_end = min(batch_start + batch_size, total_bookmarks)
-            
-            # Get batch of bookmarks with their IDs to handle potential deletions
+        last_seen_id = 0
+        while True:
+            # Page by stable primary-key windows because deleting rows mutates
+            # queryset offsets and can otherwise skip later orphaned records.
             batch_bookmarks = list(
-                bookmarks_qs[batch_start:batch_end].values(
+                bookmarks_qs.filter(id__gt=last_seen_id).order_by('id').values(
                     'id', 'user_id', 'content_type_id', 'object_id', 'content_type__model'
-                )
+                )[:batch_size]
             )
+            if not batch_bookmarks:
+                break
+
+            last_seen_id = batch_bookmarks[-1]['id']
             
             batch_orphaned = []
             
@@ -148,8 +151,7 @@ def cleanup_orphaned_bookmarks_async(
             
             logger.info(f"Batch progress: {processed}/{total_bookmarks} ({progress_percent}%) - Found {len(batch_orphaned)} orphaned in this batch")
             
-            batch_start += batch_size
-        
+
         end_time = timezone.now()
         duration = (end_time - start_time).total_seconds()
         

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -13,5 +13,6 @@ class MediaCleanupTestRunner(DiscoverRunner):
     
     def teardown_test_environment(self, **kwargs):
         """Clean up test environment and remove media files."""
-        cleanup_test_media()
-        super().teardown_test_environment(**kwargs) 
+        if not cleanup_test_media():
+            raise RuntimeError("Test media cleanup failed or was refused")
+        super().teardown_test_environment(**kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,33 @@
 """Test utilities for cleanup and setup."""
 import os
+from pathlib import Path
 from django.conf import settings
+
+
+def _is_allowed_test_media_root(test_media_root):
+    """Return true only for a real, non-symlink test_media directory."""
+    candidate = Path(test_media_root)
+    if candidate.is_symlink():
+        print(f"Refusing to clean symlinked test media directory: {test_media_root}")
+        return False
+
+    try:
+        resolved_candidate = candidate.resolve(strict=True)
+    except FileNotFoundError:
+        return False
+
+    if "test_media" not in str(candidate) or resolved_candidate != candidate.absolute():
+        print(f"Refusing to clean unexpected test media path: {test_media_root}")
+        return False
+
+    return candidate.is_dir()
 
 
 def cleanup_test_media():
     """Remove all test media files but keep the directories."""
     if hasattr(settings, 'MEDIA_ROOT') and settings.MEDIA_ROOT:
         test_media_root = settings.MEDIA_ROOT
-        if os.path.exists(test_media_root) and 'test_media' in test_media_root:
+        if os.path.exists(test_media_root) and _is_allowed_test_media_root(test_media_root):
             # Only clean if it's clearly a test directory
             try:
                 # Instead of removing the entire directory, remove its contents
@@ -22,8 +42,10 @@ def cleanup_test_media():
                         if dir_path != test_media_root:  # Don't remove the root directory
                             os.rmdir(dir_path)
                 print(f"Cleaned up test media contents: {test_media_root}")
+                return True
             except Exception as e:
                 print(f"Warning: Could not clean up test media contents {test_media_root}: {e}")
+    return False
 
 
 def setup_test_media():

--- a/tests/unit/learning_resources/test_bookmark_tasks.py
+++ b/tests/unit/learning_resources/test_bookmark_tasks.py
@@ -2,8 +2,9 @@
 Tests for learning resources Celery tasks.
 """
 from django.test.utils import override_settings
+from django.contrib.contenttypes.models import ContentType
 from tests.base import BaseTestCase
-from learning_resources.models import Bookmark
+from learning_resources.models import Bookmark, Video
 
 
 class BookmarkTasksTests(BaseTestCase):
@@ -103,6 +104,27 @@ class BookmarkTasksIntegrationTests(BaseTestCase):
         
         # Test that task is properly configured for this scenario
         self.assertTrue(hasattr(cleanup_orphaned_bookmarks_async, 'delay'))
+
+    def test_cleanup_task_deletes_all_orphans_across_batches(self):
+        """Deleting each batch should not cause later orphan rows to be skipped."""
+        from learning_resources.tasks import cleanup_orphaned_bookmarks_async
+
+        video_ct = ContentType.objects.get_for_model(Video)
+        for object_id in range(10_000, 10_005):
+            Bookmark.objects.create(
+                user=self.user,
+                content_type=video_ct,
+                object_id=object_id,
+            )
+
+        result = cleanup_orphaned_bookmarks_async.apply(
+            kwargs={"batch_size": 2, "dry_run": False}
+        ).get()
+
+        self.assertEqual(result["total_processed"], 5)
+        self.assertEqual(result["orphaned_found"], 5)
+        self.assertEqual(result["deleted"], 5)
+        self.assertEqual(Bookmark.objects.count(), 0)
 
 
 @override_settings(

--- a/tests/unit/test_cleanup_test_media.py
+++ b/tests/unit/test_cleanup_test_media.py
@@ -1,0 +1,80 @@
+"""Tests for the standalone test media cleanup script."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import TestCase, skipIf
+
+from django.test import override_settings
+
+from cleanup_test_media import cleanup_test_media
+from tests.test_utils import cleanup_test_media as cleanup_settings_test_media
+
+
+class CleanupTestMediaTests(TestCase):
+    """Validate cleanup behavior for safe and unsafe test_media paths."""
+
+    def test_cleanup_removes_project_test_media_contents(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                media_dir = Path("test_media")
+                nested_dir = media_dir / "nested"
+                nested_dir.mkdir(parents=True)
+                media_file = media_dir / "image.jpg"
+                nested_file = nested_dir / "thumb.jpg"
+                media_file.write_text("image")
+                nested_file.write_text("thumb")
+
+                cleaned = cleanup_test_media()
+
+                self.assertTrue(cleaned)
+                self.assertTrue(media_dir.exists())
+                self.assertFalse(media_file.exists())
+                self.assertFalse(nested_dir.exists())
+                self.assertFalse(nested_file.exists())
+            finally:
+                os.chdir(original_cwd)
+
+    @skipIf(not hasattr(os, "symlink"), "symlink is unavailable on this platform")
+    def test_cleanup_refuses_symlinked_test_media(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_cwd = os.getcwd()
+            external_dir = Path(tmpdir) / "external"
+            project_dir = Path(tmpdir) / "project"
+            external_dir.mkdir()
+            project_dir.mkdir()
+            external_file = external_dir / "keep.txt"
+            external_file.write_text("do not delete")
+
+            try:
+                os.chdir(project_dir)
+                os.symlink(external_dir, "test_media")
+
+                cleaned = cleanup_test_media()
+
+                self.assertFalse(cleaned)
+                self.assertTrue(external_file.exists())
+                self.assertEqual(external_file.read_text(), "do not delete")
+            finally:
+                os.chdir(original_cwd)
+
+    @skipIf(not hasattr(os, "symlink"), "symlink is unavailable on this platform")
+    def test_test_utils_cleanup_refuses_symlinked_media_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            external_dir = Path(tmpdir) / "external"
+            project_dir = Path(tmpdir) / "project"
+            external_dir.mkdir()
+            project_dir.mkdir()
+            external_file = external_dir / "keep.txt"
+            external_file.write_text("do not delete")
+            media_root = project_dir / "test_media"
+            os.symlink(external_dir, media_root)
+
+            with override_settings(MEDIA_ROOT=str(media_root)):
+                cleaned = cleanup_settings_test_media()
+
+            self.assertFalse(cleaned)
+            self.assertTrue(external_file.exists())
+            self.assertEqual(external_file.read_text(), "do not delete")

--- a/tests/unit/test_cleanup_test_media.py
+++ b/tests/unit/test_cleanup_test_media.py
@@ -4,10 +4,12 @@ import os
 import tempfile
 from pathlib import Path
 from unittest import TestCase, skipIf
+from unittest.mock import patch
 
 from django.test import override_settings
 
 from cleanup_test_media import cleanup_test_media
+from tests.test_runner import MediaCleanupTestRunner
 from tests.test_utils import cleanup_test_media as cleanup_settings_test_media
 
 
@@ -78,3 +80,14 @@ class CleanupTestMediaTests(TestCase):
             self.assertFalse(cleaned)
             self.assertTrue(external_file.exists())
             self.assertEqual(external_file.read_text(), "do not delete")
+
+    @patch("tests.test_runner.DiscoverRunner.teardown_test_environment")
+    @patch("tests.test_runner.cleanup_test_media", return_value=False)
+    def test_test_runner_raises_when_media_cleanup_is_refused(self, cleanup, teardown):
+        runner = MediaCleanupTestRunner()
+
+        with self.assertRaisesRegex(RuntimeError, "Test media cleanup failed"):
+            runner.teardown_test_environment()
+
+        cleanup.assert_called_once_with()
+        teardown.assert_not_called()


### PR DESCRIPTION
## Summary
- use stable primary-key windows for async orphan bookmark cleanup so deletions cannot skip later rows
- preserve existing participant maps until replacement generation succeeds
- reject symlinked/unexpected test media cleanup targets in both cleanup paths
- make seed_multilingual_data rerunnable with update_or_create/get_or_create

## Clawpatch
Fixes:
- fnd_sig-feat-library-bd888070b6-1e47_a0c420e64a
- fnd_sig-feat-library-4ab1946284-5b08_479c8e809f
- fnd_sig-feat-library-25faef2bc4-de75_5fef922bc3
- fnd_sig-feat-library-3186edc40b-5303_95f33f3c7f

Left intentionally untouched:
- migration/schema findings for Bookmark.object_id, nullable fast year uniqueness, reading context migration, and M2M-to-FK migration

## Validation
- scripts/crabbox-validate.sh ci (ruff + 1,086 tests)
- clawpatch revalidate fixed all four listed findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bookmark deletion iteration, map persistence, and dev seed/management behavior; mistakes could leave stale maps or affect local DB/media, but scope is bounded and well-tested.
> 
> **Overview**
> This PR hardens several **data-loss and cleanup** paths that could skip work, wipe the wrong files, or destroy maps before a successful regenerate.
> 
> **Orphan bookmark cleanup** now pages with stable primary-key windows (`id__gt=last_seen_id`) instead of slice offsets, so deleting rows in a batch cannot skip later orphans.
> 
> **Participant maps** render before any DB write; on success the task updates the newest `FastParticipantMap`, removes duplicate rows for the same fast, and **`regenerate_map` no longer deletes** the existing map up front—failed generation keeps the prior map.
> 
> **Test media cleanup** (standalone script, `test_utils`, and the custom test runner) only clears a resolved, non-symlink project `test_media` tree and **refuses** symlinked or unexpected paths; teardown **raises** if cleanup is refused.
> 
> **`seed_multilingual_data`** is rerunnable via `update_or_create` / `get_or_create` and `update_first_or_create`, with fixed seed dates and feast-date conflict avoidance so unrelated rows are not duplicated or overwritten.
> 
> New tests cover batch orphan deletion, map preservation, seed idempotency, and safe media cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01e4aff9dd69f78e4f452165cbed3cd073fee477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->