### PR TITLE
[codex] Invalidate feast API cache on data changes

### DIFF
--- a/hub/cache.py
+++ b/hub/cache.py
@@ -1,0 +1,56 @@
+"""Cache helpers for hub API responses."""
+
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+
+def feast_api_cache_key(date_obj, church_id, lang):
+    """Return the public feast API cache key."""
+    return f"feast:{date_obj}:{church_id}:{lang}"
+
+
+def feast_api_cache_languages():
+    """Return likely language variants for feast API cache invalidation."""
+    languages = ["en"]
+
+    languages.extend(getattr(settings, "MODELTRANS_AVAILABLE_LANGUAGES", []))
+    languages.extend(code for code, _name in getattr(settings, "LANGUAGES", []))
+
+    language_code = getattr(settings, "LANGUAGE_CODE", None)
+    if language_code:
+        languages.append(language_code)
+
+    seen = set()
+    return [lang for lang in languages if lang and not (lang in seen or seen.add(lang))]
+
+
+def invalidate_feast_api_cache_for_date(date_obj, church_id):
+    """Best-effort invalidation for all known feast API language variants."""
+    pattern = feast_api_cache_key(date_obj, church_id, "*")
+
+    if hasattr(cache, "delete_pattern"):
+        try:
+            cache.delete_pattern(pattern)
+        except Exception:
+            logger.warning("Failed to delete feast API cache pattern %s", pattern, exc_info=True)
+
+    keys = [
+        feast_api_cache_key(date_obj, church_id, lang)
+        for lang in feast_api_cache_languages()
+    ]
+    try:
+        cache.delete_many(keys)
+    except Exception:
+        logger.warning("Failed to delete feast API cache keys %s", keys, exc_info=True)
+
+
+def invalidate_feast_api_cache_for_feast(feast):
+    """Best-effort invalidation for the API cache entries affected by a feast."""
+    try:
+        invalidate_feast_api_cache_for_date(feast.day.date, feast.day.church_id)
+    except Exception:
+        logger.warning("Failed to invalidate feast API cache for feast %s", feast.pk, exc_info=True)

--- a/hub/signals.py
+++ b/hub/signals.py
@@ -1,11 +1,13 @@
 import logging
 
-from django.db.models.signals import m2m_changed, post_save
+from django.db.models.signals import m2m_changed, post_delete, post_save, pre_delete
 from django.dispatch import receiver
 from django.core.cache import cache
-from hub.models import Profile, Feast
+from hub.cache import invalidate_feast_api_cache_for_feast
+from hub.models import Profile, Feast, FeastContext
 from hub.tasks.llm_tasks import determine_feast_designation_task
 from hub.tasks.icon_tasks import match_icon_to_feast_task
