### PR TITLE
fix: avoid grouped select_for_update in icon merge

### DIFF
--- a/icons/management/commands/icons_merge_duplicates.py
+++ b/icons/management/commands/icons_merge_duplicates.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from django.db.models import Count
 
 from icons.models import Icon
-from icons.utils import count_icon_associations, icon_association_count_expression
+from icons.utils import count_icon_associations
 
 
 class Command(BaseCommand):
@@ -60,7 +60,6 @@ class Command(BaseCommand):
                 icons = list(
                     Icon.objects.select_for_update()
                     .filter(phash=group['phash'])
-                    .annotate(association_count=icon_association_count_expression())
                     .order_by('-created_at', 'pk')
                 )
                 if len(icons) < 2:


### PR DESCRIPTION
## Summary
- Remove the association-count annotation from the `select_for_update()` icon row lock query
- Keep the separate per-icon association recheck inside the transaction
- Fixes Postgres error: `FOR UPDATE is not allowed with GROUP BY clause`

## Verification
- `.venv/bin/ruff check icons/management/commands/icons_merge_duplicates.py`
- `.venv/bin/python manage.py test icons.tests.test_icon_dedup --noinput --parallel 1 --settings=tests.test_settings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to a management command’s query shape; merge logic still uses the same in-transaction association recheck before deletes.
> 
> **Overview**
> Fixes the duplicate-icon merge management command so it can lock rows under PostgreSQL by **dropping the association-count annotation** from the `select_for_update()` queryset (that annotation implied grouped aggregates, which Postgres rejects with `FOR UPDATE`).
> 
> Association counts for choosing a canonical icon and skipping referenced duplicates are **unchanged**: they still come from the existing per-icon `count_icon_associations` pass inside the same transaction after the lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37c9f139b9862286f8e90892c82054b56fbac66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->