### PR TITLE
Instrument Celery beat tasks with Sentry cron check-ins

### DIFF
--- a/events/tasks.py
+++ b/events/tasks.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 from datetime import timedelta
 import logging
+import sentry_sdk
 
 from .models import UserActivityFeed, Event
 
@@ -18,33 +19,33 @@ User = get_user_model()
 def create_activity_feed_item_task(self, event_id, user_id=None):
     """
     Create an activity feed item from an event asynchronously.
-    
+
     Args:
         event_id: ID of the Event to create feed item from
         user_id: Optional user ID (if not provided, uses event.user)
     """
     try:
         event = Event.objects.select_related('user', 'event_type', 'content_type').get(id=event_id)
-        
+
         # Use provided user_id or event.user
         user = None
         if user_id:
             user = User.objects.get(id=user_id)
         elif event.user:
             user = event.user
-        
+
         if not user:
             logger.info(f"No user found for event {event_id}, skipping feed item creation")
             return
-        
+
         # Create the feed item
         feed_item = UserActivityFeed.create_from_event(event, user)
-        
+
         if feed_item:
             logger.info(f"Created activity feed item {feed_item.id} for user {user.username}")
         else:
             logger.info(f"No feed item created for event {event_id} (not a tracked event type)")
-            
+
     except Event.DoesNotExist:
         logger.error(f"Event {event_id} not found for feed item creation")
     except User.DoesNotExist:
@@ -59,7 +60,7 @@ def create_activity_feed_item_task(self, event_id, user_id=None):
 def create_fast_reminder_feed_items_task(self, fast_id, reminder_type='fast_reminder'):
     """
     Create fast reminder feed items for all users in a fast.
-    
+
     Args:
         fast_id: ID of the Fast
         reminder_type: Type of reminder ('fast_reminder', 'devotional_reminder')
@@ -67,10 +68,10 @@ def create_fast_reminder_feed_items_task(self, fast_id, reminder_type='fast_remi
     try:
         from hub.models import Fast
         fast = Fast.objects.get(id=fast_id)
-        
+
         # Get all users in the fast
         users = User.objects.filter(profile__fasts=fast).distinct()
-        
+
         created_count = 0
         for user in users:
             try:
@@ -80,10 +81,10 @@ def create_fast_reminder_feed_items_task(self, fast_id, reminder_type='fast_remi
             except Exception as e:
                 logger.error(f"Error creating reminder for user {user.id}: {e}")
                 continue
-        
+
         logger.info(f"Created {created_count} reminder feed items for fast {fast.name}")
         return created_count
-        
+
     except Fast.DoesNotExist:
         logger.error(f"Fast {fast_id} not found for reminder feed items")
     except Exception as exc:
@@ -95,7 +96,7 @@ def create_fast_reminder_feed_items_task(self, fast_id, reminder_type='fast_remi
 def create_devotional_reminder_feed_items_task(self, devotional_id, fast_id):
     """
     Create devotional reminder feed items for all users in a fast.
-    
+
     Args:
         devotional_id: ID of the Devotional
         fast_id: ID of the Fast
@@ -104,10 +105,10 @@ def create_devotional_reminder_feed_items_task(self, devotional_id, fast_id):
         from hub.models import Fast, Devotional
         fast = Fast.objects.get(id=fast_id)
         devotional = Devotional.objects.get(id=devotional_id)
-        
+
         # Get all users in the fast
         users = User.objects.filter(profile__fasts=fast).distinct()
-        
+
         created_count = 0
         for user in users:
             try:
@@ -117,10 +118,10 @@ def create_devotional_reminder_feed_items_task(self, devotional_id, fast_id):
             except Exception as e:
                 logger.error(f"Error creating devotional reminder for user {user.id}: {e}")
                 continue
-        
+
         logger.info(f"Created {created_count} devotional reminder feed items for fast {fast.name}")
         return created_count
-        
+
     except (Fast.DoesNotExist, Devotional.DoesNotExist) as e:
         logger.error(f"Fast {fast_id} or Devotional {devotional_id} not found: {e}")
     except Exception as exc:
