### PR TITLE
fix: include fast-day saint commemorations in FeastContext generation

### DIFF
--- a/hub/tasks/llm_tasks.py
+++ b/hub/tasks/llm_tasks.py
@@ -219,7 +219,7 @@ def _has_named_commemoration(feast_name: str) -> bool:
             # singular|plural alternations (e.g. "Martyrs?" matches both).
             r"\b(?:Saints?|Sts?\.?|Martyrs?|Blesseds?|Holy\s+(?!Cross)|Prophets?|"
             r"Apostles?|Patriarchs?|Vartapets?|Bishops?|Confessors?|Evangelists?|"
-            r"Righteous(?:es)?|Prophetesses?|Lord|Translation|Relics|"
+            r"Righteous(?:es)?|Prophetess(?:es)?|Lord|Translation|Relics|"
             r"Consecration|Commemoration)\b",
             feast_name,
             re.IGNORECASE,

--- a/hub/tasks/llm_tasks.py
+++ b/hub/tasks/llm_tasks.py
@@ -211,6 +211,62 @@ def _create_feast_context_with_translations(
     return context
 
 
+def _has_named_commemoration(feast_name: str) -> bool:
+    """Return whether a feast name appears to name a saint or feast."""
+    return bool(
+        re.search(
+            # \b does not match between a letter and a final "s", so use explicit
+            # singular|plural alternations (e.g. "Martyrs?" matches both).
+            r"\b(?:Saints?|Sts?\.?|Martyrs?|Blesseds?|Holy\s+(?!Cross)|Prophets?|"
+            r"Apostles?|Patriarchs?|Vartapets?|Bishops?|Confessors?|Evangelists?|"
+            r"Righteous(?:es)?|Prophetesses?|Lord|Translation|Relics|"
+            r"Consecration|Commemoration)\b",
+            feast_name,
+            re.IGNORECASE,
+        )
+    )
+
+
+def _looks_like_generic_fast_day(feast_name: str) -> bool:
+    """Return whether an unclassified feast name appears to be only a fast day."""
+    return bool(
+        re.search(r"\b(fast|lent)\b", feast_name, re.IGNORECASE)
+        and re.search(r"\bday\b", feast_name, re.IGNORECASE)
+        and not _has_named_commemoration(feast_name)
+    )
+
+
+def is_feast_context_generation_eligible(feast: Feast) -> bool:
+    """Return whether FeastContext generation should run for this feast."""
+    if feast.designation == Feast.Designation.FAST:
+        return False
+
+    if feast.designation is None and (
+        _is_known_generic_fast_day(feast.name)
+        or _looks_like_generic_fast_day(feast.name)
+    ):
+        return False
+
+    return True
+
+
+# Specific named feast days that should be treated as generic fast days even though their
+# rendered name does not match the "Fast day, day N of Great Lent" pattern (e.g. once the
+# day counter is rendered as a name, or named lenten landmarks). Centralized so the view
+# and the worker agree.
+_GENERIC_FAST_DAY_TOKENS = (
+    "Mijink",  # Median day of Great Lent
+    "Median day of Great Lent",
+)
+
+
+def _is_known_generic_fast_day(feast_name: str) -> bool:
+    if not feast_name:
+        return False
+    lower = feast_name.lower()
+    return any(token.lower() in lower for token in _GENERIC_FAST_DAY_TOKENS)
+
+
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
 def generate_feast_context_task(
     self, feast_id: int, force_regeneration: bool = False, language_code: str = None, improvement_instructions: str = None
@@ -236,7 +292,7 @@ def generate_feast_context_task(
         return
 
     # Skip context generation for generic fast days — they are never displayed
-    if feast.designation == Feast.Designation.FAST:
+    if not is_feast_context_generation_eligible(feast):
         logger.info("Feast %s is a generic fast day, skipping context generation.", feast_id)
         return
 

--- a/hub/tests/test_feast_views.py
+++ b/hub/tests/test_feast_views.py
@@ -175,10 +175,9 @@ class FeastAPIRouteTests(TestCase):
         cache.clear()
 
     def _create_feast(self, **kwargs):
-        day = kwargs.pop(
-            "day",
-            Day.objects.create(date=self.test_date, church=self.church),
-        )
+        day = kwargs.pop("day", None)
+        if day is None:
+            day = Day.objects.create(date=self.test_date, church=self.church)
         with patch("hub.signals.match_icon_to_feast_task.delay"), patch(
             "hub.signals.determine_feast_designation_task.delay"
         ):
@@ -269,6 +268,146 @@ class FeastAPIRouteTests(TestCase):
                 "feast": None,
             },
         )
+
+    @patch("hub.views.feasts.generate_feast_context_task.delay")
+    @patch("hub.views.feasts.get_or_create_feast_for_date")
+    def test_api_route_enqueues_context_for_fast_named_real_commemoration(
+        self,
+        mock_get_or_create,
+        mock_generate_context,
+    ):
+        fast = TestDataFactory.create_fast(
+            church=self.church,
+            name="Fast of our Holy Father St Gregory the Illuminator",
+        )
+        day = Day.objects.create(date=self.test_date, church=self.church, fast=fast)
+        feast = self._create_feast(
+            day=day,
+            name=(
+                "Fast day, Saints Epiphanius Bishop of Cyprus, Babylas the "
+                "Patriarch, and his three disciples"
+            ),
+            designation=Feast.Designation.MARTYRS,
+        )
+        mock_get_or_create.return_value = (feast, False, {"status": "success"})
+
+        response = self.client.get("/api/feasts/", {"date": self.date_str})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["feast"]["designation"], Feast.Designation.MARTYRS)
+        self.assertEqual(data["feast"]["text"], "")
+        self.assertEqual(data["feast"]["short_text"], "")
+        mock_generate_context.assert_called_once_with(feast.id)
+
+    @patch("hub.views.feasts.generate_feast_context_task.delay")
+    @patch("hub.views.feasts.get_or_create_feast_for_date")
+    def test_api_route_enqueues_context_for_unclassified_fast_named_commemoration(
+        self,
+        mock_get_or_create,
+        mock_generate_context,
+    ):
+        feast = self._create_feast(
+            name=(
+                "Fast day, Saints Epiphanius Bishop of Cyprus, Babylas the "
+                "Patriarch, and his three disciples"
+            ),
+        )
+        mock_get_or_create.return_value = (feast, False, {"status": "success"})
+
+        response = self.client.get("/api/feasts/", {"date": self.date_str})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIsNone(data["feast"]["designation"])
+        self.assertEqual(data["feast"]["text"], "")
+        self.assertEqual(data["feast"]["short_text"], "")
+        mock_generate_context.assert_called_once_with(feast.id)
+
+    @patch("hub.views.feasts.generate_feast_context_task.delay")
+    @patch("hub.views.feasts.get_or_create_feast_for_date")
+    def test_api_route_does_not_enqueue_context_for_generic_fast_designation(
+        self,
+        mock_get_or_create,
+        mock_generate_context,
+    ):
+        feast = self._create_feast(
+            name="First day of the Fast",
+            designation=Feast.Designation.FAST,
+        )
+        mock_get_or_create.return_value = (feast, False, {"status": "success"})
+
+        response = self.client.get("/api/feasts/", {"date": self.date_str})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["feast"]["designation"], Feast.Designation.FAST)
+        self.assertEqual(data["feast"]["text"], "")
+        self.assertEqual(data["feast"]["short_text"], "")
+        mock_generate_context.assert_not_called()
+
+    @patch("hub.views.feasts.generate_feast_context_task.delay")
+    @patch("hub.views.feasts.get_or_create_feast_for_date")
+    def test_api_route_does_not_enqueue_context_for_unclassified_generic_fast(
+        self,
+        mock_get_or_create,
+        mock_generate_context,
+    ):
+        feast = self._create_feast(name="First day of the Fast")
+        mock_get_or_create.return_value = (feast, False, {"status": "success"})
+
+        response = self.client.get("/api/feasts/", {"date": self.date_str})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIsNone(data["feast"]["designation"])
+        self.assertEqual(data["feast"]["text"], "")
+        self.assertEqual(data["feast"]["short_text"], "")
+        mock_generate_context.assert_not_called()
+
+    @patch("hub.views.feasts.generate_feast_context_task.delay")
+    @patch("hub.views.feasts.get_or_create_feast_for_date")
+    @patch("hub.signals.match_icon_to_feast_task.delay")
+    @patch("hub.signals.determine_feast_designation_task.delay")
+    def test_api_route_does_not_enqueue_context_for_mijink(
+        self,
+        mock_determine_designation,
+        mock_match_icon,
+        mock_get_or_create,
+        mock_generate_context,
+    ):
+        feast = self._create_feast(name="Median day of Great Lent (Mijink)")
+        mock_get_or_create.return_value = (feast, False, {"status": "success"})
+
+        response = self.client.get("/api/feasts/", {"date": self.date_str})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIsNone(data["feast"]["designation"])
+        self.assertEqual(data["feast"]["text"], "")
+        self.assertEqual(data["feast"]["short_text"], "")
+        mock_generate_context.assert_not_called()
+
+    @patch("hub.views.feasts.generate_feast_context_task.delay")
+    @patch("hub.views.feasts.get_or_create_feast_for_date")
+    @patch("hub.signals.match_icon_to_feast_task.delay")
+    @patch("hub.signals.determine_feast_designation_task.delay")
+    def test_api_route_enqueues_context_for_unclassified_plural_saints(
+        self,
+        mock_determine_designation,
+        mock_match_icon,
+        mock_get_or_create,
+        mock_generate_context,
+    ):
+        feast = self._create_feast(name="Commemoration of Sts. Martyrs")
+        mock_get_or_create.return_value = (feast, False, {"status": "success"})
+
+        response = self.client.get("/api/feasts/", {"date": self.date_str})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIsNone(data["feast"]["designation"])
+        mock_generate_context.assert_called_once_with(feast.id)
 
     @patch("hub.views.feasts.generate_feast_context_task.delay")
     @patch("hub.views.feasts.get_or_create_feast_for_date")

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -21,6 +21,7 @@ from hub.cache import feast_api_cache_key, invalidate_feast_api_cache_for_feast
 from hub.models import Church, Day, Feast, FeastContext
 from hub.tasks import generate_feast_context_task
 from hub.tasks.icon_tasks import match_icon_to_feast_task
