### PR TITLE
fix: clear duplicate icon hashes before unique constraint

### DIFF
--- a/icons/migrations/0017_icon_image_hash_unique.py
+++ b/icons/migrations/0017_icon_image_hash_unique.py
@@ -2,6 +2,29 @@
 from django.db import migrations, models
 
 
+def clear_duplicate_image_hashes(apps, schema_editor):
+    """Keep one row per existing image_hash before adding the unique index."""
+    Icon = apps.get_model('icons', 'Icon')
+    duplicate_hashes = (
+        Icon.objects.exclude(image_hash='')
+        .values('image_hash')
+        .annotate(icon_count=models.Count('id'))
+        .filter(icon_count__gt=1)
+    )
+
+    for duplicate in duplicate_hashes.iterator():
+        icons = list(
+            Icon.objects.filter(image_hash=duplicate['image_hash'])
+            .order_by('created_at', 'pk')
+            .values_list('pk', flat=True)
+        )
+        Icon.objects.filter(pk__in=icons[1:]).update(image_hash='')
+
+
+def noop_reverse(apps, schema_editor):
+    """Do not restore cleared hashes if the migration is reversed."""
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -9,6 +32,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(
+            clear_duplicate_image_hashes,
+            reverse_code=noop_reverse,
+        ),
         migrations.AddConstraint(
             model_name='icon',
             constraint=models.UniqueConstraint(


### PR DESCRIPTION
## Summary
- Clear duplicate `Icon.image_hash` values inside migration `0017` before adding the partial unique constraint
- Preserve one existing hash per duplicate group and blank the rest so production migration can create `unique_icon_image_hash`

## Verification
- `.venv/bin/ruff check icons/migrations/0017_icon_image_hash_unique.py`
- `.venv/bin/python manage.py migrate icons 0017 --settings=tests.test_settings --noinput`
- `.venv/bin/python manage.py test icons.tests.test_icon_dedup --noinput --parallel 1 --settings=tests.test_settings`

## Production context
Render deploy for #439 failed in pre-deploy at `icons.0017_icon_image_hash_unique` because production already has duplicate `image_hash` values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-time migration data cleanup with deterministic retention; no app runtime or auth changes.
> 
> **Overview**
> Migration `0017` now runs a **data cleanup step** before creating the partial unique index on `Icon.image_hash`.
> 
> For each non-empty `image_hash` shared by multiple rows, it keeps the earliest icon (by `created_at`, then `pk`) and sets `image_hash` to `''` on the rest so `unique_icon_image_hash` can apply in production. Reversing the migration does not restore those cleared hashes (`noop_reverse`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df33ad12746bf7f91d5bfc4df3a83d9018d5c177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->