### PR TITLE
Fix Bugbot follow-ups for events and Sentry cron monitors

### DIFF
--- a/events/tasks.py
+++ b/events/tasks.py
@@ -7,7 +7,6 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 from datetime import timedelta
 import logging
-import sentry_sdk
 
 from .models import UserActivityFeed, Event
 
@@ -170,7 +169,6 @@ def batch_create_activity_feed_items_task(event_ids, user_id=None):
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-activity-feed-cleanup')
 def cleanup_old_activity_feed_items_task():
     """
     Clean up old activity feed items based on retention policies.
@@ -307,7 +305,6 @@ def track_fast_beginning_task(self, fast_id):
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-fast-beginning-check')
 def check_fast_beginning_events_task():
     """
     Check for fasts that are beginning today and create beginning events.
@@ -367,7 +364,6 @@ def check_fast_beginning_events_task():
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-participation-milestones-check')
 def check_participation_milestones_task():
     """
     Check all active fasts for participation milestones.
@@ -421,7 +417,6 @@ def check_participation_milestones_task():
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-devotional-availability-check')
 def check_devotional_availability_task():
     """
     Check for devotionals that become available today and create availability events.
@@ -657,7 +652,6 @@ def track_video_published_task(self, video_id):
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-completed-fast-milestones-check')
 def check_completed_fast_milestones_task():
     """
     Check for users who have completed their first non-weekly fast and award milestones.

--- a/events/tests/test_engagement_endpoints.py
+++ b/events/tests/test_engagement_endpoints.py
@@ -578,12 +578,18 @@ class EngagementTrackingEndpointsTest(APITestCase):
         self.assertEqual(response.data['fasts_left'], 0)
 
     def test_event_stats_hides_other_users_milestone_events_for_non_staff(self):
-        """Non-staff users should not receive other users' milestone event rows."""
+        """Non-staff users should receive own and system milestone rows only."""
         own_event = Event.create_event(
             event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
             user=self.user,
             target=self.fast,
             title='Own milestone',
+        )
+        system_event = Event.create_event(
+            event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
+            user=None,
+            target=self.fast,
+            title='System milestone',
         )
         Event.create_event(
             event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
@@ -596,8 +602,8 @@ class EngagementTrackingEndpointsTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            [event['id'] for event in response.data['milestone_events']],
-            [own_event.id],
+            {event['id'] for event in response.data['milestone_events']},
+            {own_event.id, system_event.id},
         )
 
     def test_event_stats_staff_can_see_global_milestone_events(self):
@@ -626,7 +632,7 @@ class EngagementTrackingEndpointsTest(APITestCase):
         )
 
     def test_fast_event_stats_hides_other_users_event_rows_for_non_staff(self):