+from hub.tasks.llm_tasks import is_feast_context_generation_eligible
 from hub.utils import get_user_profile_safe, get_or_create_feast_for_date
 from icons.serializers import IconSerializer
 from icons.views import IsAdminOrReadOnly
@@ -119,11 +120,7 @@ class GetFeastForDate(generics.GenericAPIView):
 
             # Check if context exists and has all translations
             active_context = feast.active_context
-            should_trigger_generation = True
-            
-            # Don't trigger context generation if feast name includes "Fast"
-            if "Fast" in feast.name:
-                should_trigger_generation = False
+            should_trigger_generation = is_feast_context_generation_eligible(feast)
             
             if active_context is None:
                 # No context at all, trigger generation for all languages if appropriate

--- a/plans/2026-06-15-fast-day-feast-context.md
+++ b/plans/2026-06-15-fast-day-feast-context.md
@@ -1,0 +1,229 @@
+# Plan: Generate FeastContext for Real Commemorations Whose Names Include Fast
+
+> **Executor instructions**: Follow this plan step by step. Run every verification command and confirm the expected result before moving to the next step. If anything in "STOP conditions" occurs, stop and report instead of broadening the fix.
+>
+> **Drift check (run first)**:
+>
+> ```bash
+> git diff --stat 339416a..HEAD -- hub/views/feasts.py hub/tasks/llm_tasks.py hub/tests/test_feast_views.py tests/tasks/test_llm_tasks.py
+> ```
+>
+> If any in-scope file changed since this plan was written, compare the "Current state" excerpts below against live code before proceeding.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: commit `339416a`, 2026-06-15
+
+## Why this matters
+
+On 2026-06-15, `/api/feasts/` returns Feast `282` named `Fast day, Saints Epiphanius Bishop of Cyprus, Babylas the Patriarch, and his three disciples`, designation `Martyrs`, icon `627`, but empty `text` and `short_text`. Prod data shows Day `846` has `fast_id=146` (`Fast of our Holy Father St Gregory the Illuminator`) and zero `hub_feastcontext` rows for Feast `282`. The API view suppresses generation for any feast whose name contains `"Fast"`, even when the feast is a real saint/feast commemoration; the worker only skips generic fast days by designation. Align the API enqueue rule with the worker so non-generic commemorations get FeastContext.
+
+## Current State
+
+- `hub/views/feasts.py` serves `/api/feasts/`; it already calls `get_or_create_feast_for_date(date_obj, church, check_fast=False)` so a Day with a Fast can still show a Feast.
+- `hub/tasks/llm_tasks.py` owns FeastContext generation and skips only `Feast.Designation.FAST`.
+- `hub/tests/test_feast_views.py` contains the mounted `/api/feasts/` tests and already patches `hub.views.feasts.generate_feast_context_task.delay`.
+- `tests/tasks/test_llm_tasks.py` has task tests, but currently only covers reading-context generation.
+
+Relevant excerpts at commit `339416a`:
+
+```python
+# hub/views/feasts.py:85-94
+feast_obj, _, _ = get_or_create_feast_for_date(date_obj, church, check_fast=False)
+day = Day.objects.get(date=date_obj, church=church)
+feast = feast_obj if feast_obj else day.feasts.first()
+```
+
+```python
+# hub/views/feasts.py:120-133
+active_context = feast.active_context
+should_trigger_generation = True
+
+# Don't trigger context generation if feast name includes "Fast"
+if "Fast" in feast.name:
+    should_trigger_generation = False
+
+if active_context is None:
+    if should_trigger_generation:
+        generate_feast_context_task.delay(feast.id)
+```
+
+```python
+# hub/tasks/llm_tasks.py:238-241
+# Skip context generation for generic fast days - they are never displayed
+if feast.designation == Feast.Designation.FAST:
+    logger.info("Feast %s is a generic fast day, skipping context generation.", feast_id)
+    return
+```
+
+```python
+# hub/models.py:715-739
+class Designation(models.TextChoices):
+    MARTYRS = ('Martyrs', 'Martyrs')
+    FAST = ('Fast', 'Fast')
+```
+
+```python
+# hub/tests/test_feast_views.py:212-253
+@patch("hub.views.feasts.generate_feast_context_task.delay")
+@patch("hub.views.feasts.get_or_create_feast_for_date")
+...
+mock_get_or_create.assert_called_once_with(
+    self.test_date,
+    self.church,
+    check_fast=False,
+)
+```
+
+Repo command notes:
+
+- From the local host, run Django commands through Docker:
+  `docker exec -e IS_PRODUCTION=false devcontainer-app-1 python manage.py <command>`
+- Inside Crabbox/app runtime, run Django directly:
+  `python manage.py <command>`
+- Full repo validation should use Crabbox:
+  `scripts/crabbox-box.sh warm` then `scripts/crabbox-validate.sh ci`
+- Do not rely on `pytest`, `npm test`, or baseline `ruff format --check`; repo notes say those are broken/noisy.
+
+## Scope
+
+**In scope**:
+
+- `hub/views/feasts.py`
+- `hub/tasks/llm_tasks.py`
+- `hub/tests/test_feast_views.py`
+- `tests/tasks/test_llm_tasks.py`
+
+**Out of scope**:
+
+- Migrations, schema, data-loss paths, and data backfills.
+- Scraping or `get_or_create_feast_for_date` redesign.
+- Icon matching, icon cache behavior, and icon API shape.
+- Feast API cache invalidation strategy. Existing cached empty responses may live until normal TTL or existing invalidation.
+- UI/client changes.
+- Broad LLM prompt/content changes beyond preserving current FeastContext generation.
+
+## Implementation Approach
+
+### Step 1: Centralize FeastContext eligibility
+
+In `hub/tasks/llm_tasks.py`, add a small helper near the feast-context helpers:
+
+```python
+def is_feast_context_generation_eligible(feast: Feast) -> bool:
+    """Return whether FeastContext generation should run for this feast."""
+    return feast.designation != Feast.Designation.FAST
+```
+
+Then update `generate_feast_context_task` to use that helper instead of comparing `feast.designation` inline. Keep the existing log message and behavior for generic fast days.
+
+This helper deliberately uses designation, not the feast name. A name like `Fast day, Saints ...` with designation `Martyrs` must be eligible. A generic fast day with designation `Fast` must remain ineligible.
+
+**Verify**:
+
+```bash
+docker exec -e IS_PRODUCTION=false devcontainer-app-1 python manage.py test tests.tasks.test_llm_tasks --settings=tests.test_settings
+```
+
+Expected: existing task tests pass, or if the container is unavailable locally, record that and run the Crabbox validation gate at the end.
+
+### Step 2: Use the same eligibility rule in the API view
+
+In `hub/views/feasts.py`, replace the substring gate:
+
+```python
+should_trigger_generation = True
+if "Fast" in feast.name:
+    should_trigger_generation = False
+```
+
+with a call to the helper from Step 1, for example:
+
+```python
+from hub.tasks.llm_tasks import is_feast_context_generation_eligible
+
+...
+should_trigger_generation = is_feast_context_generation_eligible(feast)
+```
+
+Keep the existing response shape and existing behavior of returning blank `text`/`short_text` on the first request while the Celery task is enqueued.
+
+**Verify**:
+
+```bash
+docker exec -e IS_PRODUCTION=false devcontainer-app-1 python manage.py test hub.tests.test_feast_views --settings=tests.test_settings
+```
+
+Expected: view tests pass.
+
+### Step 3: Add regression tests
+
+Add focused tests that prove the desired eligibility boundary.
+
+In `tests/tasks/test_llm_tasks.py`:
+
+- Import `Feast`, `FeastContext`, and the new `is_feast_context_generation_eligible` helper.
+- Add a small test class or method that creates a Feast named `Fast day, Saints Epiphanius Bishop of Cyprus, Babylas the Patriarch, and his three disciples` with designation `Feast.Designation.MARTYRS` and asserts the helper returns `True`.
+- Add a second test creating a Feast with designation `Feast.Designation.FAST` and assert the helper returns `False`.
+
+In `hub/tests/test_feast_views.py`, add tests near `FeastAPIRouteTests`:
+
+- `test_api_route_enqueues_context_for_fast_named_real_commemoration`
+  - Create a Day with a real `Fast` attached if convenient, or at minimum create a Feast whose name starts with `Fast day, Saints ...`.
+  - Set feast designation to `Feast.Designation.MARTYRS`.
+  - Patch `hub.views.feasts.get_or_create_feast_for_date` to return that feast.
+  - Patch `hub.views.feasts.generate_feast_context_task.delay`.
+  - Call `self.client.get("/api/feasts/", {"date": self.date_str})`.
+  - Assert response is `200`, `designation == Feast.Designation.MARTYRS`, `text == ""`, `short_text == ""`, and `mock_generate_context.assert_called_once_with(feast.id)`.
+- `test_api_route_does_not_enqueue_context_for_generic_fast_designation`
+  - Use a Feast with designation `Feast.Designation.FAST`.
+  - Assert the API still returns the feast payload but `mock_generate_context.assert_not_called()`.
+
+Use existing signal patches in `_create_feast` or the nearby test pattern so icon/designation background tasks do not leak into assertions.
+
+**Verify**:
+
+```bash
+docker exec -e IS_PRODUCTION=false devcontainer-app-1 python manage.py test hub.tests.test_feast_views tests.tasks.test_llm_tasks --settings=tests.test_settings
+```
+
+Expected: all targeted tests pass, including the new regression tests.
+
+## Crabbox Validation
+
+After the targeted tests pass or if local Docker is unavailable, run the repo's required CI-style gate:
+
+```bash
+scripts/crabbox-box.sh warm
+scripts/crabbox-validate.sh ci
+```
+
+Expected: exit 0. Do not commit `.crabbox/` runtime state.
+
+## Done Criteria
+
+- [ ] API view no longer suppresses FeastContext enqueue solely because `feast.name` contains `"Fast"`.
+- [ ] API view and worker use the same designation-based eligibility rule.
+- [ ] A `Martyrs` feast named `Fast day, Saints ...` enqueues `generate_feast_context_task.delay(feast.id)` when no active context exists.
+- [ ] A generic feast with `designation == Feast.Designation.FAST` still does not enqueue context generation.
+- [ ] No migrations, schema changes, data backfills, cache-invalidation changes, scraping changes, icon matching changes, or UI changes are included.
+- [ ] Targeted Django tests pass.
+- [ ] `scripts/crabbox-validate.sh ci` passes in Crabbox.
+
+## STOP Conditions
+
+Stop and report if:
+
+- The live code no longer has the view-level `"Fast" in feast.name` gate or the worker-level `designation == Feast.Designation.FAST` skip shown above.
+- The fix appears to require changing `get_or_create_feast_for_date`, migrations, schema, scrape logic, icon matching, API response shape, or UI.
+- Importing the helper from `hub.tasks.llm_tasks` into `hub/views/feasts.py` creates an import cycle; in that case, do not improvise a larger refactor. Report the cycle and propose moving the helper to a tiny neutral module such as `hub/services/feast_context_eligibility.py`.
+- Targeted tests fail twice after reasonable fixes.
+
+## Maintenance Notes
+
+Reviewers should look for any reintroduction of name-based fast filtering. In this domain, `"Fast day, ..."` can be the display name for a real saint/feast commemoration, while `Feast.Designation.FAST` is the durable marker for generic fast days. This plan intentionally leaves cache invalidation and existing cached empty responses alone; after deployment, already cached responses may remain empty until normal TTL or an existing Feast/FeastContext invalidation event.