+from icons.models import Icon
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +57,8 @@ def handle_feast_save(sender, instance, created, **kwargs):
     translations are updated immediately after creation.
     The task itself will also check and skip if designation is already set.
     """
+    invalidate_feast_api_cache_for_feast(instance)
+
     # Only trigger designation task on creation, not on updates
     # This prevents duplicate task enqueuing when translations are set immediately after creation
     if created and not instance.designation:
@@ -65,3 +69,46 @@ def handle_feast_save(sender, instance, created, **kwargs):
     # Trigger icon matching when feast is created
     if created:
         match_icon_to_feast_task.delay(instance.id)
+
+
+@receiver(post_delete, sender=Feast)
+def handle_feast_delete(sender, instance, **kwargs):
+    """Invalidate feast API cache entries when a feast is deleted."""
+    invalidate_feast_api_cache_for_feast(instance)
+
+
+@receiver(post_save, sender=FeastContext)
+def handle_feast_context_save(sender, instance, **kwargs):
+    """Invalidate feast API cache entries when context content or votes change."""
+    invalidate_feast_api_cache_for_feast(instance.feast)
+
+
+@receiver(post_delete, sender=FeastContext)
+def handle_feast_context_delete(sender, instance, **kwargs):
+    """Invalidate feast API cache entries when context is deleted."""
+    invalidate_feast_api_cache_for_feast(instance.feast)
+
+
+def invalidate_feast_api_cache_for_icon(icon):
+    """Invalidate feast API cache entries for every feast using an icon."""
+    for feast in icon.feasts.select_related("day", "day__church").all():
+        invalidate_feast_api_cache_for_feast(feast)
+
+
+@receiver(post_save, sender=Icon)
+def handle_icon_save(sender, instance, **kwargs):
+    """Invalidate feast API cache entries when serialized icon fields change."""
+    invalidate_feast_api_cache_for_icon(instance)
+
+
+@receiver(pre_delete, sender=Icon)
+def handle_icon_delete(sender, instance, **kwargs):
+    """Invalidate feast API cache entries before icon deletion clears feast links."""
+    invalidate_feast_api_cache_for_icon(instance)
+
+
+@receiver(m2m_changed, sender=Icon.tags.through)
+def handle_icon_tags_change(sender, instance, action, **kwargs):
+    """Invalidate feast API cache entries when serialized icon tags change."""
+    if isinstance(instance, Icon) and action in ("post_add", "post_remove", "post_clear"):
+        invalidate_feast_api_cache_for_icon(instance)

--- a/hub/tests/test_feast_views.py
+++ b/hub/tests/test_feast_views.py
@@ -4,14 +4,17 @@ from unittest.mock import Mock, patch
 import urllib.error
 
 from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import resolve, reverse
 from rest_framework import status
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from hub.models import Church, Day, Feast, FeastContext
+from hub.tasks.icon_tasks import match_icon_to_feast_task
 from hub.utils import _fetch_sacredtradition, _stable_url_key
 from hub.views.feasts import FeastContextFeedbackView, GetFeastForDate
+from icons.models import Icon
 from tests.fixtures.test_data import TestDataFactory
 
 
@@ -171,6 +174,35 @@ class FeastAPIRouteTests(TestCase):
         self.hub_url = reverse("feast-for-date")
         cache.clear()
 
+    def _create_feast(self, **kwargs):
+        day = kwargs.pop(
+            "day",
+            Day.objects.create(date=self.test_date, church=self.church),
+        )
+        with patch("hub.signals.match_icon_to_feast_task.delay"), patch(
+            "hub.signals.determine_feast_designation_task.delay"
+        ):
+            return Feast.objects.create(day=day, **kwargs)
+
+    def _create_icon(self, title="Nativity Icon"):
+        return Icon.objects.create(
+            title=title,
+            church=self.church,
+            image=SimpleUploadedFile(
+                "test-icon.jpg",
+                b"fake image content",
+                content_type="image/jpeg",
+            ),
+            cached_thumbnail_url="https://example.com/test-icon.jpg",
+        )
+
+    def _get_cached_feast_response(self, feast):
+        with patch("hub.views.feasts.generate_feast_context_task.delay"), patch(
+            "hub.views.feasts.get_or_create_feast_for_date",
+            return_value=(feast, False, {"status": "success"}),
+        ):
+            return self.client.get("/api/feasts/", {"date": self.date_str})
+
     def test_hub_feasts_url_resolves_to_feast_for_date_view(self):
         match = resolve("/hub/feasts/")
 
@@ -315,6 +347,129 @@ class FeastAPIRouteTests(TestCase):
             "Invalid date format. Expected format: YYYY-MM-DD",
             str(response.json()),
         )
+
+    def test_feast_save_invalidates_cached_icon_response(self):
+        feast = self._create_feast(name="Christmas")
+        icon = self._create_icon()
+
+        first_response = self._get_cached_feast_response(feast)
+        self.assertIsNone(first_response.json()["feast"]["icon"])
+
+        feast.icon = icon
+        feast.save(update_fields=["icon"])
+
+        second_response = self._get_cached_feast_response(feast)
+        self.assertEqual(second_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(second_response.json()["feast"]["icon"]["id"], icon.id)
+
+    def test_icon_matching_task_save_invalidates_cached_response(self):
+        feast = self._create_feast(name="Nativity of Christ")
+        icon = self._create_icon()
+
+        first_response = self._get_cached_feast_response(feast)
+        self.assertIsNone(first_response.json()["feast"]["icon"])
+
+        with patch("hub.tasks.icon_tasks._match_icons_with_llm") as mock_match:
+            mock_match.return_value = [{"id": icon.id, "confidence": "high"}]
+            match_icon_to_feast_task(feast.id)
+
+        feast.refresh_from_db()
+        second_response = self._get_cached_feast_response(feast)
+        self.assertEqual(second_response.json()["feast"]["icon"]["id"], icon.id)
+
+    def test_feast_context_save_invalidates_cached_context_response(self):
+        feast = self._create_feast(name="Christmas")
+        context = FeastContext.objects.create(
+            feast=feast,
+            text="Old context",
+            short_text="Old short",
+        )
+
+        first_response = self._get_cached_feast_response(feast)
+        self.assertEqual(first_response.json()["feast"]["text"], "Old context")
+
+        context.text = "New context"
+        context.short_text = "New short"
+        context.save(update_fields=["text", "short_text"])
+
+        second_response = self._get_cached_feast_response(feast)
+        self.assertEqual(second_response.json()["feast"]["text"], "New context")
+        self.assertEqual(second_response.json()["feast"]["short_text"], "New short")
+
+    def test_feast_context_feedback_invalidates_cached_vote_counts(self):
+        feast = self._create_feast(name="Christmas")
+        FeastContext.objects.create(
+            feast=feast,
+            text="Existing feast context",
+            short_text="Existing short context",
+        )
+
+        first_response = self._get_cached_feast_response(feast)
+        self.assertEqual(first_response.json()["feast"]["context_thumbs_up"], 0)
+
+        feedback_response = self.client.post(
+            reverse("feast-context-feedback", args=[feast.id]),
+            data={"feedback_type": "up"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(feedback_response.status_code, status.HTTP_200_OK)
+        second_response = self._get_cached_feast_response(feast)
+        self.assertEqual(second_response.json()["feast"]["context_thumbs_up"], 1)
+
+    def test_icon_save_invalidates_cached_icon_payload(self):
+        icon = self._create_icon(title="Old Icon Title")
+        feast = self._create_feast(name="Christmas", icon=icon)
+
+        first_response = self._get_cached_feast_response(feast)
+        self.assertEqual(
+            first_response.json()["feast"]["icon"]["title"],
+            "Old Icon Title",
+        )
+
+        icon.title = "New Icon Title"
+        icon.save(update_fields=["title"])
+
+        second_response = self._get_cached_feast_response(feast)
+        self.assertEqual(
+            second_response.json()["feast"]["icon"]["title"],
+            "New Icon Title",
+        )
+
+    def test_icon_tag_change_invalidates_cached_icon_payload(self):
+        icon = self._create_icon()
+        icon.tags.add("old-tag")
+        feast = self._create_feast(name="Christmas", icon=icon)
+
+        first_response = self._get_cached_feast_response(feast)
+        self.assertEqual(
+            first_response.json()["feast"]["icon"]["tag_list"],
+            ["old-tag"],
+        )
+
+        icon.tags.add("new-tag")
+
+        second_response = self._get_cached_feast_response(feast)
+        self.assertEqual(
+            set(second_response.json()["feast"]["icon"]["tag_list"]),
+            {"old-tag", "new-tag"},
+        )
+
+    def test_feast_delete_invalidates_cached_response(self):
+        feast = self._create_feast(name="Christmas")
+        with patch("hub.views.feasts.generate_feast_context_task.delay"), patch(
+            "hub.views.feasts.get_or_create_feast_for_date"
+        ) as mock_get_or_create:
+            mock_get_or_create.return_value = (feast, False, {"status": "success"})
+            first_response = self.client.get("/api/feasts/", {"date": self.date_str})
+            self.assertEqual(first_response.json()["feast"]["id"], feast.id)
+
+            feast.delete()
+
+            mock_get_or_create.return_value = (None, False, {"status": "not_found"})
+            second_response = self.client.get("/api/feasts/", {"date": self.date_str})
+
+        self.assertIsNone(second_response.json()["feast"])
 
 
 class FeastContextFeedbackAPITests(TestCase):

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -17,6 +17,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from hub.cache import feast_api_cache_key, invalidate_feast_api_cache_for_feast
 from hub.models import Church, Day, Feast, FeastContext
 from hub.tasks import generate_feast_context_task
 from hub.tasks.icon_tasks import match_icon_to_feast_task
@@ -76,7 +77,7 @@ class GetFeastForDate(generics.GenericAPIView):
             church = Church.objects.get(pk=Church.get_default_pk())
 
         # Cache key for feast lookup (includes lang to prevent cross-language poisoning)
-        cache_key = f"feast:{date_obj}:{church.id}:{lang}"
+        cache_key = feast_api_cache_key(date_obj, church.id, lang)
         cached_result = cache.get(cache_key)
         if cached_result:
             return Response(cached_result)
@@ -315,12 +316,14 @@ class FeastContextFeedbackView(APIView):
             FeastContext.objects.filter(pk=active_context.pk).update(
                 thumbs_up=F('thumbs_up') + 1
             )
+            invalidate_feast_api_cache_for_feast(feast)
             return Response({"status": "success", "regenerate": False})
         elif feedback_type == "down":
             # Use atomic increment to prevent race conditions
             FeastContext.objects.filter(pk=active_context.pk).update(
                 thumbs_down=F('thumbs_down') + 1
             )
+            invalidate_feast_api_cache_for_feast(feast)
             # Refresh the object to get the updated value for threshold check
             active_context.refresh_from_db()
             threshold = getattr(settings, "FEAST_CONTEXT_REGENERATION_THRESHOLD", 5)

--- a/plans/2026-06-15-feast-cache-invalidation.md
+++ b/plans/2026-06-15-feast-cache-invalidation.md
@@ -1,0 +1,219 @@
+# Feast API Cache Invalidation Plan
+
+## Context
+
+`GET /api/feasts/?date=2026-06-15` served a stale cached response with `icon: null` after icon matching had already set `Feast.icon_id=627` for Feast 282.
+
+The cache entry is written in `hub/views/feasts.py` as:
+
+```python
+cache_key = f"feast:{date_obj}:{church.id}:{lang}"
+cache.set(cache_key, response_data, 3600)
+```
+
+The response includes feast fields, serialized icon data, active context text, short text, and context vote counters, so changes to either `Feast` or `FeastContext` need to invalidate the relevant date/church/language entries.
+
+## Scope
+
+- Invalidate cached `/api/feasts/` responses when feast data changes.
+- Invalidate cached `/api/feasts/` responses when feast context data changes.
+- Preserve the existing `feast:{date}:{church_id}:{lang}` cache key shape and 3600 second TTL.
+- Do not redesign context generation, icon matching, scraping, or feast name normalization.
+- Do not change frontend behavior.
+
+## Feature Branch
+
+Create a branch from the current base:
+
+```bash
+git checkout -b fix/feast-api-cache-invalidation
+```
+
+Keep the branch limited to the files below plus tests.
+
+## Implementation
+
+### 1. Centralize feast API cache helpers
+
+Add a small helper module, preferably `hub/cache.py`.
+
+Responsibilities:
+
+- Build the existing feast API cache key from `date`, `church_id`, and `lang`.
+- Delete one exact cache key.
+- Delete all known language variants for a date/church pair.
+- Use `cache.delete_pattern("feast:{date}:{church_id}:*")` when available, because production Redis via `django-redis` should support it.
+- Fall back to exact `cache.delete_many(...)` for test/local backends that do not support pattern deletion.
+
+Suggested public API:
+
+```python
+def feast_api_cache_key(date_obj, church_id, lang):
+    return f"feast:{date_obj}:{church_id}:{lang}"
+
+def feast_api_cache_languages():
+    # Include settings.MODELTRANS_AVAILABLE_LANGUAGES, settings.LANGUAGES,
+    # settings.LANGUAGE_CODE, and "en"; return a de-duplicated list.
+
+def invalidate_feast_api_cache_for_date(date_obj, church_id):
+    # Best effort. Delete pattern first when supported, then exact known keys.
+
+def invalidate_feast_api_cache_for_feast(feast):
+    # Uses feast.day.date and feast.day.church_id.
+```
+
+Implementation notes:
+
+- Import `django.core.cache.cache` inside this helper, not in multiple callers.
+- Avoid raising from invalidation. Log warnings if the cache backend delete fails.
+- Do not include a separate `bahk:` prefix; Django cache settings already handle any backend key prefixing.
+- Keep language fallback broad enough to cover no-query public requests (`en`) and explicit `lang=hy`.
+
+### 2. Use the helper in the feast view
+
+Update `hub/views/feasts.py`:
+
+- Replace the inline `cache_key = f"feast:{date_obj}:{church.id}:{lang}"` with `feast_api_cache_key(date_obj, church.id, lang)`.
+- Keep the existing cache lookup/set behavior and TTL unchanged.
+- Import only the helper needed by the view.
+
+This prevents future key drift between the view and invalidation logic.
+
+### 3. Invalidate on Feast saves/deletes
+
+Update `hub/signals.py`:
+
+- Extend the existing `post_save` receiver for `Feast` so every saved feast invalidates its date/church feast API cache.
+- Keep the existing creation-only designation and icon matching tasks unchanged.
+- Add a `post_delete` receiver for `Feast` that invalidates the same date/church keys.
+
+Why this fixes the observed bug:
+
+- `hub/tasks/icon_tasks.py` assigns an icon with `feast.save(update_fields=['icon'])`.
+- That emits `post_save`.
+- The signal invalidates `feast:{date}:{church_id}:*`.
+- The next `GET /api/feasts/?date=2026-06-15` recomputes and serializes the non-null icon.
+
+Suggested shape:
+
+```python
+@receiver(post_save, sender=Feast)
+def handle_feast_save(sender, instance, created, **kwargs):
+    invalidate_feast_api_cache_for_feast(instance)
+    ...
+
+@receiver(post_delete, sender=Feast)
+def handle_feast_delete(sender, instance, **kwargs):
+    invalidate_feast_api_cache_for_feast(instance)
+```
+
+### 4. Invalidate on FeastContext saves/deletes
+
+Update `hub/signals.py`:
+
+- Import `FeastContext`.
+- Add `post_save` and `post_delete` receivers for `FeastContext`.
+- Invalidate via `instance.feast`.
+
+This covers context creation and updates from `hub/tasks/llm_tasks.py`, because `_create_feast_context_with_translations(...)` and `_update_feast_context_translations(...)` both call `context.save()`.
+
+### 5. Invalidate after feedback counter updates
+
+Update `hub/views/feasts.py` in `FeastContextFeedbackView.post`.
+
+Reason:
+
+- The feedback endpoint increments `thumbs_up` and `thumbs_down` via `FeastContext.objects.filter(...).update(...)`.
+- `QuerySet.update()` bypasses model `save()` and Django signals.
+- The cached `/api/feasts/` response includes `context_thumbs_up` and `context_thumbs_down`.
+
+After each successful atomic update, call `invalidate_feast_api_cache_for_feast(feast)` before returning.
+
+Keep this scoped to the two successful feedback branches. Do not change regeneration behavior.
+
+### 6. Add regression tests
+
+Add focused tests to `hub/tests/test_feast_views.py`, likely in `FeastViewCacheTests`, or create `hub/tests/test_feast_cache_invalidation.py` if the class gets too large.
+
+Recommended tests:
+
+1. `test_feast_save_invalidates_cached_icon_response`
+   - Create a `Day`, `Feast` without icon, and `Icon`.
+   - Request `/api/feasts/?date=...` once and assert cached `icon is None`.
+   - Set `feast.icon = icon` and `feast.save(update_fields=['icon'])`.
+   - Request the same URL again.
+   - Assert `icon` is not null and has the expected icon id.
+
+2. `test_icon_matching_save_invalidates_cached_response`
+   - Same setup, but call `match_icon_to_feast_task(feast.id)` with `_match_icons_with_llm` mocked to return the icon with `confidence: "high"`.
+   - First request should cache `icon: null`.
+   - Task should save the icon.
+   - Second request should show the icon.
+
+3. `test_feast_context_save_invalidates_cached_context_response`
+   - Create a feast and active context with `text="Old"`, `short_text="Old short"`.
+   - Request once and assert old context text.
+   - Modify the context fields and call `context.save()`.
+   - Request again and assert new context text.
+
+4. `test_feast_context_feedback_invalidates_cached_vote_counts`
+   - Create a feast with active context.
+   - Request `/api/feasts/` once to cache `context_thumbs_up: 0`.
+   - POST `{"feedback_type": "up"}` to `/api/feasts/<id>/feedback/`.
+   - Request `/api/feasts/` again and assert `context_thumbs_up: 1`.
+
+5. `test_feast_delete_invalidates_cached_response`
+   - Cache a populated feast response.
+   - Delete the feast.
+   - Request again and assert the endpoint no longer returns the deleted feast from cache.
+
+Test details:
+
+- Use `cache.clear()` in setup.
+- Patch `hub.views.feasts.generate_feast_context_task.delay`, `hub.signals.match_icon_to_feast_task.delay`, and `hub.signals.determine_feast_designation_task.delay` where fixture creation would otherwise enqueue work.
+- Use the existing `tests.test_settings` locmem cache. The fallback exact-key deletion path must make these tests pass without Redis pattern deletion.
+- Keep tests out of slow/performance tags unless explicitly needed.
+
+## Targeted Verification
+
+Run focused tests locally:
+
+```bash
+python manage.py test hub.tests.test_feast_views --settings=tests.test_settings
+python manage.py test hub.tests.test_feast_icon_matching --exclude-tag=slow --settings=tests.test_settings
+```
+
+If a new test file is created, run it directly:
+
+```bash
+python manage.py test hub.tests.test_feast_cache_invalidation --settings=tests.test_settings
+```
+
+## Full / Crabbox Verification
+
+Run the project test job through Crabbox:
+
+```bash
+scripts/crabbox-validate.sh test
+```
+
+For final review confidence, run CI:
+
+```bash
+scripts/crabbox-validate.sh ci
+```
+
+The Crabbox `test` and `ci` jobs already run Django tests with:
+
+```bash
+python manage.py test --noinput --parallel --exclude-tag=performance --exclude-tag=slow --settings=tests.test_settings
+```
+
+## Review Checklist
+
+- Confirm no cache keys are renamed, only centralized.
+- Confirm `Feast.icon` changes via `save(update_fields=['icon'])` invalidate cached `/api/feasts/` responses.
+- Confirm `FeastContext.save()` invalidates context text and short text in cached responses.
+- Confirm feedback `QuerySet.update()` paths explicitly invalidate vote counters.
+- Confirm invalidation is best-effort and cannot break feast saves, deletes, context generation, or feedback submission if Redis is unavailable.
+- Confirm no unrelated context generation, scraping, normalization, or icon matching behavior changed.


### PR DESCRIPTION
## Summary
- centralize the `/api/feasts/` cache key helper while preserving `feast:{date}:{church_id}:{lang}`
- invalidate cached feast responses when Feast, FeastContext, and serialized Icon data changes
- explicitly invalidate after feedback vote `QuerySet.update()` calls
- add regression coverage for stale icon/context/vote/delete cache behavior

## Root Cause
`/api/feasts/` cached the full serialized feast response for one hour. The icon matching task correctly saved `Feast.icon_id`, but that save did not clear the existing date/church/lang cache entry, so public responses could keep serving `icon: null` while admin/prod DB showed the icon attached.

## Validation
- `python3 -m py_compile hub/cache.py hub/signals.py hub/views/feasts.py hub/tests/test_feast_views.py`
- local `ruff check hub/cache.py hub/signals.py hub/views/feasts.py hub/tests/test_feast_views.py`
- `bash scripts/crabbox-validate.sh test` — 1169 tests OK, 2 skipped
- `bash scripts/crabbox-validate.sh ci` — ruff OK, 1169 tests OK, 2 skipped
- reviewer re-check: no findings

## Notes
Residual untested edge cases from review: icon delete, tag remove/clear, and arbitrary unsupported `lang` query values. The implementation path is covered by shared invalidation helpers and production Redis pattern deletion for the language variants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public feast endpoint caching path across several models and signal hooks; behavior is limited to cache eviction and is best-effort with broad test coverage, but missed invalidation edge cases (e.g. uncommon `lang` values) could still serve stale data briefly.
> 
> **Overview**
> Fixes stale **`GET /api/feasts/`** responses (e.g. `icon: null` after icon matching) by clearing the existing **`feast:{date}:{church_id}:{lang}`** entries whenever serialized payload inputs change, without changing cache TTL or key shape.
> 
> Adds **`hub/cache.py`** with shared key building and **best-effort** invalidation (Redis **`delete_pattern`** when available, plus **`delete_many`** for known language codes). **`GetFeastForDate`** now uses the helper for lookups; **`FeastContextFeedbackView`** explicitly invalidates after atomic **`QuerySet.update()`** on thumbs up/down because that path skips signals.
> 
> **`hub/signals.py`** wires invalidation on **`Feast`** save/delete, **`FeastContext`** save/delete, **`Icon`** save/pre-delete, and icon tag M2M changes (all feasts linked to the icon). Regression tests in **`test_feast_views.py`** cover icon assignment, icon matching task, context edits, feedback votes, icon metadata/tags, and feast delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 339416aa042c98c1c1b71072d4c3807c684126ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->