### PR TITLE
fix: return icon image for prayer requests

### DIFF
--- a/prayers/serializers.py
+++ b/prayers/serializers.py
@@ -325,6 +325,19 @@ class PrayerRequestSerializer(serializers.ModelSerializer, ThumbnailCacheMixin):
                     return None
         return None
 
+    def to_representation(self, instance):
+        """Represent icon-backed requests with the icon's full image URL."""
+        data = super().to_representation(instance)
+        if not data.get('image') and instance.icon_id and instance.icon:
+            try:
+                image_url = instance.icon.image.url
+            except (AttributeError, ValueError, OSError):
+                pass
+            else:
+                request = self.context.get('request')
+                data['image'] = request.build_absolute_uri(image_url) if request else image_url
+        return data
+
     def get_acceptance_count(self, obj):
         """Get the number of users who accepted this request."""
         return obj.get_acceptance_count()

--- a/tests/test_prayer_requests.py
+++ b/tests/test_prayer_requests.py
@@ -479,6 +479,7 @@ class PrayerRequestAPITests(BaseAPITestCase):
         self.assertEqual(results[0]['id'], created_request.id)
         self.assertEqual(results[0]['icon_id'], icon.id)
         self.assertEqual(results[0]['thumbnail_url'], icon.cached_thumbnail_url)
+        self.assertEqual(results[0]['image'], f'http://testserver{icon.image.url}')
 
     @tag('integration')
     def test_create_allows_icon_when_user_has_no_profile(self):


### PR DESCRIPTION
## Summary

- Fill `PrayerRequestSerializer.image` from the selected icon's full image URL when a prayer request has no uploaded image.
- Preserve uploaded prayer request image behavior.
- Match DRF `ImageField` read behavior by returning an absolute URL when request context is available.
- Extend existing icon-backed prayer request regression coverage.

## Verification

- `.venv/bin/ruff check prayers/serializers.py tests/test_prayer_requests.py`
- `.venv/bin/python manage.py test tests.test_prayer_requests --noinput --parallel --settings=tests.test_settings`
- `bash scripts/crabbox-validate.sh ci` — ruff clean, 1141 tests OK, 2 skipped

Fixes #294

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path serializer change only; uploaded images unchanged and behavior is covered by an existing integration test.
> 
> **Overview**
> **Icon-only prayer requests** now return a usable **`image`** URL in list/detail responses, not just `thumbnail_url` from the selected icon.
> 
> `PrayerRequestSerializer` overrides **`to_representation`**: when there is no uploaded image but an **`icon_id`** is set, it sets **`image`** from the icon’s full asset URL. With request context, the URL is **absolute** (same pattern as DRF `ImageField` reads). Uploaded images are unchanged.
> 
> Regression test asserts the list payload **`image`** matches the icon’s absolute URL for the existing icon-backed create/list flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e362f710e36227646366e93bc07d19530e3a931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->