### PR TITLE
fix: add icon prefetch to PrayerSet detail queryset

### DIFF
--- a/prayers/views.py
+++ b/prayers/views.py
@@ -217,6 +217,7 @@ class PrayerSetDetailView(generics.RetrieveAPIView):
         return PrayerSet.objects.select_related('church', 'icon').prefetch_related(
             'memberships__prayer__church',
             'memberships__prayer__fast',
+            'memberships__prayer__icon',
             'memberships__prayer__tags'
         )
 


### PR DESCRIPTION
Prevents N+1 queries on prayer set detail endpoint. Each prayer's `PrayerSerializer.get_icon` was triggering a separate icon query — now prefetched via `memberships__prayer__icon`.

Found by Cursor Bugbot on PR #428 (commit `9abb6f73b6`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prefetch path addition with no auth or response contract changes.
> 
> **Overview**
> Adds **`memberships__prayer__icon`** to the `PrayerSetDetailView` queryset prefetch so nested prayers in a prayer set load icons in bulk instead of one query per prayer when `PrayerSerializer.get_icon` runs.
> 
> This aligns prayer-set detail with how the prayer list already uses `select_related('icon')` and only touches ORM optimization—no API shape or behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09622083694d9916e6f2dbe1f30a8ad0bc4c5dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->