-        """Non-staff users should only receive their own per-fast event rows."""
+        """Non-staff users should receive own and system per-fast event rows."""
         own_recent = Event.create_event(
             event_type_code=EventType.USER_JOINED_FAST,
             user=self.user,
@@ -638,6 +644,12 @@ class EngagementTrackingEndpointsTest(APITestCase):
             user=self.user,
             target=self.fast,
             title='Own milestone',
+        )
+        system_milestone = Event.create_event(
+            event_type_code=EventType.FAST_PARTICIPANT_MILESTONE,
+            user=None,
+            target=self.fast,
+            title='System milestone',
         )
         Event.create_event(
             event_type_code=EventType.USER_LEFT_FAST,
@@ -658,8 +670,8 @@ class EngagementTrackingEndpointsTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            [event['id'] for event in response.data['milestone_events']],
-            [own_milestone.id],
+            {event['id'] for event in response.data['milestone_events']},
+            {own_milestone.id, system_milestone.id},
         )
         self.assertEqual(
             {event['id'] for event in response.data['recent_activity']},

--- a/events/views.py
+++ b/events/views.py
@@ -3,7 +3,7 @@ API views for the events app.
 Provides endpoints for retrieving events, analytics, and statistics.
 """
 
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from datetime import timedelta
@@ -231,7 +231,9 @@ class EventStatsView(APIView):
             'event_type', 'user', 'content_type'
         ).order_by('-timestamp')
         if not request.user.is_staff:
-            milestone_events = milestone_events.filter(user=request.user)
+            milestone_events = milestone_events.filter(
+                Q(user__isnull=True) | Q(user=request.user)
+            )
         milestone_events = milestone_events[:5]
         
         stats_data = {
@@ -358,7 +360,9 @@ class FastEventStatsView(APIView):
             'event_type', 'user', 'content_type'
         ).order_by('-timestamp')
         if not request.user.is_staff:
-            milestone_events = milestone_events.filter(user=request.user)
+            milestone_events = milestone_events.filter(
+                Q(user__isnull=True) | Q(user=request.user)
+            )
         milestone_events = milestone_events[:5]
         
         # Join timeline (last 30 days)

--- a/hub/tasks/bible_api_tasks.py
+++ b/hub/tasks/bible_api_tasks.py
@@ -15,7 +15,6 @@ import logging
 import time
 from datetime import timedelta
 
-import sentry_sdk
 from celery import shared_task
 from django.conf import settings
 from django.db.models import Q
@@ -57,7 +56,6 @@ def fetch_reading_text_task(self, reading_id: int):
 
 
 @shared_task(bind=True, max_retries=1, default_retry_delay=300, name='hub.tasks.refresh_all_reading_texts_task')
-@sentry_sdk.monitor(monitor_slug='weekly-reading-text-refresh')
 def refresh_all_reading_texts_task(self):
     """Refresh Bible text (all languages) for all stale readings.
 

--- a/hub/tasks/email_tasks.py
+++ b/hub/tasks/email_tasks.py
@@ -11,7 +11,6 @@ def test_email_task():
     test_email()
 
 @shared_task(name='hub.tasks.send_fast_reminder_task')
-@sentry_sdk.monitor(monitor_slug='daily-fast-notifications')
 def send_fast_reminder_task():
     """Send reminders about upcoming fasts."""
     # Add additional context for Sentry

--- a/hub/tasks/feast_tasks.py
+++ b/hub/tasks/feast_tasks.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 @shared_task(name='hub.tasks.create_feast_date_task')
-@sentry_sdk.monitor(monitor_slug='daily-feast-date-creation')
 def create_feast_date_task():
     """
     Create feast date for today if it doesn't already exist.

--- a/hub/tasks/mapping_tasks.py
+++ b/hub/tasks/mapping_tasks.py
@@ -459,7 +459,6 @@ def generate_participant_map(self, fast_id, delay=0):
 
 
 @shared_task(name='hub.tasks.update_current_fast_maps')
-@sentry_sdk.monitor(monitor_slug='daily-fast-map-updates')
 def update_current_fast_maps():
     """
     Update maps for current and upcoming fasts only.

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -10,7 +10,6 @@ from django.db.models import OuterRef, Subquery, Count, Q
 from django.core.cache import cache
 import logging
 import time
-import sentry_sdk
 from .constants import (
     DAILY_FAST_MESSAGE, UPCOMING_FAST_MESSAGE, ONGOING_FAST_MESSAGE,
     ONGOING_FAST_WITH_DEVOTIONAL_MESSAGE, FAST_NONJOIN_NUDGE_MESSAGE,
@@ -530,7 +529,6 @@ def send_daily_fast_push_notification_task():
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-culmination-feast-notifications')
 def send_culmination_feast_push_notification_task():
     """
     Send push notifications to users on the culmination feast date of their joined fasts.
@@ -588,7 +586,6 @@ def send_culmination_feast_push_notification_task():
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='weekly-prayer-request-notifications')
 def send_weekly_prayer_request_push_notification_task():
     """
     Send weekly push notifications about available prayer requests.
@@ -685,7 +682,6 @@ def send_weekly_prayer_request_push_notification_task():
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-fast-nonjoin-nudge')
 def send_fast_nonjoin_nudge_task():
     """
     On days 2, 10, and 20 of an active fast, nudge church members who haven't joined.
@@ -742,7 +738,6 @@ def send_fast_nonjoin_nudge_task():
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-inactive-fast-member-nudge')
 def send_inactive_fast_member_nudge_task():
     """
     Nudge users who joined an active fast but haven't opened the app in 5+ days.
@@ -802,7 +797,6 @@ def send_inactive_fast_member_nudge_task():
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-activity-feed-nudge')
 def send_activity_feed_nudge_task():
     """
     Nudge users with 5+ unread activity feed items who haven't opened the app in 5+ days.
@@ -855,7 +849,6 @@ def send_activity_feed_nudge_task():
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-prayer-acceptance-nudge')
 def send_prayer_acceptance_nudge_task():
     """
     Remind users who accepted a prayer request but haven't logged a prayer for it

--- a/prayers/tasks.py
+++ b/prayers/tasks.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.db.models import Count, Q
 from django.utils import timezone
-import sentry_sdk
 
 from events.models import Event, EventType, UserActivityFeed, UserMilestone
 from hub.models import LLMPrompt
@@ -482,7 +481,6 @@ Admin URL: {settings.SITE_URL}/admin/prayers/prayerrequest/{prayer_request.id}/c
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='frequent-expired-prayer-requests-check')
 def check_expired_prayer_requests_task():
     """
     Check for expired prayer requests and mark them as completed.
@@ -519,7 +517,6 @@ def check_expired_prayer_requests_task():
 
 
 @shared_task
-@sentry_sdk.monitor(monitor_slug='daily-prayer-count-notifications')
 def send_daily_prayer_count_notifications_task():
     """
     Send daily notifications to prayer request creators about how many people prayed.

--- a/tests/unit/test_celery_beat_sync.py
+++ b/tests/unit/test_celery_beat_sync.py
@@ -3,6 +3,10 @@
 from celery.schedules import crontab
 from django.test import TestCase
 from django_celery_beat.models import CrontabSchedule, PeriodicTask
+from django_celery_beat.schedulers import ModelEntry
+from sentry_sdk.integrations.celery.beat import _apply_crons_data_to_schedule_entry
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from bahk.celery import app, sync_beat_schedule_to_db
 
@@ -50,3 +54,44 @@ class BeatScheduleSyncTests(TestCase):
         self.assertEqual(task.task, "hub.tasks.send_fast_reminder_task")
         self.assertEqual(task.crontab.hour, "6")
         self.assertEqual(task.crontab.minute, "30")
+
+    def test_database_scheduler_entries_receive_sentry_cron_headers(self):
+        """DB-backed beat entries still get Sentry cron headers at dispatch."""
+        name = "send-fast-notifications-every-day"
+        app.conf.beat_schedule = {
+            name: {
+                "task": "hub.tasks.send_fast_reminder_task",
+                "schedule": crontab(hour=6, minute=30),
+                "options": {
+                    "sentry": {
+                        "monitor_slug": "daily-fast-notifications",
+                    }
+                },
+            }
+        }
+
+        sync_beat_schedule_to_db()
+
+        periodic_task = PeriodicTask.objects.get(name=name)
+        entry = ModelEntry(periodic_task, app=app)
+        scheduler = SimpleNamespace(app=app)
+        integration = SimpleNamespace(
+            monitor_beat_tasks=True,
+            exclude_beat_tasks=[],
+        )
+
+        with patch(
+            "sentry_sdk.integrations.celery.beat.capture_checkin",
+            return_value="check-in-id",
+        ) as capture_checkin:
+            _apply_crons_data_to_schedule_entry(scheduler, entry, integration)
+
+        headers = entry.options["headers"]
+        self.assertEqual(headers["sentry-monitor-slug"], name)
+        self.assertEqual(headers["sentry-monitor-check-in-id"], "check-in-id")
+        self.assertEqual(headers["sentry-monitor-config"]["schedule"]["type"], "crontab")
+        self.assertEqual(
+            headers["sentry-monitor-config"]["schedule"]["value"],
+            "30 6 * * *",
+        )
+        capture_checkin.assert_called_once()

--- a/tests/unit/test_sentry_cron_monitors.py
+++ b/tests/unit/test_sentry_cron_monitors.py
@@ -1,4 +1,4 @@
-"""Tests for Sentry Cron monitor instrumentation on scheduled Celery tasks."""
+"""Tests for Sentry Cron monitor configuration on scheduled Celery tasks."""
 
 from django.test import SimpleTestCase
 
@@ -12,26 +12,32 @@ import prayers.tasks  # noqa: F401
 
 
 class SentryCronMonitorTests(SimpleTestCase):
-    """Ensure code-managed cron tasks emit Sentry check-ins."""
+    """Ensure code-managed cron tasks are configured for Sentry beat monitoring."""
 
-    def test_sentry_beat_tasks_are_monitor_wrapped(self):
+    def test_sentry_beat_tasks_have_monitor_slugs_and_registered_tasks(self):
         missing = []
         for entry_name, entry in app.conf.beat_schedule.items():
             sentry_options = entry.get("options", {}).get("sentry")
-            if not sentry_options:
-                continue
+            if not sentry_options or not sentry_options.get("monitor_slug"):
+                missing.append(f"{entry_name}: missing Sentry monitor_slug")
 
             task_name = entry["task"]
             task = app.tasks.get(task_name)
             if task is None:
                 missing.append(f"{entry_name}: task {task_name} is not registered")
-                continue
-
-            if not getattr(task.run, "__wrapped__", None):
-                monitor_slug = sentry_options.get("monitor_slug")
-                missing.append(
-                    f"{entry_name}: {task_name} is not wrapped by "
-                    f"sentry_sdk.monitor({monitor_slug!r})"
-                )
 
         self.assertEqual(missing, [])
+
+    def test_sentry_beat_tasks_are_not_also_monitor_wrapped(self):
+        """Avoid duplicate check-ins from beat metadata plus task decorators."""
+        wrapped = []
+        for entry_name, entry in app.conf.beat_schedule.items():
+            if not entry.get("options", {}).get("sentry"):
+                continue
+
+            task_name = entry["task"]
+            task = app.tasks.get(task_name)
+            if task is not None and getattr(task.run, "__wrapped__", None):
+                wrapped.append(f"{entry_name}: {task_name}")
+
+        self.assertEqual(wrapped, [])


### PR DESCRIPTION
## Summary
- preserve system milestone rows (`user=None`) for non-staff event stats while still hiding other users' milestone rows
- remove task-level `@sentry_sdk.monitor` wrappers from scheduled beat tasks to avoid duplicate Sentry cron check-ins
- add regression coverage for DB-backed `django-celery-beat` schedule entries receiving Sentry cron headers via beat instrumentation

## Validation
- `.venv/bin/python manage.py test tests.unit.test_celery_beat_sync tests.unit.test_sentry_cron_monitors events.tests.test_engagement_endpoints --noinput --parallel --settings=tests.test_settings` — 66 OK
- `.venv/bin/ruff check ...` — passed
- `bash scripts/crabbox-validate.sh ci` — ruff passed, 1148 tests OK, 2 skipped
- reviewer re-review — clean

## Context
Follow-up for Bugbot comments on merged PRs #442 and #445.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted privacy filter and observability wiring changes with expanded unit tests; no auth or data-migration impact.
> 
> **Overview**
> Non-staff **event stats** milestone lists now include **system milestones** (`user=None`) as well as the viewer’s own rows, while still hiding other users’ milestones; **per-fast recent activity** stays limited to the current user.
> 
> **Sentry Cron** monitoring for scheduled jobs is consolidated on **Celery Beat** (`options.sentry.monitor_slug` and beat integration): task-level `@sentry_sdk.monitor` decorators were removed from beat-driven tasks across events, hub, notifications, and prayers so check-ins are not duplicated. Tests now assert beat metadata, DB scheduler headers, and that beat tasks are not double-wrapped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c1f54ab59092fe649e8fa4ed4687ad5b63bdd45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->