### PR TITLE
fix: add 429 retry/backoff for OpenAI icon matching during bulk import

### DIFF
--- a/hub/tasks/icon_tasks.py
+++ b/hub/tasks/icon_tasks.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import re
+import time
 
 from celery import shared_task
 from django.conf import settings
@@ -11,6 +12,44 @@ from hub.models import Feast
 from icons.models import Icon
 
 logger = logging.getLogger(__name__)
+
+
+def _get_openai_error_details(api_error):
+    error_body = getattr(api_error, 'body', {}) or {}
+    error_payload = error_body.get('error', error_body) if isinstance(error_body, dict) else {}
+    error_code = ''
+    error_message = str(api_error)
+    if isinstance(error_payload, dict):
+        error_code = error_payload.get('code') or ''
+        error_message = error_payload.get('message') or error_message
+    return str(error_code), str(error_message)
+
+
+def _is_openai_rate_limit_error(api_error, error_code, error_message):
+    status_code = getattr(api_error, 'status_code', None)
+    return (
+        status_code == 429
+        or 'rate_limit_exceeded' in error_code
+        or 'rate_limit' in error_code
+        or 'rate limit' in error_message.lower()
+    )
+
+
+def _extract_openai_retry_delay(api_error, error_message):
+    response = getattr(api_error, 'response', None)
+    headers = getattr(response, 'headers', {}) or {}
+    retry_after = headers.get('retry-after') or headers.get('Retry-After')
+    if retry_after:
+        try:
+            return float(retry_after)
+        except (TypeError, ValueError):
+            pass
+
+    match = re.search(r'please try again in ([0-9]+(?:\.[0-9]+)?)s', error_message, re.IGNORECASE)
+    if match:
+        return float(match.group(1))
+
+    return None
 
 
 def _simple_match_icons(icons, prompt, max_results):
@@ -155,9 +194,52 @@ Return up to {max_results} most relevant icons as a JSON array of objects with "
                 break
             except APIError as api_error:
                 last_error = api_error
-                error_body = getattr(api_error, 'body', {}) or {}
-                error_code = error_body.get('error', {}).get('code', '')
-                error_message = str(api_error)
+                error_code, error_message = _get_openai_error_details(api_error)
+
+                if _is_openai_rate_limit_error(api_error, error_code, error_message):
+                    max_rate_limit_retries = 3
+                    for attempt in range(1, max_rate_limit_retries + 1):
+                        retry_delay = _extract_openai_retry_delay(api_error, error_message)
+                        backoff_delay = 2 ** (attempt - 1)
+                        delay = max(backoff_delay, retry_delay or 0)
+                        logger.warning(
+                            "Rate limited by OpenAI, retrying in %.2fs (attempt %s/%s)",
+                            delay,
+                            attempt,
+                            max_rate_limit_retries,
+                        )
+                        time.sleep(delay)
+                        try:
+                            response = client.chat.completions.create(
+                                model=model,
+                                messages=[
+                                    {"role": "system", "content": system_prompt},
+                                    {"role": "user", "content": user_message},
+                                ],
+                                max_completion_tokens=500
+                            )
+                            logger.info(f"Successfully used model: {model}")
+                            break
+                        except APIError as retry_api_error:
+                            last_error = retry_api_error
+                            error_code, error_message = _get_openai_error_details(retry_api_error)
+                            if _is_openai_rate_limit_error(retry_api_error, error_code, error_message):
+                                api_error = retry_api_error
+                                continue
+                            raise
+                        except Exception as retry_error:
+                            last_error = retry_error
+                            raise
+
+                    if response:
+                        break
+
+                    logger.warning("OpenAI rate limit retries exhausted, falling back to simple tag matching")
+                    matched_ids = _simple_match_icons(icons, prompt, max_results)
+                    return [
+                        {'id': icon_id, 'confidence': 'medium'}
+                        for icon_id in matched_ids
+                    ]
                 
                 # Check if it's a model access error (403 or model_not_found)
                 if api_error.status_code == 403 or 'model_not_found' in error_code or 'does not have access' in error_message:

--- a/icons/management/commands/backfill_icon_footprints.py
+++ b/icons/management/commands/backfill_icon_footprints.py
@@ -2,8 +2,6 @@
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db.models import Q
-
 from icons.models import Icon
 
 logger = logging.getLogger(__name__)

--- a/prayers/tasks.py
+++ b/prayers/tasks.py
@@ -1,6 +1,7 @@
 """Celery tasks for the prayers app."""
 
 import logging
+import time
 
 from better_profanity import profanity
 from celery import shared_task
@@ -60,6 +61,8 @@ def match_icons_for_imported_prayers_task(prayer_ids, church_id):
                 church_id,
                 exc,
             )
+        finally:
+            time.sleep(0.5)
 
 
 def _get_moderation_prompt_and_service(prayer_request):


### PR DESCRIPTION
## Summary
Fixes #434 — OpenAI RateLimitError (429) during prayer set JSON import.

When importing many prayers, `match_icons_for_imported_prayers_task` calls `_match_icons_with_llm()` in a tight loop, burning through the 200k TPM limit on gpt-4.1-nano.

## Changes

### `hub/tasks/icon_tasks.py`
- Added 429 rate limit detection with exponential backoff retry (up to 3 attempts, 1s/2s/4s or server-suggested delay)
- On exhaustion, gracefully falls back to `_simple_match_icons()` instead of failing
- Added helper functions: `_get_openai_error_details`, `_is_openai_rate_limit_error`, `_extract_openai_retry_delay`

### `prayers/tasks.py`
- Added `time.sleep(0.5)` between prayer iterations in the import task to stay under rate limits (~120 calls/min max, safely below 200k TPM)

## Testing
- `icons.tests`: 48/48 passed
- `prayers.tests`: 57/57 passed
- Reviewer: no blocking issues found

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to icon-matching resilience and import pacing; failures degrade to tag/title matching rather than breaking imports.
> 
> **Overview**
> Addresses **OpenAI 429 rate limits** during bulk prayer import icon matching by throttling and retrying instead of failing the whole run.
> 
> **`hub/tasks/icon_tasks.py`** now classifies rate-limit errors, waits using `Retry-After` or parsed message hints (with exponential backoff, up to 3 retries per model attempt), and if limits persist falls back to **`_simple_match_icons()`** with medium confidence. Shared helpers centralize error parsing from API responses.
> 
> **`prayers/tasks.py`** adds a **0.5s pause** after each prayer in `match_icons_for_imported_prayers_task` so many sequential LLM calls stay under TPM limits during JSON import.
> 
> **`backfill_icon_footprints.py`** drops an unused `Q` import only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 978e051a98978c76c6f84b57fd5a14ea25391eac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->