### PR TITLE
Fix API.Bible Esther additions reference

### DIFF
--- a/hub/services/bible_api_service.py
+++ b/hub/services/bible_api_service.py
@@ -122,6 +122,31 @@ class BibleAPIService:
         return usfm_id
 
     @staticmethod
+    def resolve_reading_passage(
+        book_name: str,
+        start_chapter: int,
+        start_verse: int,
+        end_chapter: int,
+        end_verse: int,
+    ) -> tuple[str, int, int, int, int]:
+        """Resolve a Reading reference to the API.Bible book/range.
+
+        KJVAIC stores the Greek additions to Esther as ESG 1-7. The liturgical
+        source may refer to the first addition as Esther 10:4-13, which maps to
+        API.Bible's ESG 1:4-13.
+        """
+        usfm_id = BibleAPIService.resolve_book_name(book_name)
+        if (
+            usfm_id == "EST"
+            and start_chapter == 10
+            and end_chapter == 10
+            and start_verse >= 4
+            and end_verse <= 13
+        ):
+            return "ESG", 1, start_verse, 1, end_verse
+        return usfm_id, start_chapter, start_verse, end_chapter, end_verse
+
+    @staticmethod
     def _bible_id_for_book(usfm_book_id: str) -> tuple[str, str]:
         """Return the (bible_id, version_name) to use for a given book.
 
@@ -182,10 +207,15 @@ def fetch_text_for_reading(reading, service: BibleAPIService | None = None) -> b
             return False
 
     try:
-        usfm_id = BibleAPIService.resolve_book_name(reading.book)
+        passage = BibleAPIService.resolve_reading_passage(
+            reading.book,
+            reading.start_chapter,
+            reading.start_verse,
+            reading.end_chapter,
+            reading.end_verse,
+        )
         result = service.get_passage(
-            usfm_id, reading.start_chapter, reading.start_verse,
-            reading.end_chapter, reading.end_verse,
+            *passage,
         )
 
         ReadingModel.objects.filter(pk=reading.pk).update(

--- a/hub/services/reading_text_service.py
+++ b/hub/services/reading_text_service.py
@@ -55,13 +55,15 @@ def fetch_english_text(reading, *, service: BibleAPIService | None = None, **_kw
             return False
 
     try:
-        usfm_id = BibleAPIService.resolve_book_name(reading.book)
-        result = service.get_passage(
-            usfm_id,
+        passage = BibleAPIService.resolve_reading_passage(
+            reading.book,
             reading.start_chapter,
             reading.start_verse,
             reading.end_chapter,
             reading.end_verse,
+        )
+        result = service.get_passage(
+            *passage,
         )
 
         ReadingModel.objects.filter(pk=reading.pk).update(

--- a/hub/tests/test_bible_api.py
+++ b/hub/tests/test_bible_api.py
@@ -242,6 +242,24 @@ class BibleAPIServiceResolveBookNameTests(TestCase):
         self.assertIn("Nonexistent Book", str(ctx.exception))
 
 
+class BibleAPIServiceResolveReadingPassageTests(TestCase):
+    """Tests for Reading reference resolution into API.Bible passage IDs."""
+
+    def test_esther_greek_addition_uses_esg_numbering(self):
+        """Esther 10:4-9 maps to the KJVAIC Esther Additions book."""
+        self.assertEqual(
+            BibleAPIService.resolve_reading_passage("Esther", 10, 4, 10, 9),
+            ("ESG", 1, 4, 1, 9),
+        )
+
+    def test_regular_esther_stays_canonical(self):
+        """Canonical Esther references should continue to use EST."""
+        self.assertEqual(
+            BibleAPIService.resolve_reading_passage("Esther", 10, 1, 10, 3),
+            ("EST", 10, 1, 10, 3),
+        )
+
+
 class BibleAPIServiceBibleIdSelectionTests(TestCase):
     """Tests for BibleAPIService._bible_id_for_book."""
 
@@ -647,6 +665,35 @@ class RefreshAllReadingTextsTaskTests(TestCase):
         # Check that the failure was logged
         log_output = "\n".join(log.output)
         self.assertIn("API call failed", log_output)
+
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_refresh_maps_esther_greek_addition_to_esg(self, mock_config, mock_get_passage):
+        """Esther 10:4-9 should fetch from KJVAIC's ESG 1:4-9."""
+        mock_get_passage.return_value = {
+            "content": "Then Mordecai said...",
+            "copyright": "KJVAIC copyright",
+            "version": "KJVAIC",
+            "reference": "Esther (Additions) 1:4-9",
+            "fums_token": "test-fums-token",
+        }
+
+        day = Day.objects.create(date=date(2025, 3, 15), church=self.church)
+        reading = _create_reading(
+            day,
+            book="Esther",
+            start_ch=10,
+            start_v=4,
+            end_ch=10,
+            end_v=9,
+        )
+
+        refresh_all_reading_texts_task()
+
+        mock_get_passage.assert_called_once_with("ESG", 1, 4, 1, 9)
+        reading.refresh_from_db()
+        self.assertEqual(reading.text, "Then Mordecai said...")
+        self.assertEqual(reading.text_version, "KJVAIC")
 
     @patch('hub.services.bible_api_service.config', return_value="")
     def test_no_api_key_aborts_refresh(self, mock_config):


### PR DESCRIPTION
## Summary
- map liturgical Esther 10:4-13 subranges to API.Bible KJVAIC Esther Additions coordinates ESG 1:4-13
- route both English fetch paths through the shared reading passage resolver
- add regression coverage for canonical Esther and the weekly refresh path

Fixes #370

## Validation
- targeted Bible API and FUMS tests passed locally
- ruff passed for touched files
- Crabbox full CI passed: 1144 tests OK, 2 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized reference-mapping fix for Bible text fetching; no auth, data model, or broad behavioral changes beyond Esther addition ranges.
> 
> **Overview**
> Liturgical readings that cite **Esther 10:4–13** (Greek additions) are now translated to API.Bible’s **KJVAIC** coordinates **`ESG` 1:4–13** instead of canonical **`EST`**, via a shared `resolve_reading_passage` helper on `BibleAPIService`.
> 
> Both English text paths (`fetch_text_for_reading` and `fetch_english_text`) call that resolver before `get_passage`, so sync and batch refresh behave the same. Canonical Esther (e.g. 10:1–3) is unchanged.
> 
> Regression tests cover the mapping, canonical Esther, and the weekly refresh task calling `ESG` with the remapped chapter/verses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d8b131505e416c23774e7eddbb18e82ded1425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->