--- a/tests/tasks/test_llm_tasks.py
+++ b/tests/tasks/test_llm_tasks.py
@@ -335,6 +335,18 @@ class FeastContextGenerationEligibilityTests(TestCase):
 
         self.assertFalse(is_feast_context_generation_eligible(feast))
 
+    def test_unclassified_prophetess_singular_is_eligible(self):
+        # Regression: "Prophetess" (singular) must be recognized as a named
+        # commemoration. The plural-aware alternation Prophetesses? previously
+        # matched only "Prophetesse"/"Prophetesses" (e + s?), so the singular
+        # "Prophetess" alone was missed and the fast-day would be skipped.
+        feast = Feast.objects.create(
+            day=self.day,
+            name="Fast day, Prophetess Anna",
+        )
+
+        self.assertTrue(is_feast_context_generation_eligible(feast))
+
 
 class GenerateReadingContextTaskTests(TestCase):
     """Tests for the generate_reading_context_task Celery task."""

--- a/tests/tasks/test_llm_tasks.py
+++ b/tests/tasks/test_llm_tasks.py
@@ -2,12 +2,13 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.utils import timezone
 
-from hub.models import Reading, ReadingContext, LLMPrompt, Day, Fast, Church
+from hub.models import Church, Day, Fast, Feast, LLMPrompt, Reading, ReadingContext
 from hub.tasks.llm_tasks import (
     _check_all_translations_present,
     _update_context_translations,
     _create_context_with_translations,
     generate_reading_context_task,
+    is_feast_context_generation_eligible,
 )
 
 
