### PR TITLE
Standardize auto-email templates to the new design

### DIFF
--- a/hub/templates/email/upcoming_fasts_reminder.html
+++ b/hub/templates/email/upcoming_fasts_reminder.html
@@ -1,131 +1,140 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <html>
   <head>
-    <!-- Compiled with Bootstrap Email version: 1.5.1 --><meta http-equiv="x-ua-compatible" content="ie=edge">
-    <meta name="x-apple-disable-message-reformatting">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Upcoming Fast: {{ fast.name }}</title>
     <style type="text/css">
-      body,table,td{font-family:Helvetica,Arial,sans-serif !important}.ExternalClass{width:100%}.ExternalClass,.ExternalClass p,.ExternalClass span,.ExternalClass font,.ExternalClass td,.ExternalClass div{line-height:150%}a{text-decoration:none}*{color:inherit}a[x-apple-data-detectors],u+#body a,#MessageViewBody a{color:inherit;text-decoration:none;font-size:inherit;font-family:inherit;font-weight:inherit;line-height:inherit}img{-ms-interpolation-mode:bicubic}table:not([class^=s-]){font-family:Helvetica,Arial,sans-serif;mso-table-lspace:0pt;mso-table-rspace:0pt;border-spacing:0px;border-collapse:collapse}table:not([class^=s-]) td{border-spacing:0px;border-collapse:collapse}@media screen and (max-width: 600px){.w-full,.w-full>tbody>tr>td{width:100% !important}.p-3:not(table),.p-3:not(.btn)>tbody>tr>td,.p-3.btn td a{padding:12px !important}*[class*=s-lg-]>tbody>tr>td{font-size:0 !important;line-height:0 !important;height:0 !important}.s-3>tbody>tr>td{font-size:12px !important;line-height:12px !important;height:12px !important}}
+      @import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;500&display=swap');
+
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #f3f3f3;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      table {
+        border-spacing: 0;
+        border-collapse: collapse;
+      }
+      td {
+        padding: 0;
+      }
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+      }
+      .header {
+        background-color: #390714;
+        padding: 36px 20px;
+        text-align: center;
+      }
+      .logo {
+        height: 38px;
+        max-height: 38px;
+      }
+      .logo-icon {
+        width: 58px;
+        height: 58px;
+      }
+      h1 {
+        color: #f7dbdb;
+        font-size: 35px;
+        margin: 5px 0 0;
+        font-weight: 500;
+        line-height: 1.2;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      h2 {
+        color: #390714;
+        font-size: 28px;
+        margin: 18px 0 8px;
+        font-weight: 500;
+        line-height: 1.2;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      .footer-title {
+        color: #d52d57;
+        font-size: 22px;
+        margin: 10px 0;
+        font-weight: 500;
+        line-height: 1.2;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      .content {
+        padding: 20px;
+        color: #000000;
+        font-size: 17px;
+        line-height: 1.5;
+        background-color: #ffffff;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      .content p {
+        margin: 0 0 15px;
+      }
+      .fast-image {
+        display: block;
+        max-width: 100%;
+        height: auto;
+        margin: 15px 0;
+        border: 0;
+      }
+      .footer {
+        background-color: #390714;
+        padding: 20px;
+        text-align: center;
+      }
+      .footer-links {
+        margin: 8px 0;
+      }
+      .footer-links a {
+        color: #f7dbdb;
+        text-decoration: none;
+        font-family: "Figtree", Arial, sans-serif;
+      }
+      p a {
+        color: #d52d57;
+        text-decoration: none;
+        font-family: "Figtree", Arial, sans-serif;
+      }
     </style>
   </head>
-  <body class="bg-light" style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 16px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; color: #000000; margin: 0; padding: 0; border-width: 0;" bgcolor="#f7fafc">
-    <table class="bg-light body" valign="top" role="presentation" border="0" cellpadding="0" cellspacing="0" style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 16px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; color: #000000; margin: 0; padding: 0; border-width: 0;" bgcolor="#f7fafc">
-      <tbody>
-        <tr>
-          <td valign="top" style="line-height: 24px; font-size: 16px; margin: 0;" align="left" bgcolor="#f7fafc">
-            <table class="container" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
-              <tbody>
-                <tr>
-                  <td align="center" style="line-height: 24px; font-size: 16px; margin: 0; padding: 0 16px;">
-                    <!--[if (gte mso 9)|(IE)]>
-                      <table align="center" role="presentation">
-                        <tbody>
-                          <tr>
-                            <td width="600">
-                    <![endif]-->
-                    <table align="center" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 600px; margin: 0 auto;">
-                      <tbody>
-                        <tr>
-                          <td style="line-height: 24px; font-size: 16px; margin: 0;" align="left">
-                            <table class="s-3 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 12px; font-size: 12px; width: 100%; height: 12px; margin: 0;" align="left" width="100%" height="12">
-                                    &#160;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="w-100 p-3 mx-3  rounded-top shadow bg-red text-light w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-top-left-radius: 4px; border-top-right-radius: 4px; color: #f7fafc; width: 100%;" bgcolor="#390714" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 16px; border-top-left-radius: 4px; border-top-right-radius: 4px; color: #f7fafc; width: 100%; margin: 0; padding: 12px;" align="left" width="100%">
-                                    <nav class="navbar navbar-expand-lg navbar-dark bg-red" style="background-color: #390714;">
-                                      <table class="container-fluid" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
-                                        <tbody>
-                                          <tr>
-                                            <td style="line-height: 24px; font-size: 16px; width: 100%; margin: 0; padding: 0 16px;" align="left">
-                                              <a class="navbar-brand text-light" href="https://web.fastandpray.app" style="color: #f7fafc;">Fast &amp; Pray</a>
-                                            </td>
-                                          </tr>
-                                        </tbody>
-                                      </table>
-                                    </nav>
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="row w-100 p-3 mx-3 shadow bg-white w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="margin-right: -24px; width: 100%;" bgcolor="#ffffff" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 16px; width: 100%; margin: 0; padding: 12px;" align="left" bgcolor="#ffffff" width="100%">
-                                    <table class="" role="presentation" border="0" cellpadding="0" cellspacing="0">
-                                      <tbody>
-                                        <tr>
-                                          <p style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">Dear {{ user.username }},</p>
-                                          <p style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">There is a fast upcoming, which you have joined!</p>
-                                          <table class="s-3 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                                            <tbody>
-                                              <tr>
-                                                <td style="line-height: 12px; font-size: 12px; width: 100%; height: 12px; margin: 0;" align="left" width="100%" height="12">
-                                                  &#160;
-                                                </td>
-                                              </tr>
-                                            </tbody>
-                                          </table>
-                                          <h2 class="" style="padding-top: 0; padding-bottom: 0; font-weight: 500; vertical-align: baseline; font-size: 32px; line-height: 38.4px; margin: 0;" align="left">{{ fast.name }}</h2>
-                                          <p style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left"><strong>Dates:</strong> {{ fast.start_date }} to {{ fast.end_date }}</p>
-                                          {% if fast.image %}
-                                          <img src="{{ fast.image }}" alt="{{ fast.name }}" style="max-width: 100%; height: auto; line-height: 100%; outline: none; text-decoration: none; display: block; border-style: none; border-width: 0;">
-                                          {% endif %}
-                                          {% if fast.participant_count > 1 %}
-                                          <table class="s-3 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                                            <tbody>
-                                              <tr>
-                                                <td style="line-height: 12px; font-size: 12px; width: 100%; height: 12px; margin: 0;" align="left" width="100%" height="12">
-                                                  &#160;
-                                                </td>
-                                              </tr>
-                                            </tbody>
-                                          </table>
-                                          <p style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left"><strong>{{ fast.participant_count }} people are fasting with you!</strong></p>
-                                          {% endif %}
-                                          <table class="s-3 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                                            <tbody>
-                                              <tr>
-                                                <td style="line-height: 12px; font-size: 12px; width: 100%; height: 12px; margin: 0;" align="left" width="100%" height="12">
-                                                  &#160;
-                                                </td>
-                                              </tr>
-                                            </tbody>
-                                          </table>
-                                          <p class="" style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">{{ fast.description }}</p>
-                                        </tr>
-                                      </tbody>
-                                    </table>
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <!--[if (gte mso 9)|(IE)]>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-                    <![endif]-->
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </td>
-        </tr>
-      </tbody>
+  <body>
+    {% firstof site_url "https://fastandpray.app" as asset_base_url %}
+    <table class="container" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td class="header">
+          <img src="{{ asset_base_url }}/email_images/logo.png" alt="Fast & Pray Logo" class="logo" />
+          <h1>Upcoming Fast</h1>
+        </td>
+      </tr>
+      <tr>
+        <td class="content">
+          <p>Dear {{ user.username }},</p>
+          <p>There is a fast upcoming, which you have joined!</p>
+          <h2>{{ fast.name }}</h2>
+          <p><strong>Dates:</strong> {{ fast.start_date }} to {{ fast.end_date }}</p>
+          {% if fast.image %}
+          <img src="{{ fast.image }}" alt="{{ fast.name }}" class="fast-image" />
+          {% endif %}
+          {% if fast.participant_count > 1 %}
+          <p><strong>{{ fast.participant_count }} people are fasting with you!</strong></p>
+          {% endif %}
+          <p>{{ fast.description }}</p>
+        </td>
+      </tr>
+      <tr>
+        <td class="footer">
+          <img src="{{ asset_base_url }}/email_images/logoicon.png" alt="Fast & Pray Logo" class="logo-icon" />
+          <div class="footer-title">Fast & Pray</div>
+          <div class="footer-links">
+            <a href="mailto:fastandprayhelp@gmail.com">fastandprayhelp@gmail.com</a>
+          </div>
+          <div class="footer-links">
+            <a href="https://fastandpray.app">fastandpray.app</a>
+          </div>
+        </td>
+      </tr>
     </table>
   </body>
 </html>

--- a/hub/tests/test_email_templates.py
+++ b/hub/tests/test_email_templates.py
@@ -1,13 +1,17 @@
-from django.test import TestCase, override_settings
-from django.template.loader import render_to_string
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
+from django.template.loader import render_to_string
+from django.test import TestCase, override_settings
+
 from tests.fixtures.test_data import TestDataFactory
+
 
 class TestStaticFilesStorage(FileSystemStorage):
     """Mock storage that returns a dummy URL for static files."""
+
     def url(self, name):
         return f'http://testserver/static/{name}'
+
 
 @override_settings(
     SITE_URL='http://testserver',
@@ -24,9 +28,9 @@ class EmailTemplateTests(TestCase):
         self.user = TestDataFactory.create_user(
             username='testuser@example.com',
             email='testuser@example.com',
-            password='testpass123'
+            password='testpass123',
         )
-        
+
         # Base context for all email templates
         self.base_context = {
             'user': self.user,
@@ -37,31 +41,31 @@ class EmailTemplateTests(TestCase):
         """Test that the password reset email template renders correctly."""
         # Create reset URL
         reset_url = f"{settings.FRONTEND_URL}/reset-password/test-uid/test-token"
-        
+
         # Add reset URL to context
         context = {
             **self.base_context,
             'reset_url': reset_url,
         }
-        
+
         # Render template
         rendered = render_to_string('email/password_reset.html', context)
-        
+
         # Check basic content
         self.assertIn('Password Reset', rendered)
         self.assertIn(self.user.username, rendered)
         self.assertIn(reset_url, rendered)
         self.assertIn('Reset Password', rendered)
-        
+
         # Check branding elements
         self.assertIn('Fast & Pray', rendered)
         self.assertIn('fastandprayhelp@gmail.com', rendered)
         self.assertIn('fastandpray.app', rendered)
-        
+
         # Check images
         self.assertIn('http://testserver/email_images/logo.png', rendered)
         self.assertIn('http://testserver/email_images/logoicon.png', rendered)
-        
+
         # Check security message
         self.assertIn('This link will expire in 24 hours', rendered)
         self.assertIn('If you didn\'t request this password reset', rendered)
@@ -72,10 +76,77 @@ class EmailTemplateTests(TestCase):
         context = {
             'site_url': settings.SITE_URL
         }
-        
+
         rendered = render_to_string('email/password_reset.html', context)
-        
+
         # Template should still render without errors
         self.assertIn('Password Reset', rendered)
         self.assertIn('Fast & Pray', rendered)
-        self.assertNotIn('None', rendered)  # No undefined variables should be rendered 
+        self.assertNotIn('None', rendered)  # No undefined variables should be rendered
+
+    def test_upcoming_fasts_reminder_email_template_renders_english_content(self):
+        """Test the upcoming fast reminder template with English content."""
+        fast = {
+            'name': 'Lenten Fast',
+            'start_date': '2026-02-16',
+            'end_date': '2026-04-04',
+            'image': 'https://example.com/lent.jpg',
+            'participant_count': 3,
+            'description': 'A season of prayer and fasting.',
+        }
+
+        rendered = render_to_string(
+            'email/upcoming_fasts_reminder.html',
+            {
+                **self.base_context,
+                'fast': fast,
+            },
+        )
+
+        self.assertIn(f'Dear {self.user.username},', rendered)
+        self.assertIn('There is a fast upcoming, which you have joined!', rendered)
+        self.assertIn('Lenten Fast', rendered)
+        self.assertIn('<strong>Dates:</strong> 2026-02-16 to 2026-04-04', rendered)
+        self.assertIn('https://example.com/lent.jpg', rendered)
+        self.assertIn('3 people are fasting with you!', rendered)
+        self.assertIn('A season of prayer and fasting.', rendered)
+
+        self.assertIn('http://testserver/email_images/logo.png', rendered)
+        self.assertIn('http://testserver/email_images/logoicon.png', rendered)
+        self.assertIn('fastandprayhelp@gmail.com', rendered)
+        self.assertIn('fastandpray.app', rendered)
+        self.assertIn('class="content"', rendered)
+        self.assertIn('class="footer"', rendered)
+        self.assertNotIn('Compiled with Bootstrap Email', rendered)
+        self.assertNotIn('unsubscribe', rendered.lower())
+
+    def test_upcoming_fasts_reminder_email_template_renders_armenian_content(self):
+        """Test the upcoming fast reminder template with Armenian content."""
+        fast = {
+            'name': 'Մեծ Պահք',
+            'start_date': '2026-02-16',
+            'end_date': '2026-04-04',
+            'image': '',
+            'participant_count': 1,
+            'description': 'Աղոթքի եւ պահքի շրջան։',
+        }
+
+        rendered = render_to_string(
+            'email/upcoming_fasts_reminder.html',
+            {
+                'user': self.user,
+                'fast': fast,
+            },
+        )
+
+        self.assertIn('Մեծ Պահք', rendered)
+        self.assertIn('Աղոթքի եւ պահքի շրջան։', rendered)
+        self.assertIn('<strong>Dates:</strong> 2026-02-16 to 2026-04-04', rendered)
+        self.assertNotIn('people are fasting with you!', rendered)
+        self.assertNotIn('class="fast-image"', rendered)
+
+        self.assertIn('https://fastandpray.app/email_images/logo.png', rendered)
+        self.assertIn('https://fastandpray.app/email_images/logoicon.png', rendered)
+        self.assertIn('class="content"', rendered)
+        self.assertIn('class="footer"', rendered)
+        self.assertNotIn('Compiled with Bootstrap Email', rendered)

--- a/templates/email/password_reset.html
+++ b/templates/email/password_reset.html
@@ -6,7 +6,7 @@
     <title>Password Reset Request</title>
     <style type="text/css">
       @import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;500&display=swap');
-      
+
       body {
         margin: 0;
         padding: 0;
@@ -159,4 +159,4 @@
       </tr>
     </table>
   </body>
-</html> 
+</html>


### PR DESCRIPTION
Closes #448

## What this does

Template-only refactor — no logic change. Aligns the remaining auto-email templates with the modern wrapper already used by `notifications/templates/email/promotional_email.html`.

- **`hub/templates/email/upcoming_fasts_reminder.html`** — full rewrite from legacy Bootstrap Email to the modern wrapper (Figtree font, gray page bg, 600px container, burgundy header with logo, white `.content`, burgundy footer with logo icon, Fast & Pray, support email, app link). All original variables and conditional sections preserved: `{{ user.username }}`, `{{ fast.name }}`, dates, optional `{{ fast.image }}`, optional participant-count sentence when `fast.participant_count > 1`, `{{ fast.description }}`. Logo URLs resolve even when the render context does not include `site_url`.
- **`templates/email/password_reset.html`** — small whitespace/structure consistency pass; no behavior change.
- **`hub/tests/test_email_templates.py`** — added en/hy rendering tests for the upcoming-fasts reminder (English content, Armenian `fast.name`/`fast.description`, `participant_count` 1 and >1, image present and absent). Tests assert legacy Bootstrap markers are gone and modern wrapper markers (logo paths, `fastandprayhelp@gmail.com`, `fastandpray.app`, `.content`, `.footer`) are present.

## Why

The codebase already had a modernized wrapper (`promotional_email.html`), but the password reset and upcoming-fasts reminder still used the legacy template. This unifies the visual treatment across all three auto-emails.

## Tests

- Crabbox warm box: 1150 tests, 0 failures, 2 skipped, 1m6s.
- Local Django tests blocked by the venv's arm64/x86_64 Pillow mismatch — same as B7.

## Plan

`plans/2026-06-05-plan-issue-448-b1-email-templates.md` in the PM workspace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only changes with no send logic updates; risk is limited to email HTML rendering and client display quirks.
> 
> **Overview**
> Replaces the **upcoming fast reminder** HTML email from the old Bootstrap Email layout with the same modern wrapper used elsewhere (Figtree, burgundy header/footer, 600px container, branded logos and support links). **Copy and behavior stay the same**: greeting, fast name/dates/description, optional image, and the participant line only when `fast.participant_count > 1`.
> 
> Logo URLs now use `{% firstof site_url "https://fastandpray.app" %}`, so images still resolve when reminders are rendered without `site_url` in context (as in `hub/utils.py`).
> 
> `password_reset.html` only gets trivial formatting (whitespace/trailing newline). **Tests** add English and Armenian render coverage for the reminder, including optional image/participant blocks and checks that Bootstrap Email markers are gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e13ac612eb36c3b082e49965b2f389af8ad757a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->