### PR TITLE
feat: add find_duplicate_icons management command

### DIFF
--- a/icons/management/commands/find_duplicate_icons.py
+++ b/icons/management/commands/find_duplicate_icons.py
@@ -1,0 +1,30 @@
+"""Management command to find duplicate icons by phash."""
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+from icons.models import Icon
+
+
+class Command(BaseCommand):
+    help = "Find duplicate icons grouped by phash"
+
+    def handle(self):
+        dupes = (
+            Icon.objects
+            .exclude(phash='')
+            .values('phash')
+            .annotate(count=Count('id'))
+            .filter(count__gt=1)
+            .order_by('-count')
+        )
+
+        total = 0
+        for row in dupes:
+            self.stdout.write(f"phash={row['phash']} count={row['count']}")
+            total += row['count']
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nTotal duplicate icons: {total}\n"
+                f"Unique phash values with duplicates: {dupes.count()}"
+            )
+        )


### PR DESCRIPTION
One-liner to find duplicate icons by phash for triage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only reporting via a management command; no auth, data writes, or API surface changes.
> 
> **Overview**
> Adds a Django management command **`find_duplicate_icons`** for ops/triage: it scans **`Icon`** rows with a non-empty **`phash`**, groups by **`phash`**, and prints each duplicate group (largest groups first) plus totals.
> 
> The command is **read-only** (aggregation + stdout); it does not modify data. It pairs with existing footprint backfill work by surfacing how many icons share the same perceptual hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4f82d25829d98573c549152daa4bc14236a5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->