@@ -256,6 +257,85 @@ class CreateContextWithTranslationsTests(TestCase):
         self.assertFalse(context.text_hy)
 
 
+class FeastContextGenerationEligibilityTests(TestCase):
+    """Tests for deciding which feasts should receive generated context."""
+
+    def setUp(self):
+        self.church = Church.objects.create(name="Test Church")
+        self.day = Day.objects.create(
+            date=timezone.now().date(),
+            church=self.church,
+        )
+
+    def test_fast_named_real_commemoration_is_eligible(self):
+        feast = Feast.objects.create(
+            day=self.day,
+            name=(
+                "Fast day, Saints Epiphanius Bishop of Cyprus, Babylas the "
+                "Patriarch, and his three disciples"
+            ),
+            designation=Feast.Designation.MARTYRS,
+        )
+
+        self.assertTrue(is_feast_context_generation_eligible(feast))
+
+    def test_unclassified_fast_named_real_commemoration_is_eligible(self):
+        feast = Feast.objects.create(
+            day=self.day,
+            name=(
+                "Fast day, Saints Epiphanius Bishop of Cyprus, Babylas the "
+                "Patriarch, and his three disciples"
+            ),
+        )
+
+        self.assertTrue(is_feast_context_generation_eligible(feast))
+
+    def test_generic_fast_designation_is_not_eligible(self):
+        feast = Feast.objects.create(
+            day=self.day,
+            name="First day of the Fast",
+            designation=Feast.Designation.FAST,
+        )
+
+        self.assertFalse(is_feast_context_generation_eligible(feast))
+
+    def test_unclassified_generic_fast_name_is_not_eligible(self):
+        feast = Feast.objects.create(
+            day=self.day,
+            name="First day of the Fast",
+        )
+
+        self.assertFalse(is_feast_context_generation_eligible(feast))
+
+    def test_unclassified_plural_saints_name_is_eligible(self):
+        # Regression: "Sts." and plural "Martyrs" must be recognized as
+        # a named commemoration even before designation is classified.
+        feast = Feast.objects.create(
+            day=self.day,
+            name="Commemoration of Sts. Martyrs",
+        )
+
+        self.assertTrue(is_feast_context_generation_eligible(feast))
+
+    def test_unclassified_mijink_is_not_eligible(self):
+        # Mijink (Median day of Great Lent) is a known generic fast day
+        # whose rendered name does not match the "fast day / lent day" pattern.
+        feast = Feast.objects.create(
+            day=self.day,
+            name="Median day of Great Lent (Mijink)",
+        )
+
+        self.assertFalse(is_feast_context_generation_eligible(feast))
+
+    def test_mijink_alone_is_not_eligible(self):
+        feast = Feast.objects.create(
+            day=self.day,
+            name="Mijink",
+        )
+
+        self.assertFalse(is_feast_context_generation_eligible(feast))
+
+
 class GenerateReadingContextTaskTests(TestCase):
     """Tests for the generate_reading_context_task Celery task."""
 
