### PR TITLE
fix: scope event stats rows to current user

### DIFF
--- a/events/tests/test_engagement_endpoints.py
+++ b/events/tests/test_engagement_endpoints.py
@@ -576,6 +576,121 @@ class EngagementTrackingEndpointsTest(APITestCase):
         self.assertEqual(response.data['total_events'], 1)
         self.assertEqual(response.data['fasts_joined'], 1)
         self.assertEqual(response.data['fasts_left'], 0)
+
+    def test_event_stats_hides_other_users_milestone_events_for_non_staff(self):
+        """Non-staff users should not receive other users' milestone event rows."""
+        own_event = Event.create_event(
+            event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
+            user=self.user,
+            target=self.fast,
+            title='Own milestone',
+        )
+        Event.create_event(
+            event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
+            user=self.other_user,
+            target=self.fast,
+            title='Other milestone',
+        )
+
+        response = self.client.get(reverse('events:event-stats'))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            [event['id'] for event in response.data['milestone_events']],
+            [own_event.id],
+        )
+
+    def test_event_stats_staff_can_see_global_milestone_events(self):
+        """Staff users keep global milestone visibility for analytics."""
+        own_event = Event.create_event(
+            event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
+            user=self.user,
+            target=self.fast,
+            title='Own milestone',
+        )
+        other_event = Event.create_event(
+            event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
+            user=self.other_user,
+            target=self.fast,
+            title='Other milestone',
+        )
+        refresh = RefreshToken.for_user(self.staff_user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {refresh.access_token}')
+
+        response = self.client.get(reverse('events:event-stats'))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            {event['id'] for event in response.data['milestone_events']},
+            {own_event.id, other_event.id},
+        )
+
+    def test_fast_event_stats_hides_other_users_event_rows_for_non_staff(self):
+        """Non-staff users should only receive their own per-fast event rows."""
+        own_recent = Event.create_event(
+            event_type_code=EventType.USER_JOINED_FAST,
+            user=self.user,
+            target=self.fast,
+            title='Own join',
+        )
+        own_milestone = Event.create_event(
+            event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
+            user=self.user,
+            target=self.fast,
+            title='Own milestone',
+        )
+        Event.create_event(
+            event_type_code=EventType.USER_LEFT_FAST,
+            user=self.other_user,
+            target=self.fast,
+            title='Other leave',
+        )
+        Event.create_event(
+            event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
+            user=self.other_user,
+            target=self.fast,
+            title='Other milestone',
+        )
+
+        response = self.client.get(
+            reverse('events:fast-event-stats', kwargs={'fast_id': self.fast.id})
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            [event['id'] for event in response.data['milestone_events']],
+            [own_milestone.id],
+        )
+        self.assertEqual(
+            {event['id'] for event in response.data['recent_activity']},
+            {own_recent.id, own_milestone.id},
+        )
+
+    def test_fast_event_stats_staff_can_see_global_event_rows(self):
+        """Staff users keep global per-fast event row visibility."""
+        own_event = Event.create_event(
+            event_type_code=EventType.USER_JOINED_FAST,
+            user=self.user,
+            target=self.fast,
+            title='Own join',
+        )
+        other_event = Event.create_event(
+            event_type_code=EventType.USER_LEFT_FAST,
+            user=self.other_user,
+            target=self.fast,
+            title='Other leave',
+        )
+        refresh = RefreshToken.for_user(self.staff_user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {refresh.access_token}')
+
+        response = self.client.get(
+            reverse('events:fast-event-stats', kwargs={'fast_id': self.fast.id})
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        event_ids = {event['id'] for event in response.data['recent_activity']}
+        self.assertIn(own_event.id, event_ids)
+        self.assertIn(other_event.id, event_ids)
     
     def test_track_devotional_viewed_success(self):
         """Test successful devotional viewed tracking."""

--- a/events/views.py
+++ b/events/views.py
@@ -229,7 +229,10 @@ class EventStatsView(APIView):
             timestamp__gte=last_30d
         ).select_related(
             'event_type', 'user', 'content_type'
-        ).order_by('-timestamp')[:5]
+        ).order_by('-timestamp')
+        if not request.user.is_staff:
+            milestone_events = milestone_events.filter(user=request.user)
+        milestone_events = milestone_events[:5]
         
         stats_data = {
             'total_events': total_events,
@@ -353,7 +356,10 @@ class FastEventStatsView(APIView):
             event_type__code=EventType.FAST_PARTICIPANT_MILESTONE
         ).select_related(
             'event_type', 'user', 'content_type'
-        ).order_by('-timestamp')[:5]
+        ).order_by('-timestamp')
+        if not request.user.is_staff:
+            milestone_events = milestone_events.filter(user=request.user)
+        milestone_events = milestone_events[:5]
         
         # Join timeline (last 30 days)
         now = timezone.now()
@@ -386,7 +392,10 @@ class FastEventStatsView(APIView):
         # Recent activity
         recent_activity = fast_events.select_related(
             'event_type', 'user', 'content_type'
-        ).order_by('-timestamp')[:10]
+        ).order_by('-timestamp')
+        if not request.user.is_staff:
+            recent_activity = recent_activity.filter(user=request.user)
+        recent_activity = recent_activity[:10]
         
         stats_data = {
             'fast_id': fast.id,


### PR DESCRIPTION
## Summary

- Scope `EventStatsView.milestone_events` to the current user for non-staff callers.
- Scope `FastEventStatsView.milestone_events` and `recent_activity` to the current user for non-staff callers.
- Preserve staff/global analytics visibility and existing aggregate counts.
- Add regression coverage for non-staff row hiding and staff global row visibility.

## Verification

- `.venv/bin/python manage.py test events.tests.test_engagement_endpoints --noinput --parallel --settings=tests.test_settings`
- `.venv/bin/python manage.py test events.tests.tests --noinput --parallel --settings=tests.test_settings`
- `.venv/bin/ruff check events/views.py events/tests/test_engagement_endpoints.py`
- `bash scripts/crabbox-validate.sh ci` — ruff clean, 1145 tests OK, 2 skipped

Fixes #397

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Privacy fix on authenticated stats endpoints; behavior change for non-staff clients that relied on cross-user rows in milestone/recent lists, though aggregates are unchanged.
> 
> **Overview**
> Non-staff callers no longer see other users’ event rows in stats APIs: **global** `event-stats` now limits `milestone_events` to the requesting user, and **per-fast** `fast-event-stats` limits both `milestone_events` and `recent_activity` the same way. **Staff** users still receive unscoped lists for analytics. **Aggregate** counts and timelines on those endpoints are unchanged.
> 
> Regression tests cover non-staff row hiding and staff global visibility for both endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0615d157049f1770036facadb40390bb7b28aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->