@@ -132,7 +133,7 @@ def create_devotional_reminder_feed_items_task(self, devotional_id, fast_id):
 def batch_create_activity_feed_items_task(event_ids, user_id=None):
     """
     Create multiple activity feed items in batch.
-    
+
     Args:
         event_ids: List of Event IDs
         user_id: Optional user ID (if not provided, uses each event's user)
@@ -141,7 +142,7 @@ def batch_create_activity_feed_items_task(event_ids, user_id=None):
         events = Event.objects.select_related('user', 'event_type', 'content_type').filter(
             id__in=event_ids
         )
-        
+
         created_count = 0
         for event in events:
             try:
@@ -150,25 +151,26 @@ def batch_create_activity_feed_items_task(event_ids, user_id=None):
                     user = User.objects.get(id=user_id)
                 elif event.user:
                     user = event.user
-                
+
                 if user:
                     feed_item = UserActivityFeed.create_from_event(event, user)
                     if feed_item:
                         created_count += 1
-                        
+
             except Exception as e:
                 logger.error(f"Error creating feed item for event {event.id}: {e}")
                 continue
-        
+
         logger.info(f"Created {created_count} feed items from {len(events)} events")
         return created_count
-        
+
     except Exception as e:
         logger.error(f"Error in batch feed item creation: {e}")
         return 0
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-activity-feed-cleanup')
 def cleanup_old_activity_feed_items_task():
     """
     Clean up old activity feed items based on retention policies.
@@ -187,7 +189,7 @@ def cleanup_old_activity_feed_items_task():
 def populate_user_activity_feed_task(user_id, days_back=30):
     """
     Populate a user's activity feed with historical events.
-    
+
     Args:
         user_id: ID of the User
         days_back: Number of days back to populate
@@ -196,14 +198,14 @@ def populate_user_activity_feed_task(user_id, days_back=30):
         user = User.objects.get(id=user_id)
         end_date = timezone.now()
         start_date = end_date - timedelta(days=days_back)
-        
+
         # Get user's events in the date range
         events = Event.objects.filter(
             user=user,
             timestamp__gte=start_date,
             timestamp__lte=end_date
         ).select_related('event_type', 'content_type')
-        
+
         created_count = 0
         for event in events:
             # Check if feed item already exists
@@ -211,15 +213,15 @@ def populate_user_activity_feed_task(user_id, days_back=30):
                 user=user,
                 event=event
             ).exists()
-            
+
             if not existing_feed_item:
                 feed_item = UserActivityFeed.create_from_event(event, user)
                 if feed_item:
                     created_count += 1
-        
+
         logger.info(f"Created {created_count} activity feed items for user {user.username}")
         return created_count
-        
+
     except User.DoesNotExist:
         logger.error(f"User {user_id} not found for feed population")
         return 0
@@ -232,7 +234,7 @@ def populate_user_activity_feed_task(user_id, days_back=30):
 def track_fast_participant_milestone_task(self, fast_id, participant_count=None, milestone_type="participant_count"):
     """
     Track when a fast reaches participation milestones asynchronously.
-    
+
     Args:
         fast_id: ID of the Fast
         participant_count: Current number of participants (if None, will be calculated)