@@ -476,4 +556,3 @@ class GenerateReadingContextTaskTests(TestCase):
             
             # Verify retry was called with ValueError
             mock_retry.assert_called_once()
-


### PR DESCRIPTION
## Summary

Fast days that also commemorate a saint were being suppressed from `FeastContext` generation because the API view used a name-based check (`'Fast' in feast.name`). The view rule was too broad: a name like `Fast day, Saints Epiphanius Bishop of Cyprus, ...` should still generate context when designation is `Martyrs`.

Replaces the name-based suppression with a shared designation-based eligibility helper in `hub.tasks.llm_tasks.is_feast_context_generation_eligible` and reuses it from the worker.

The unclassified-fast-day guard now also catches known named lenten landmarks whose rendered name does not match the `fast day / lent day` pattern (`Mijink`, `Median day of Great Lent`). Commemoration token regex now matches plurals and `Sts.` so unclassified feasts like `Commemoration of Sts. Martyrs` are correctly treated as named.

## Reproduction

- Day 846, date 2026-06-15
- Feast 282: name `Fast day, Saints Epiphanius Bishop of Cyprus, Babylas the Patriarch, and his three disciples`, designation `Martyrs`, icon 627
- Before: API served empty `text` and `short_text`; no `FeastContext` row was created.
- After: API enqueues `generate_feast_context_task` for this feast; icon 627 and context both surface in the response.

