### PR TITLE
Expose feast icon match trigger endpoint

### DIFF
--- a/hub/tests/test_feast_match_icon_api.py
+++ b/hub/tests/test_feast_match_icon_api.py
@@ -1,0 +1,129 @@
+"""Tests for the feast icon match trigger API."""
+
+from datetime import date
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from hub.models import Church, Day, Feast
+from icons.models import Icon
+
+
+class FeastMatchIconAPITests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.staff_user = user_model.objects.create_user(
+            username="staff",
+            email="staff@example.com",
+            password="password",
+            is_staff=True,
+        )
+        self.regular_user = user_model.objects.create_user(
+            username="regular",
+            email="regular@example.com",
+            password="password",
+        )
+        self.client = APIClient()
+        self.church = Church.objects.get(pk=Church.get_default_pk())
+
+        self.day_without_icon = Day.objects.create(
+            date=date(2026, 6, 8),
+            church=self.church,
+        )
+        self.day_with_icon = Day.objects.create(
+            date=date(2026, 6, 9),
+            church=self.church,
+        )
+        image = SimpleUploadedFile(
+            name="test_icon.jpg",
+            content=b"fake image content",
+            content_type="image/jpeg",
+        )
+        self.icon = Icon.objects.create(
+            title="Existing Icon",
+            church=self.church,
+            image=image,
+        )
+
+        with patch("hub.signals.match_icon_to_feast_task.delay"), patch(
+            "hub.signals.determine_feast_designation_task.delay"
+        ):
+            self.feast_without_icon = Feast.objects.create(
+                day=self.day_without_icon,
+                name="Feast Without Icon",
+            )
+            self.feast_with_icon = Feast.objects.create(
+                day=self.day_with_icon,
+                name="Feast With Icon",
+                icon=self.icon,
+            )
+
+    def test_staff_post_enqueues_when_icon_missing(self):
+        self.client.force_authenticate(user=self.staff_user)
+        url = reverse("feast-match-icon", kwargs={"feast_id": self.feast_without_icon.pk})
+
+        with patch("hub.views.feasts.match_icon_to_feast_task.delay") as mock_delay:
+            response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "status": "enqueued",
+                "feast_id": self.feast_without_icon.pk,
+                "reason": "icon missing",
+            },
+        )
+        mock_delay.assert_called_once_with(self.feast_without_icon.pk)
+
+    def test_staff_post_skips_when_icon_present(self):
+        self.client.force_authenticate(user=self.staff_user)
+        url = reverse("feast-match-icon", kwargs={"feast_id": self.feast_with_icon.pk})
+
+        with patch("hub.views.feasts.match_icon_to_feast_task.delay") as mock_delay:
+            response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "status": "skipped",
+                "feast_id": self.feast_with_icon.pk,
+                "reason": "icon already present",
+            },
+        )
+        mock_delay.assert_not_called()
+
+    def test_non_staff_post_forbidden(self):
+        self.client.force_authenticate(user=self.regular_user)
+        url = reverse("feast-match-icon", kwargs={"feast_id": self.feast_without_icon.pk})
+
+        with patch("hub.views.feasts.match_icon_to_feast_task.delay") as mock_delay:
+            response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_delay.assert_not_called()
+
+    def test_anonymous_post_requires_authentication(self):
+        url = reverse("feast-match-icon", kwargs={"feast_id": self.feast_without_icon.pk})
+
+        with patch("hub.views.feasts.match_icon_to_feast_task.delay") as mock_delay:
+            response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        mock_delay.assert_not_called()
+
+    def test_missing_feast_returns_404_for_staff(self):
+        self.client.force_authenticate(user=self.staff_user)
+        url = reverse("feast-match-icon", kwargs={"feast_id": 999999})
+
+        with patch("hub.views.feasts.match_icon_to_feast_task.delay") as mock_delay:
+            response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        mock_delay.assert_not_called()

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -30,7 +30,7 @@ from .views.user import (
 )
 from .views.church import ChurchListView, ChurchDetailView
 from .views.readings import GetDailyReadingsForDate, ReadingContextFeedbackView
-from .views.feasts import GetFeastForDate, FeastContextFeedbackView
+from .views.feasts import FeastContextFeedbackView, FeastMatchIconView, GetFeastForDate
 from .views.patristic_quotes import (
     PatristicQuoteListView,
     PatristicQuoteDetailView,
@@ -106,6 +106,11 @@ urlpatterns = [
 
     # Feasts endpoints
     path("feasts/", GetFeastForDate.as_view(), name="feast-for-date"),
+    path(
+        "feasts/<int:feast_id>/match-icon/",
+        FeastMatchIconView.as_view(),
+        name="feast-match-icon",
+    ),
     path("feasts/<int:pk>/feedback/", FeastContextFeedbackView.as_view(), name="feast-context-feedback"),
 
 

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -19,8 +19,10 @@ from rest_framework.views import APIView
 
 from hub.models import Church, Day, Feast, FeastContext
 from hub.tasks import generate_feast_context_task
+from hub.tasks.icon_tasks import match_icon_to_feast_task
 from hub.utils import get_user_profile_safe, get_or_create_feast_for_date
 from icons.serializers import IconSerializer
+from icons.views import IsAdminOrReadOnly
 
 
 class GetFeastForDate(generics.GenericAPIView):
@@ -230,6 +232,35 @@ class GetFeastForDate(generics.GenericAPIView):
                 },
                 status=status.HTTP_200_OK  # Return 200 not 500 so clients handle gracefully
             )
+
+
+class FeastMatchIconView(APIView):
+    """Admin-only endpoint to enqueue icon matching for a feast missing an icon."""
+
+    permission_classes = [IsAdminOrReadOnly]
+
+    def post(self, request, feast_id: int):
+        feast = get_object_or_404(Feast, pk=feast_id)
+
+        if feast.icon_id is None:
+            match_icon_to_feast_task.delay(feast.id)
+            return Response(
+                {
+                    "status": "enqueued",
+                    "feast_id": feast.id,
+                    "reason": "icon missing",
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        return Response(
+            {
+                "status": "skipped",
+                "feast_id": feast.id,
+                "reason": "icon already present",
+            },
+            status=status.HTTP_200_OK,
+        )
 
 
 class FeastContextFeedbackView(APIView):


### PR DESCRIPTION
## Summary
- add staff-only POST /api/feasts/<feast_id>/match-icon/ endpoint
- enqueue AI icon matching only when the feast has no icon
- add API tests for enqueue, skip, auth/permission, and missing feast cases

Closes #455.

## Validation
- .venv/bin/ruff check hub/views/feasts.py hub/urls.py hub/tests/test_feast_match_icon_api.py
- bash scripts/crabbox-validate.sh test: 1162 tests OK, skipped 2
- bash scripts/crabbox-validate.sh ci: ruff OK; 1162 tests OK, skipped 2

## Review
- reviewer subagent: no findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped admin trigger with idempotent skip when an icon exists; covered by tests and no changes to public feast read paths.
> 
> **Overview**
> Adds a **staff-only** `POST /feasts/<feast_id>/match-icon/` route so admins can manually kick off icon matching for a feast.
> 
> `FeastMatchIconView` loads the feast, and if `icon_id` is missing it enqueues `match_icon_to_feast_task` and returns `{status: enqueued, reason: icon missing}`; if an icon is already linked it returns `{status: skipped}` without calling the task. Access uses the existing `IsAdminOrReadOnly` permission (staff for writes).
> 
> New API tests cover enqueue vs skip, 403 for non-staff, 401 for anonymous callers, and 404 for unknown feast IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166e4a1f248a38ef05bce0ab6c3843991a0c927f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->