### PR TITLE
feat: system tags API endpoint

### DIFF
--- a/bahk/tag_views.py
+++ b/bahk/tag_views.py
@@ -1,0 +1,86 @@
+"""Cross-app tag API views."""
+
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from taggit.models import TaggedItem
+
+
+SUPPORTED_MODELS = {
+    "prayer": ("prayers", "prayer"),
+    "icon": ("icons", "icon"),
+    "patristic_quote": ("hub", "patristicquote"),
+}
+
+MODEL_ALIASES = {
+    "patristicquote": "patristic_quote",
+}
+
+
+class SystemTagsView(APIView):
+    """Return unique django-taggit tag names used by supported content models."""
+
+    permission_classes = [AllowAny]
+    authentication_classes = []
+
+    def get(self, request):
+        raw_model_filter = request.query_params.get("model")
+        selected_models, invalid_models = self._parse_model_filter(raw_model_filter)
+
+        if invalid_models:
+            return Response(
+                {
+                    "detail": f"Unsupported model filter: {', '.join(invalid_models)}",
+                    "allowed_models": list(SUPPORTED_MODELS.keys()),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        tags_by_model = {
+            model_key: self._get_tags_for_model(model_key)
+            for model_key in selected_models
+        }
+
+        if raw_model_filter is not None and len(selected_models) == 1:
+            return Response(tags_by_model[selected_models[0]])
+
+        return Response(tags_by_model)
+
+    def _parse_model_filter(self, raw_model_filter):
+        if raw_model_filter is None or raw_model_filter.strip() == "":
+            return list(SUPPORTED_MODELS.keys()), []
+
+        selected_models = []
+        invalid_models = []
+        seen_models = set()
+
+        for fragment in raw_model_filter.split(","):
+            model_key = fragment.strip().lower()
+            if not model_key:
+                continue
+
+            model_key = MODEL_ALIASES.get(model_key, model_key)
+
+            if model_key not in SUPPORTED_MODELS:
+                invalid_models.append(fragment.strip().lower())
+                continue
+
+            if model_key not in seen_models:
+                selected_models.append(model_key)
+                seen_models.add(model_key)
+
+        if not selected_models and not invalid_models:
+            return list(SUPPORTED_MODELS.keys()), []
+
+        return selected_models, invalid_models
+
+    def _get_tags_for_model(self, model_key):
+        app_label, model_name = SUPPORTED_MODELS[model_key]
+        content_type = ContentType.objects.get_by_natural_key(app_label, model_name)
+        names = TaggedItem.objects.filter(
+            content_type=content_type,
+        ).values_list("tag__name", flat=True).distinct()
+
+        return sorted(set(names), key=str.casefold)

--- a/bahk/urls.py
+++ b/bahk/urls.py
@@ -22,6 +22,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.urls import include, path
 from django.views.generic import RedirectView
 from markdownx.views import ImageUploadView, MarkdownifyView
+from bahk.tag_views import SystemTagsView
 #Apply Simple JSON Web Token (SimpleJWT) Authentication Routes to the API
 from rest_framework_simplejwt.views import (
     TokenRefreshView,
@@ -133,6 +134,7 @@ urlpatterns += [
 
 # pin hub endpoints to /api/ root url
 urlpatterns += [
+    path("api/tags/", SystemTagsView.as_view(), name="system-tags"),
     path("api/", include("hub.urls")),
     path("api/learning-resources/", include("learning_resources.urls")),
     path("api/events/", include("events.urls")),

--- a/docs/PRAYER_SET_JSON_IMPORT.md
+++ b/docs/PRAYER_SET_JSON_IMPORT.md
@@ -127,6 +127,22 @@ Alternatively, use a `translations` (or `i18n`) block:
 Translatable fields for **prayer sets**: `title`, `description`
 Translatable fields for **prayers**: `title`, `text`
 
+## Tag Discovery
+
+When generating import JSON (manually or via LLM), prefer tags that already exist in the system for consistency. The public `/api/tags/` endpoint lists all unique tags currently in use.
+
+```bash
+# Get all prayer tags as a flat sorted array
+curl https://example.com/api/tags/?model=prayer
+# → ["daily", "evening", "fasting", "morning", "thanksgiving"]
+
+# Get tags for all supported models
+curl https://example.com/api/tags/
+# → {"prayer": [...], "icon": [...], "patristic_quote": [...]}
+```
+
+**LLM workflow tip:** When an LLM generates a prayer set import, it should first call `/api/tags/?model=prayer` to discover existing tags, then use those (plus any new ones needed) in the `"tags"` field of each prayer. This keeps the tag vocabulary consistent and makes prayers discoverable through existing filters.
+
 ## AI Icon Matching
 
 The import form includes a checkbox: **"Use AI to match icons to imported prayers"**. When checked:

--- a/docs/PRAYER_SET_JSON_IMPORT.md
+++ b/docs/PRAYER_SET_JSON_IMPORT.md
@@ -133,11 +133,11 @@ When generating import JSON (manually or via LLM), prefer tags that already exis
 
 ```bash
 # Get all prayer tags as a flat sorted array
-curl https://example.com/api/tags/?model=prayer
+curl https://api.fastandpray.app/api/tags/?model=prayer
 # → ["daily", "evening", "fasting", "morning", "thanksgiving"]
 
 # Get tags for all supported models
-curl https://example.com/api/tags/
+curl https://api.fastandpray.app/api/tags/
 # → {"prayer": [...], "icon": [...], "patristic_quote": [...]}
 ```
 

--- a/tests/test_system_tags_api.py
+++ b/tests/test_system_tags_api.py
@@ -1,0 +1,157 @@
+"""Tests for the cross-app system tags API."""
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from hub.models import Church, PatristicQuote
+from icons.models import Icon
+from prayers.models import Prayer
+
+
+class SystemTagsAPITests(APITestCase):
+    """Test /api/tags/ responses across taggable models."""
+
+    url = "/api/tags/"
+
+    def setUp(self):
+        self.church = Church.objects.create(name="Test Church")
+
+    def create_prayer(self, title, tags):
+        prayer = Prayer.objects.create(
+            title=title,
+            text=f"{title} text.",
+            category="general",
+            church=self.church,
+        )
+        prayer.tags.add(*tags)
+        return prayer
+
+    def create_icon(self, title, tags):
+        icon = Icon.objects.create(
+            title=title,
+            church=self.church,
+            image=SimpleUploadedFile(
+                name=f"{title.lower().replace(' ', '_')}.jpg",
+                content=b"fake image content",
+                content_type="image/jpeg",
+            ),
+        )
+        icon.tags.add(*tags)
+        return icon
+
+    def create_quote(self, attribution, tags):
+        quote = PatristicQuote.objects.create(
+            text=f"Quote from {attribution}.",
+            attribution=attribution,
+        )
+        quote.churches.add(self.church)
+        quote.tags.add(*tags)
+        return quote
+
+    def test_public_endpoint_requires_no_auth(self):
+        self.create_prayer("Morning Prayer", ["daily"])
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_public_endpoint_ignores_invalid_auth_header(self):
+        self.create_prayer("Morning Prayer", ["daily"])
+
+        response = self.client.get(
+            self.url,
+            HTTP_AUTHORIZATION="Bearer not-a-valid-token",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["prayer"], ["daily"])
+
+    def test_single_model_returns_flat_sorted_unique_array(self):
+        self.create_prayer("Morning Prayer", ["Zebra", "alpha", "daily"])
+        self.create_prayer("Evening Prayer", ["daily", "Beta"])
+        self.create_icon("Cross Icon", ["cross"])
+
+        response = self.client.get(self.url, {"model": "prayer"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, ["alpha", "Beta", "daily", "Zebra"])
+
+    def test_multi_model_returns_grouped_object(self):
+        self.create_prayer("Morning Prayer", ["daily"])
+        self.create_icon("Cross Icon", ["cross"])
+        self.create_quote("St. Basil", ["humility"])
+
+        response = self.client.get(self.url, {"model": "prayer,icon"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(set(response.data.keys()), {"prayer", "icon"})
+        self.assertEqual(response.data["prayer"], ["daily"])
+        self.assertEqual(response.data["icon"], ["cross"])
+
+    def test_all_models_returns_grouped_object(self):
+        self.create_prayer("Morning Prayer", ["daily"])
+        self.create_icon("Cross Icon", ["cross"])
+        self.create_quote("St. Basil", ["humility"])
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data,
+            {
+                "prayer": ["daily"],
+                "icon": ["cross"],
+                "patristic_quote": ["humility"],
+            },
+        )
+
+    def test_model_param_normalizes_whitespace_case_and_duplicates(self):
+        self.create_prayer("Morning Prayer", ["daily"])
+        self.create_icon("Cross Icon", ["cross"])
+
+        response = self.client.get(self.url, {"model": " Prayer,ICON,prayer"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(list(response.data.keys()), ["prayer", "icon"])
+        self.assertEqual(response.data["prayer"], ["daily"])
+        self.assertEqual(response.data["icon"], ["cross"])
+
+    def test_patristic_quote_alias_returns_canonical_flat_response(self):
+        self.create_quote("St. Basil", ["humility"])
+
+        response = self.client.get(self.url, {"model": "patristicquote"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, ["humility"])
+
+    def test_invalid_model_returns_400(self):
+        response = self.client.get(self.url, {"model": "prayer,unknown"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "Unsupported model filter: unknown")
+        self.assertEqual(
+            response.data["allowed_models"],
+            ["prayer", "icon", "patristic_quote"],
+        )
+
+    def test_empty_model_has_empty_array(self):
+        self.create_prayer("Morning Prayer", ["daily"])
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["prayer"], ["daily"])
+        self.assertEqual(response.data["icon"], [])
+        self.assertEqual(response.data["patristic_quote"], [])
+
+    def test_blank_model_filter_returns_all_models(self):
+        self.create_prayer("Morning Prayer", ["daily"])
+
+        response = self.client.get(f"{self.url}?model=")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            set(response.data.keys()),
+            {"prayer", "icon", "patristic_quote"},
+        )


### PR DESCRIPTION
Unauthenticated `GET /api/tags/` endpoint returning unique django-taggit tags, filterable by model.

**Endpoint:** `/api/tags/`

**Features:**
- `GET /api/tags/` — grouped object with all model tags
- `GET /api/tags/?model=prayer` — flat sorted array
- `GET /api/tags/?model=prayer,icon` — grouped object for specified models
- Supports: `prayer`, `icon`, `patristic_quote`
- Alias: `patristicquote` → `patristic_quote`
- Invalid models return 400 with `allowed_models`
- Case-insensitive sorted, uniqueness guaranteed
- Truly unauthenticated (`AllowAny` + `authentication_classes = []`)

**Files:**
- `bahk/tag_views.py` — view module
- `bahk/urls.py` — root-level route
- `tests/test_system_tags_api.py` — 10 tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only tag enumeration with AllowAny access; no auth or data mutation, covered by dedicated API tests.
> 
> **Overview**
> Adds a **public, unauthenticated** `GET /api/tags/` API that returns distinct **django-taggit** tag names already used on supported content (`prayer`, `icon`, `patristic_quote`), wired at the project root in `bahk/urls.py` via new `SystemTagsView` in `bahk/tag_views.py`.
> 
> Callers can omit `model` for a grouped map of all supported types, pass a single `model` for a **flat, case-insensitive sorted** list, or pass comma-separated models for a partial grouped response. Invalid model names yield **400** with `allowed_models`; `patristicquote` is accepted as an alias. Documentation in `docs/PRAYER_SET_JSON_IMPORT.md` describes using the endpoint for tag discovery during JSON/LLM imports. **10** API tests cover auth behavior, filtering, sorting, aliases, and errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c8372f695e8c9165a9d5a3c0eaf73b053b901cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->