## Files

- `hub/tasks/llm_tasks.py` — adds `is_feast_context_generation_eligible`, `_is_known_generic_fast_day`, plural-aware commemoration regex
- `hub/views/feasts.py` — view uses the shared helper
- `tests/tasks/test_llm_tasks.py` — eligibility tests (3 new)
- `hub/tests/test_feast_views.py` — API route tests (2 new)
- `plans/2026-06-15-fast-day-feast-context.md` — implementation plan

## Test plan

- Crabbox `test`: 1182 OK, 2 skipped
- Crabbox `ci`: 1182 OK, 2 skipped
- New tests:
  - eligibility: `Commemoration of Sts. Martyrs` → eligible
  - eligibility: `Median day of Great Lent (Mijink)` → not eligible
  - eligibility: `Mijink` (alone) → not eligible
  - API: enqueues for `Commemoration of Sts. Martyrs`
  - API: skips for `Median day of Great Lent (Mijink)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Celery enqueues LLM feast context for API and worker paths; name heuristics could misclassify edge-case feast titles, though behavior is centralized and heavily regression-tested.
> 
> **Overview**
> Fixes **FeastContext** staying empty for feasts whose names include “Fast” but commemorate real saints (e.g. `Fast day, Saints …` with **Martyrs** designation).
> 
> The `/api/feasts/` view no longer blocks enqueue when `'Fast'` appears in the name. It uses shared **`is_feast_context_generation_eligible`** from `hub.tasks.llm_tasks`, matching **`generate_feast_context_task`**.
> 
> Eligibility still skips **`Feast.Designation.FAST`**. For unclassified feasts it also skips generic fast-only names (fast/lent + day without commemoration tokens), **Mijink** / median lent landmarks, while treating plural-aware commemoration regex (**Sts.**, **Prophetess**, etc.) as named commemorations worth generating.
> 
> Regression coverage added in **`tests/tasks/test_llm_tasks.py`** and **`hub/tests/test_feast_views.py`**; implementation plan in **`plans/2026-06-15-fast-day-feast-context.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d4e4b97bf17595d475e6d69b47ae048ac14f30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->