@@ -241,28 +243,28 @@ def track_fast_participant_milestone_task(self, fast_id, participant_count=None,
     try:
         from hub.models import Fast
         from .signals import track_fast_participant_milestone
-        
+
         fast = Fast.objects.get(id=fast_id)
-        
+
         # Calculate participant count if not provided
         if participant_count is None:
             participant_count = fast.profiles.count()
-        
+
         # Track the milestone
         milestone_created = track_fast_participant_milestone(fast, participant_count, milestone_type)
-        
+
         if milestone_created:
             logger.info(f"Created milestone event for fast {fast.name} with {participant_count} participants")
         else:
             logger.info(f"No milestone reached for fast {fast.name} with {participant_count} participants")
-        
+
         return {
             'fast_id': fast_id,
             'fast_name': fast.name,
             'participant_count': participant_count,
             'milestone_created': milestone_created
         }
-        
+
     except Fast.DoesNotExist:
         logger.error(f"Fast {fast_id} not found for milestone tracking")
     except Exception as exc:
@@ -275,27 +277,27 @@ def track_fast_participant_milestone_task(self, fast_id, participant_count=None,
 def track_fast_beginning_task(self, fast_id):
     """
     Track when a fast begins asynchronously.
-    
+
     Args:
         fast_id: ID of the Fast
     """
     try:
         from hub.models import Fast
         from .signals import track_fast_beginning
-        
+
         fast = Fast.objects.get(id=fast_id)
-        
+
         # Track the fast beginning
         track_fast_beginning(fast)
-        
+
         logger.info(f"Tracked fast beginning event for fast {fast.name}")
-        
+
         return {
             'fast_id': fast_id,
             'fast_name': fast.name,
             'event_created': True
         }
-        
+
     except Fast.DoesNotExist:
         logger.error(f"Fast {fast_id} not found for beginning tracking")
     except Exception as exc:
@@ -305,6 +307,7 @@ def track_fast_beginning_task(self, fast_id):
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-fast-beginning-check')
 def check_fast_beginning_events_task():
     """
     Check for fasts that are beginning today and create beginning events.
@@ -314,16 +317,16 @@ def check_fast_beginning_events_task():
         from hub.models import Fast
         from django.db.models import Min
         from django.utils import timezone
-        
+
         today = timezone.now().date()
-        
+
         # Find fasts that start today (first day of the fast)
         fasts_beginning_today = Fast.objects.annotate(
             start_date=Min('days__date')
         ).filter(
             start_date=today
         ).distinct()
-        
+
         events_created = 0
         for fast in fasts_beginning_today:
             try:
@@ -335,7 +338,7 @@ def check_fast_beginning_events_task():
                     content_type__model='fast',
                     timestamp__date=today
                 ).exists()
-                
+
                 if not existing_event:
                     # Create the beginning event
                     track_fast_beginning_task.delay(fast.id)
@@ -343,17 +346,17 @@ def check_fast_beginning_events_task():
                     logger.info(f"Scheduled fast beginning event for {fast.name}")
                 else:
                     logger.info(f"Fast beginning event already exists for {fast.name} today")
-                    
+
             except Exception as e:
                 logger.error(f"Error processing fast beginning for {fast.name}: {e}")
                 continue
-        
+
         logger.info(f"Checked {fasts_beginning_today.count()} fasts, created {events_created} beginning events")
         return {
             'fasts_checked': fasts_beginning_today.count(),
             'events_created': events_created
         }
-        
+
     except Exception as e:
         logger.error(f"Error checking fast beginning events: {e}")
         return {
@@ -364,6 +367,7 @@ def check_fast_beginning_events_task():
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-participation-milestones-check')
 def check_participation_milestones_task():
     """
     Check all active fasts for participation milestones.
@@ -373,40 +377,40 @@ def check_participation_milestones_task():
         from hub.models import Fast
         from django.utils import timezone
         from .signals import check_and_track_participation_milestones
-        
+
         today = timezone.now().date()
-        
+
         # Find active fasts (those with days today or in the future)
         active_fasts = Fast.objects.filter(
             days__date__gte=today
         ).distinct()
-        
+
         milestones_created = 0
         fasts_checked = 0
-        
+
         for fast in active_fasts:
             try:
                 fasts_checked += 1
-                
+
                 # Check for milestones
                 milestone_created = check_and_track_participation_milestones(fast)
-                
+
                 if milestone_created:
                     milestones_created += 1
                     logger.info(f"Created milestone event for fast {fast.name}")
                 else:
                     logger.debug(f"No milestone reached for fast {fast.name}")
-                    
+
             except Exception as e:
                 logger.error(f"Error checking milestones for fast {fast.name}: {e}")
                 continue
-        
+
         logger.info(f"Checked {fasts_checked} active fasts, created {milestones_created} milestone events")
         return {
             'fasts_checked': fasts_checked,
             'milestones_created': milestones_created
         }
-        
+
     except Exception as e:
         logger.error(f"Error checking participation milestones: {e}")
         return {
@@ -417,6 +421,7 @@ def check_participation_milestones_task():
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-devotional-availability-check')
 def check_devotional_availability_task():
     """
     Check for devotionals that become available today and create availability events.
@@ -426,22 +431,22 @@ def check_devotional_availability_task():
         from hub.models import Devotional
         from django.utils import timezone
         from .signals import track_devotional_available
-        
+
         today = timezone.now().date()
-        
+
         # Find devotionals for today
         devotionals_today = Devotional.objects.filter(
             day__date=today
         ).select_related('day', 'day__fast', 'day__fast__church', 'video')
-        
+
         logger.info(f"Found {devotionals_today.count()} devotionals for today ({today})")
-        
+
         events_created = 0
         for devotional in devotionals_today:
             logger.info(f"Processing devotional {devotional.id}: {devotional.video.title if devotional.video else 'No video'}")
             try:
                 fast = devotional.day.fast
-                
+
                 # Check if availability event already exists for today
                 from .models import Event, EventType
                 existing_event = Event.objects.filter(
@@ -451,7 +456,7 @@ def check_devotional_availability_task():
                     timestamp__date=today,
                     data__devotional_id=devotional.id
                 ).exists()
-                
+
                 if not existing_event:
                     # Create devotional info
                     devotional_info = {
@@ -462,24 +467,24 @@ def check_devotional_availability_task():
                         'day_id': devotional.day.id,
                         'order': devotional.order,
                     }
-                    
+
                     # Track the devotional availability
                     track_devotional_available(fast, devotional_info)
                     events_created += 1
                     logger.info(f"Created devotional availability event for {fast.name} - {devotional.video.title if devotional.video else 'Devotional'}")
                 else:
                     logger.info(f"Devotional availability event already exists for {fast.name} - {devotional.video.title if devotional.video else 'Devotional'} today")
-                    
+
             except Exception as e:
                 logger.error(f"Error processing devotional availability for devotional {devotional.id}: {e}")
                 continue
-        
+
         logger.info(f"Checked {devotionals_today.count()} devotionals, created {events_created} availability events")
         return {
             'devotionals_checked': devotionals_today.count(),
             'events_created': events_created
         }
-        
+
     except Exception as e:
         logger.error(f"Error checking devotional availability: {e}")
         return {
@@ -493,11 +498,11 @@ def check_devotional_availability_task():
 def track_devotional_availability_task(self, fast_id, devotional_id):
     """
     Track when a specific devotional becomes available asynchronously.
-    
+
     NOTE: This task is primarily for manual/testing purposes.
     The main devotional availability tracking is handled by the daily
     check_devotional_availability_task which runs at 7 AM.
-    
+
     Args:
         fast_id: ID of the Fast
         devotional_id: ID of the Devotional
@@ -505,10 +510,10 @@ def track_devotional_availability_task(self, fast_id, devotional_id):
     try:
         from hub.models import Fast, Devotional
         from .signals import track_devotional_available
-        
+
         fast = Fast.objects.get(id=fast_id)
         devotional = Devotional.objects.get(id=devotional_id)
-        
+
         # Create devotional info
         devotional_info = {
             'devotional_id': devotional.id,
@@ -518,12 +523,12 @@ def track_devotional_availability_task(self, fast_id, devotional_id):
             'day_id': devotional.day.id,
             'order': devotional.order,
         }
-        
+
         # Track the devotional availability
         track_devotional_available(fast, devotional_info)
-        
+
         logger.info(f"Tracked devotional availability event for fast {fast.name} - {devotional.video.title if devotional.video else 'Devotional'}")
-        
+
         return {
             'fast_id': fast_id,
             'fast_name': fast.name,
@@ -531,7 +536,7 @@ def track_devotional_availability_task(self, fast_id, devotional_id):
             'devotional_title': devotional_info['devotional_title'],
             'event_created': True
         }
-        
+
     except (Fast.DoesNotExist, Devotional.DoesNotExist) as e:
         logger.error(f"Fast {fast_id} or Devotional {devotional_id} not found: {e}")
     except Exception as exc:
@@ -544,27 +549,27 @@ def track_devotional_availability_task(self, fast_id, devotional_id):
 def track_article_published_task(self, article_id):
     """
     Track when an article is published asynchronously.
-    
+
     Args:
         article_id: ID of the Article
     """
     try:
         from learning_resources.models import Article
         from .signals import track_article_published
-        
+
         article = Article.objects.get(id=article_id)
-        
+
         # Track the article publication
         track_article_published(article)
-        
+
         logger.info(f"Tracked article publication event for {article.title}")
-        
+
         return {
             'article_id': article_id,
             'article_title': article.title,
             'event_created': True
         }
-        
+
     except Article.DoesNotExist:
         logger.error(f"Article {article_id} not found")
     except Exception as exc:
@@ -577,27 +582,27 @@ def track_article_published_task(self, article_id):
 def track_recipe_published_task(self, recipe_id):
     """
     Track when a recipe is published asynchronously.
-    
+
     Args:
         recipe_id: ID of the Recipe
     """
     try:
         from learning_resources.models import Recipe
         from .signals import track_recipe_published
-        
+
         recipe = Recipe.objects.get(id=recipe_id)
-        
+
         # Track the recipe publication
         track_recipe_published(recipe)
-        
+
         logger.info(f"Tracked recipe publication event for {recipe.title}")
-        
+
         return {
             'recipe_id': recipe_id,
             'recipe_title': recipe.title,
             'event_created': True
         }
-        
+
     except Recipe.DoesNotExist:
         logger.error(f"Recipe {recipe_id} not found")
     except Exception as exc:
@@ -611,16 +616,16 @@ def track_video_published_task(self, video_id):
     """
     Track when a video is published asynchronously.
     Only tracks general and tutorial videos.
-    
+
     Args:
         video_id: ID of the Video
     """
     try:
         from learning_resources.models import Video
         from .signals import track_video_published
-        
+
         video = Video.objects.get(id=video_id)
-        
+
         # Only track general and tutorial videos
         if video.category not in ['general', 'tutorial']:
             logger.info(f"Skipping video publication tracking for {video.title} (category: {video.category})")
@@ -630,19 +635,19 @@ def track_video_published_task(self, video_id):
                 'event_created': False,
                 'reason': f'Category {video.category} not tracked'
             }
-        
+
         # Track the video publication
         track_video_published(video)
-        
+
         logger.info(f"Tracked video publication event for {video.title}")
-        
+
         return {
             'video_id': video_id,
             'video_title': video.title,
             'video_category': video.category,
             'event_created': True
         }
-        
+
     except Video.DoesNotExist:
         logger.error(f"Video {video_id} not found")
     except Exception as exc:
@@ -652,6 +657,7 @@ def track_video_published_task(self, video_id):
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-completed-fast-milestones-check')
 def check_completed_fast_milestones_task():
     """
     Check for users who have completed their first non-weekly fast and award milestones.
@@ -664,10 +670,10 @@ def check_completed_fast_milestones_task():
         from django.db import models
         from .models import UserMilestone
         from notifications.utils import is_weekly_fast
-        
+
         yesterday = timezone.now().date() - timedelta(days=1)
         logger.info(f"Checking for fasts that ended on {yesterday}")
-        
+
         # Find fasts that ended yesterday
         completed_fasts = Fast.objects.filter(
             days__date=yesterday
@@ -676,33 +682,33 @@ def check_completed_fast_milestones_task():
         ).filter(
             end_date=yesterday  # Only fasts where yesterday was truly the last day
         ).distinct()
-        
+
         milestones_awarded = 0
         users_processed = 0
-        
+
         for fast in completed_fasts:
             # Skip weekly fasts
             if is_weekly_fast(fast):
                 logger.debug(f"Skipping weekly fast: {fast.name}")
                 continue
-                
+
             logger.info(f"Processing completed fast: {fast.name}")
-            
+
             # Get all users who participated in this fast
             participants = fast.profiles.all()
-            
+
             for profile in participants:
                 try:
                     users_processed += 1
                     user = profile.user
-                    
+
                     # Check if user already has the first non-weekly fast completion milestone
                     if UserMilestone.objects.filter(
                         user=user,
                         milestone_type='first_nonweekly_fast_complete'
                     ).exists():
                         continue
-                    
+
                     # Check if this is their first completed non-weekly fast
                     # Get all fasts this user has participated in that have ended before today
                     user_completed_fasts = Fast.objects.filter(
@@ -712,13 +718,13 @@ def check_completed_fast_milestones_task():
                     ).filter(
                         end_date__lt=timezone.now().date()
                     ).distinct()
-                    
+
                     # Filter out weekly fasts
                     non_weekly_completed_fasts = [
-                        f for f in user_completed_fasts 
+                        f for f in user_completed_fasts
                         if not is_weekly_fast(f)
                     ]
-                    
+
                     # If this is their first completed non-weekly fast, award milestone
                     if len(non_weekly_completed_fasts) == 1 and fast in non_weekly_completed_fasts:
                         milestone = UserMilestone.create_milestone(
@@ -735,18 +741,18 @@ def check_completed_fast_milestones_task():
                         if milestone:
                             milestones_awarded += 1
                             logger.info(f"Awarded first non-weekly fast completion milestone to {user.username} for {fast.name}")
-                        
+
                 except Exception as e:
                     logger.error(f"Error processing user {profile.user.username} for fast {fast.name}: {e}")
                     continue
-        
+
         logger.info(f"Processed {users_processed} users, awarded {milestones_awarded} completion milestones")
         return {
             'users_processed': users_processed,
             'milestones_awarded': milestones_awarded,
             'completed_fasts_checked': completed_fasts.count()
         }
-        
+
     except Exception as e:
         logger.error(f"Error checking completed fast milestones: {e}")
         return {
@@ -761,18 +767,18 @@ def check_completed_fast_milestones_task():
 def create_announcement_feed_items_task(self, announcement_id):
     """
     Create activity feed items for all target users when an announcement is published.
-    
+
     Args:
         announcement_id: ID of the Announcement
     """
     try:
         from .models import Announcement, UserActivityFeed
-        
+
         announcement = Announcement.objects.get(id=announcement_id)
-        
+
         # Get target users
         target_users = announcement.get_target_users()
-        
+
         created_count = 0
         for user in target_users:
             try:
@@ -785,28 +791,28 @@ def create_announcement_feed_items_task(self, announcement_id):
                     content_type=announcement_ct,
                     object_id=announcement.id
                 ).exists()
-                
+
                 if not existing_item:
                     UserActivityFeed.create_announcement_item(user, announcement)
                     created_count += 1
-                    
+
             except Exception as e:
                 logger.error(f"Error creating announcement feed item for user {user.username}: {e}")
                 continue
-        
+
         # Update total recipients count
         announcement.total_recipients = created_count
         announcement.save(update_fields=['total_recipients'])
-        
+
         logger.info(f"Created {created_count} announcement feed items for announcement '{announcement.title}'")
-        
+
         return {
             'announcement_id': announcement_id,
             'announcement_title': announcement.title,
             'recipients_count': created_count,
             'target_all_users': announcement.target_all_users
         }
-        
+
     except Announcement.DoesNotExist:
         logger.error(f"Announcement {announcement_id} not found")
         return {
@@ -817,4 +823,4 @@ def create_announcement_feed_items_task(self, announcement_id):
     except Exception as exc:
         logger.error(f"Error creating announcement feed items for announcement {announcement_id}: {exc}")
         # Retry the task
-        raise self.retry(exc=exc) 
+        raise self.retry(exc=exc)

--- a/hub/tasks/bible_api_tasks.py
+++ b/hub/tasks/bible_api_tasks.py
@@ -15,6 +15,7 @@ import logging
 import time
 from datetime import timedelta
 
+import sentry_sdk
 from celery import shared_task
 from django.conf import settings
 from django.db.models import Q
@@ -56,6 +57,7 @@ def fetch_reading_text_task(self, reading_id: int):
 
 
 @shared_task(bind=True, max_retries=1, default_retry_delay=300, name='hub.tasks.refresh_all_reading_texts_task')
+@sentry_sdk.monitor(monitor_slug='weekly-reading-text-refresh')
 def refresh_all_reading_texts_task(self):
     """Refresh Bible text (all languages) for all stale readings.
 

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -10,6 +10,7 @@ from django.db.models import OuterRef, Subquery, Count, Q
 from django.core.cache import cache
 import logging
 import time
+import sentry_sdk
 from .constants import (
     DAILY_FAST_MESSAGE, UPCOMING_FAST_MESSAGE, ONGOING_FAST_MESSAGE,
     ONGOING_FAST_WITH_DEVOTIONAL_MESSAGE, FAST_NONJOIN_NUDGE_MESSAGE,
@@ -529,6 +530,7 @@ def send_daily_fast_push_notification_task():
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-culmination-feast-notifications')
 def send_culmination_feast_push_notification_task():
     """
     Send push notifications to users on the culmination feast date of their joined fasts.
@@ -586,6 +588,7 @@ def send_culmination_feast_push_notification_task():
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='weekly-prayer-request-notifications')
 def send_weekly_prayer_request_push_notification_task():
     """
     Send weekly push notifications about available prayer requests.
@@ -682,6 +685,7 @@ def send_weekly_prayer_request_push_notification_task():
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-fast-nonjoin-nudge')
 def send_fast_nonjoin_nudge_task():
     """
     On days 2, 10, and 20 of an active fast, nudge church members who haven't joined.
@@ -738,6 +742,7 @@ def send_fast_nonjoin_nudge_task():
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-inactive-fast-member-nudge')
 def send_inactive_fast_member_nudge_task():
     """
     Nudge users who joined an active fast but haven't opened the app in 5+ days.
@@ -797,6 +802,7 @@ def send_inactive_fast_member_nudge_task():
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-activity-feed-nudge')
 def send_activity_feed_nudge_task():
     """
     Nudge users with 5+ unread activity feed items who haven't opened the app in 5+ days.
@@ -849,6 +855,7 @@ def send_activity_feed_nudge_task():
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-prayer-acceptance-nudge')
 def send_prayer_acceptance_nudge_task():
     """
     Remind users who accepted a prayer request but haven't logged a prayer for it

--- a/prayers/tasks.py
+++ b/prayers/tasks.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.db.models import Count, Q
 from django.utils import timezone
+import sentry_sdk
 
 from events.models import Event, EventType, UserActivityFeed, UserMilestone
 from hub.models import LLMPrompt
@@ -481,6 +482,7 @@ Admin URL: {settings.SITE_URL}/admin/prayers/prayerrequest/{prayer_request.id}/c
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='frequent-expired-prayer-requests-check')
 def check_expired_prayer_requests_task():
     """
     Check for expired prayer requests and mark them as completed.
@@ -517,6 +519,7 @@ def check_expired_prayer_requests_task():
 
 
 @shared_task
+@sentry_sdk.monitor(monitor_slug='daily-prayer-count-notifications')
 def send_daily_prayer_count_notifications_task():
     """
     Send daily notifications to prayer request creators about how many people prayed.

--- a/tests/unit/test_sentry_cron_monitors.py
+++ b/tests/unit/test_sentry_cron_monitors.py
@@ -1,0 +1,37 @@
+"""Tests for Sentry Cron monitor instrumentation on scheduled Celery tasks."""
+
+from django.test import SimpleTestCase
+
+from bahk.celery import app
+
+# Import modules that register tasks used by app.conf.beat_schedule.
+import events.tasks  # noqa: F401
+import hub.tasks  # noqa: F401
+import notifications.tasks  # noqa: F401
+import prayers.tasks  # noqa: F401
+
+
+class SentryCronMonitorTests(SimpleTestCase):
+    """Ensure code-managed cron tasks emit Sentry check-ins."""
+
+    def test_sentry_beat_tasks_are_monitor_wrapped(self):
+        missing = []
+        for entry_name, entry in app.conf.beat_schedule.items():
+            sentry_options = entry.get("options", {}).get("sentry")
+            if not sentry_options:
+                continue
+
+            task_name = entry["task"]
+            task = app.tasks.get(task_name)
+            if task is None:
+                missing.append(f"{entry_name}: task {task_name} is not registered")
+                continue
+
+            if not getattr(task.run, "__wrapped__", None):
+                monitor_slug = sentry_options.get("monitor_slug")
+                missing.append(
+                    f"{entry_name}: {task_name} is not wrapped by "
+                    f"sentry_sdk.monitor({monitor_slug!r})"
+                )
+
+        self.assertEqual(missing, [])


### PR DESCRIPTION
## Summary
- add Sentry cron monitor decorators to every code-managed Celery beat task that was missing one
- reuse the monitor slugs already configured in bahk/celery.py beat_schedule
- add a guard test that every beat entry with Sentry metadata is registered and monitor-wrapped
- clean trailing whitespace in events/tasks.py; non-whitespace code changes there are only the Sentry import and decorators

Fixes #380

## Validation
- targeted task/monitor tests passed locally: 144 tests OK
- focused monitor guard test passed after whitespace cleanup
- ruff passed for touched files
- git diff --check passed
- Crabbox full CI passed: 1142 tests OK, 2 skipped
- reviewer pass: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only decorators and a test; no change to task business logic beyond whitespace in events/tasks.py.
> 
> **Overview**
> Adds **Sentry Cron check-ins** to scheduled Celery beat tasks by decorating each beat-managed task with `@sentry_sdk.monitor`, using the same `monitor_slug` values already declared in `bahk/celery.py` `beat_schedule`.
> 
> Coverage spans **events** (feed cleanup, fast beginning, milestones, devotionals), **hub** weekly reading refresh, **notifications** (feast, prayer, re-engagement nudges), and **prayers** (expiry and daily prayer counts). A new unit test fails if any beat entry with Sentry metadata points at a task that is not monitor-wrapped. `events/tasks.py` also gets trailing-whitespace cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbce1a5e6a9b890a5e62f30d302fc6bf18a90f83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->