### PR TITLE
fix: AI Match returns empty results for all queries

### DIFF
--- a/icons/views.py
+++ b/icons/views.py
@@ -232,6 +232,12 @@ class IconMatchView(views.APIView):
                 status=status.HTTP_200_OK
             )
         
+        # Pre-filter: use simple matching to narrow candidates before sending to LLM.
+        # With 550+ icons the full list overwhelms the model; pre-filter to top 30.
+        prefilter_ids = self._simple_match_icons(icons, prompt, max_results=30)
+        if prefilter_ids:
+            icons = [icon for icon in icons if icon.id in prefilter_ids]
+
         # Format icon data for LLM
         icon_descriptions = []
         for icon in icons:
@@ -462,6 +468,15 @@ Return up to {max_results} most relevant icons as a JSON array of objects with "
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR
                 )
         
+        # If LLM returned no matches, fall back to simple keyword matching
+        if not matched_results:
+            logger.info("LLM returned no matches, falling back to simple matching")
+            matched_ids = self._simple_match_icons(icons, prompt, max_results)
+            matched_results = [
+                {'id': icon_id, 'confidence': 'medium'}
+                for icon_id in matched_ids
+            ]
+
         # Build response using matched_results with confidence from LLM
         matches = []
         for match_result in matched_results:


### PR DESCRIPTION
## Problem
The AI Match button on the icon library always returns empty results, even for obvious matches like "crucifixion" or "St Gregory".

## Root Cause
Two issues in `IconMatchView`:

1. **LLM prompt too large**: All 552+ icons were sent in one prompt to the LLM, overwhelming the model. The model returned `[]` — which is a "successful" response, not an exception.

2. **Fallback never triggered**: `_simple_match_icons` fallback was only called in the `except` block, so when the LLM returned empty results (no exception), the fallback was skipped.

## Fix
- **Pre-filter**: Run `_simple_match_icons` first to narrow to top 30 candidates, then send only those to the LLM. This gives the model a manageable context it can actually reason about.
- **Empty-result fallback**: If pre-filter + LLM still returns empty, fall back to simple keyword matching results so users always get something.

## Testing
- All 1116 tests pass (CI on crabbox)
- Ruff clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted changes to icon match request handling and fallbacks; no auth, payments, or broad data-model changes.
> 
> **Overview**
> Fixes **AI Match** on the icon library returning empty results when the LLM succeeds but returns no matches.
> 
> **`IconMatchView`** now **pre-filters** candidates with `_simple_match_icons` (top 30) before building the LLM prompt, so the model is not sent the full catalog (~550+ icons). If the LLM still returns an empty match list, a **second fallback** runs simple keyword matching on the (possibly narrowed) icon set so users get results instead of an empty `matches` array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f69b8cd80dc2787b22267675fd207ea6bee7058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->