### PR TITLE
Add guarded feast icon assignment API

### DIFF
--- a/hub/signals.py
+++ b/hub/signals.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.db.models.signals import m2m_changed, post_delete, post_save, pre_delete
+from django.db import transaction
 from django.dispatch import receiver
 from django.core.cache import cache
 from hub.cache import invalidate_feast_api_cache_for_feast
@@ -57,7 +58,7 @@ def handle_feast_save(sender, instance, created, **kwargs):
     translations are updated immediately after creation.
     The task itself will also check and skip if designation is already set.
     """
-    invalidate_feast_api_cache_for_feast(instance)
+    transaction.on_commit(lambda: invalidate_feast_api_cache_for_feast(instance))
 
     # Only trigger designation task on creation, not on updates
     # This prevents duplicate task enqueuing when translations are set immediately after creation

--- a/hub/tasks/icon_tasks.py
+++ b/hub/tasks/icon_tasks.py
@@ -6,6 +6,7 @@ import time
 
 from celery import shared_task
 from django.conf import settings
+from django.db import transaction
 
 from hub.constants import ICON_MATCH_CONFIDENCE_THRESHOLD
 from hub.models import Feast
@@ -433,8 +434,16 @@ def match_icon_to_feast_task(self, feast_id: int):
             icon_id = first_match['id']
             try:
                 icon = Icon.objects.get(pk=icon_id, church=church)
-                feast.icon = icon
-                feast.save(update_fields=['icon'])
+                with transaction.atomic():
+                    locked_feast = Feast.objects.select_for_update().get(pk=feast_id)
+                    if locked_feast.icon_id is not None:
+                        logger.info(
+                            "Feast %s received an icon while matching, skipping.",
+                            feast_id,
+                        )
+                        return
+                    locked_feast.icon = icon
+                    locked_feast.save(update_fields=['icon'])
                 logger.info(
                     "Matched icon %s (confidence: %s) to feast %s (%s)",
                     icon_id, match_confidence, feast_id, prompt

--- a/hub/tests/test_feast_assign_icon_api.py
+++ b/hub/tests/test_feast_assign_icon_api.py
@@ -1,0 +1,250 @@
+"""Tests for the staff-only feast icon assignment API."""
+
+from datetime import date
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from hub.cache import feast_api_cache_key
+from hub.models import Church, Day, Feast
+from hub.tasks.icon_tasks import match_icon_to_feast_task
+from icons.models import Icon
+
+
+class FeastAssignIconAPITests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.staff_user = user_model.objects.create_user(
+            username="staff-assign",
+            email="staff-assign@example.com",
+            password="password",
+            is_staff=True,
+        )
+        self.regular_user = user_model.objects.create_user(
+            username="regular-assign",
+            email="regular-assign@example.com",
+            password="password",
+        )
+        self.client = APIClient()
+        self.church = Church.objects.get(pk=Church.get_default_pk())
+        self.other_church = Church.objects.create(name="Other Church")
+        self.day = Day.objects.create(date=date(2026, 7, 23), church=self.church)
+        self.icon = self._create_icon("Requested Icon", self.church)
+        self.other_icon = self._create_icon("Other Icon", self.church)
+        self.cross_church_icon = self._create_icon("Cross Church Icon", self.other_church)
+        with patch("hub.signals.match_icon_to_feast_task.delay"), patch(
+            "hub.signals.determine_feast_designation_task.delay"
+        ):
+            self.feast = Feast.objects.create(day=self.day, name="Test Feast")
+        self.url = reverse("feast-assign-icon", kwargs={"feast_id": self.feast.pk})
+
+    @staticmethod
+    def _create_icon(title, church):
+        return Icon.objects.create(
+            title=title,
+            church=church,
+            image=SimpleUploadedFile(
+                name=f"{title.lower().replace(' ', '-')}.jpg",
+                content=b"fake image content",
+                content_type="image/jpeg",
+            ),
+        )
+
+    def _authenticate_staff(self):
+        self.client.force_authenticate(user=self.staff_user)
+
+    def _post(self, **overrides):
+        payload = {
+            "icon_id": self.icon.id,
+            "replace": False,
+            "expected_current_icon_id": None,
+            **overrides,
+        }
+        return self.client.post(self.url, payload, format="json")
+
+    def test_staff_preflight_returns_exact_iconless_and_assigned_snapshots(self):
+        self._authenticate_staff()
+        response = self.client.get(self.url)
+        self.assertEqual(
+            response.json(),
+            {
+                "feast_id": self.feast.id,
+                "date": "2026-07-23",
+                "church_id": self.church.id,
+                "current_icon_id": None,
+                "current_icon": None,
+            },
+        )
+
+        self.feast.icon = self.other_icon
+        self.feast.save(update_fields=["icon"])
+        response = self.client.get(self.url)
+        self.assertEqual(response.json()["current_icon_id"], self.other_icon.id)
+        self.assertEqual(
+            response.json()["current_icon"],
+            {"id": self.other_icon.id, "title": "Other Icon"},
+        )
+
+    def test_get_and_post_require_staff(self):
+        for method in (self.client.get, lambda url: self.client.post(url, {}, format="json")):
+            response = method(self.url)
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        self.client.force_authenticate(user=self.regular_user)
+        for method in (self.client.get, lambda url: self.client.post(url, {}, format="json")):
+            response = method(self.url)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_missing_feast_and_icon_return_404(self):
+        self._authenticate_staff()
+        missing_url = reverse("feast-assign-icon", kwargs={"feast_id": 999999})
+        self.assertEqual(self.client.get(missing_url).status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(
+            self._post(icon_id=999999).status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+
+    def test_cross_church_icon_is_rejected_without_mutation(self):
+        self._authenticate_staff()
+        response = self._post(icon_id=self.cross_church_icon.id)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("church", response.json()["icon_id"])
+        self.feast.refresh_from_db()
+        self.assertIsNone(self.feast.icon_id)
+
+    def test_payload_types_are_validated_deliberately(self):
+        self._authenticate_staff()
+        response = self.client.post(self.url, [self.icon.id], format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("non_field_errors", response.json())
+
+        cases = [
+            ({"icon_id": True}, "icon_id"),
+            ({"replace": 1}, "replace"),
+            ({"expected_current_icon_id": 0}, "expected_current_icon_id"),
+        ]
+        for overrides, field in cases:
+            response = self._post(**overrides)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertIn(field, response.json())
+
+        response = self.client.post(
+            self.url,
+            {"icon_id": self.icon.id, "replace": False},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("expected_current_icon_id", response.json())
+
+    def test_first_assignment_requires_null_expected_id_and_invalidates_cache(self):
+        self._authenticate_staff()
+        cache_key = feast_api_cache_key(self.day.date, self.church.id, "en")
+        cache.set(cache_key, {"stale": True}, 60)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["status"], "assigned")
+        self.assertIsNone(response.json()["previous_icon_id"])
+        self.assertEqual(response.json()["current_icon_id"], self.icon.id)
+        self.feast.refresh_from_db()
+        self.assertEqual(self.feast.icon_id, self.icon.id)
+        self.assertIsNone(cache.get(cache_key))
+
+    def test_existing_icon_requires_explicit_replacement(self):
+        self._authenticate_staff()
+        self.feast.icon = self.other_icon
+        self.feast.save(update_fields=["icon"])
+
+        response = self._post(expected_current_icon_id=self.other_icon.id)
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.json()["code"], "replacement_required")
+        self.feast.refresh_from_db()
+        self.assertEqual(self.feast.icon_id, self.other_icon.id)
+
+    def test_explicit_replacement_succeeds(self):
+        self._authenticate_staff()
+        self.feast.icon = self.other_icon
+        self.feast.save(update_fields=["icon"])
+
+        response = self._post(
+            replace=True,
+            expected_current_icon_id=self.other_icon.id,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["status"], "replaced")
+        self.assertEqual(response.json()["previous_icon_id"], self.other_icon.id)
+        self.assertEqual(response.json()["current_icon_id"], self.icon.id)
+        self.feast.refresh_from_db()
+        self.assertEqual(self.feast.icon_id, self.icon.id)
+
+    def test_same_icon_is_noop_without_save(self):
+        self._authenticate_staff()
+        self.feast.icon = self.icon
+        self.feast.save(update_fields=["icon"])
+
+        with patch.object(Feast, "save", autospec=True) as mock_save:
+            response = self._post(expected_current_icon_id=self.icon.id)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["status"], "unchanged")
+        mock_save.assert_not_called()
+
+    def test_later_assignment_makes_preflight_stale_and_wins_over_replacement_policy(self):
+        self._authenticate_staff()
+        preflight = self.client.get(self.url).json()
+        self.assertIsNone(preflight["current_icon_id"])
+        self.feast.icon = self.other_icon
+        self.feast.save(update_fields=["icon"])
+
+        response = self._post(replace=True)
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.json()["code"], "stale_assignment")
+        self.assertEqual(response.json()["current_icon_id"], self.other_icon.id)
+        self.feast.refresh_from_db()
+        self.assertEqual(self.feast.icon_id, self.other_icon.id)
+
+    def test_matcher_rechecks_locked_feast_after_manual_assignment_wins(self):
+        self._authenticate_staff()
+
+        with patch("hub.tasks.icon_tasks._match_icons_with_llm") as mock_match:
+            def assign_manually_before_matcher_save(*args, **kwargs):
+                self.assertEqual(self._post().status_code, status.HTTP_200_OK)
+                return [{"id": self.other_icon.id, "confidence": "high"}]
+
+            mock_match.side_effect = assign_manually_before_matcher_save
+            match_icon_to_feast_task(self.feast.id)
+
+        self.feast.refresh_from_db()
+        self.assertEqual(self.feast.icon_id, self.icon.id)
+
+    def test_rollback_preserves_assignment_and_cache(self):
+        self._authenticate_staff()
+        cache_key = feast_api_cache_key(self.day.date, self.church.id, "en")
+        cache.set(cache_key, {"still": "valid"}, 60)
+        original_save = Feast.save
+
+        def save_then_fail(instance, *args, **kwargs):
+            original_save(instance, *args, **kwargs)
+            raise RuntimeError("force transaction rollback")
+
+        self.client.raise_request_exception = False
+        with patch.object(Feast, "save", new=save_then_fail):
+            with self.captureOnCommitCallbacks(execute=True) as callbacks:
+                response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(callbacks, [])
+        self.feast.refresh_from_db()
+        self.assertIsNone(self.feast.icon_id)
+        self.assertEqual(cache.get(cache_key), {"still": "valid"})

--- a/hub/tests/test_feast_views.py
+++ b/hub/tests/test_feast_views.py
@@ -513,7 +513,8 @@ class FeastAPIRouteTests(TestCase):
         self.assertIsNone(first_response.json()["feast"]["icon"])
 
         feast.icon = icon
-        feast.save(update_fields=["icon"])
+        with self.captureOnCommitCallbacks(execute=True):
+            feast.save(update_fields=["icon"])
 
         second_response = self._get_cached_feast_response(feast)
         self.assertEqual(second_response.status_code, status.HTTP_200_OK)
@@ -526,9 +527,10 @@ class FeastAPIRouteTests(TestCase):
         first_response = self._get_cached_feast_response(feast)
         self.assertIsNone(first_response.json()["feast"]["icon"])
 
-        with patch("hub.tasks.icon_tasks._match_icons_with_llm") as mock_match:
-            mock_match.return_value = [{"id": icon.id, "confidence": "high"}]
-            match_icon_to_feast_task(feast.id)
+        with self.captureOnCommitCallbacks(execute=True):
+            with patch("hub.tasks.icon_tasks._match_icons_with_llm") as mock_match:
+                mock_match.return_value = [{"id": icon.id, "confidence": "high"}]
+                match_icon_to_feast_task(feast.id)
 
         feast.refresh_from_db()
         second_response = self._get_cached_feast_response(feast)

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -30,7 +30,12 @@ from .views.user import (
 )
 from .views.church import ChurchListView, ChurchDetailView
 from .views.readings import GetDailyReadingsForDate, ReadingContextFeedbackView
-from .views.feasts import FeastContextFeedbackView, FeastMatchIconView, GetFeastForDate
+from .views.feasts import (
+    FeastAssignIconView,
+    FeastContextFeedbackView,
+    FeastMatchIconView,
+    GetFeastForDate,
+)
 from .views.patristic_quotes import (
     PatristicQuoteListView,
     PatristicQuoteDetailView,
@@ -110,6 +115,11 @@ urlpatterns = [
         "feasts/<int:feast_id>/match-icon/",
         FeastMatchIconView.as_view(),
         name="feast-match-icon",
+    ),
+    path(
+        "feasts/<int:feast_id>/assign-icon/",
+        FeastAssignIconView.as_view(),
+        name="feast-assign-icon",
     ),
     path("feasts/<int:pk>/feedback/", FeastContextFeedbackView.as_view(), name="feast-context-feedback"),
 

--- a/hub/views/feasts.py
+++ b/hub/views/feasts.py
@@ -4,16 +4,19 @@ Currently based on the Daily Worship app's website, sacredtradition.am
 """
 
 import logging
+from collections.abc import Mapping
 from datetime import datetime
 
 import sentry_sdk
 from django.conf import settings
+from django.db import transaction
 from django.db.models import F
 from django.core.cache import cache
 from django.shortcuts import get_object_or_404
 from django.utils.translation import activate, get_language_from_request
 from rest_framework import generics, status
 from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -24,6 +27,7 @@ from hub.tasks.icon_tasks import match_icon_to_feast_task
 from hub.tasks.llm_tasks import is_feast_context_generation_eligible
 from hub.utils import get_user_profile_safe, get_or_create_feast_for_date
 from icons.serializers import IconSerializer
+from icons.models import Icon
 from icons.views import IsAdminOrReadOnly
 
 
@@ -261,6 +265,124 @@ class FeastMatchIconView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+
+
+class FeastAssignIconView(APIView):
+    """Staff-only feast icon assignment preflight and mutation endpoint."""
+
+    permission_classes = [IsAdminUser]
+
+    @staticmethod
+    def _icon_snapshot(icon):
+        if icon is None:
+            return None
+        return {"id": icon.id, "title": icon.title}
+
+    @classmethod
+    def _feast_snapshot(cls, feast):
+        return {
+            "feast_id": feast.id,
+            "date": feast.day.date.isoformat(),
+            "church_id": feast.day.church_id,
+            "current_icon_id": feast.icon_id,
+            "current_icon": cls._icon_snapshot(feast.icon),
+        }
+
+    @staticmethod
+    def _is_positive_integer(value):
+        return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+    def get(self, request, feast_id: int):
+        feast = get_object_or_404(
+            Feast.objects.select_related("day", "day__church", "icon"),
+            pk=feast_id,
+        )
+        return Response(self._feast_snapshot(feast), status=status.HTTP_200_OK)
+
+    def post(self, request, feast_id: int):
+        if not isinstance(request.data, Mapping):
+            return Response(
+                {"non_field_errors": ["Request body must be a JSON object."]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        icon_id = request.data.get("icon_id")
+        replace = request.data.get("replace", False)
+
+        errors = {}
+        if not self._is_positive_integer(icon_id):
+            errors["icon_id"] = "Must be a positive integer."
+        if not isinstance(replace, bool):
+            errors["replace"] = "Must be a boolean."
+        if "expected_current_icon_id" not in request.data:
+            errors["expected_current_icon_id"] = "This field is required."
+        else:
+            expected_icon_id = request.data["expected_current_icon_id"]
+            if expected_icon_id is not None and not self._is_positive_integer(expected_icon_id):
+                errors["expected_current_icon_id"] = "Must be a positive integer or null."
+        if errors:
+            return Response(errors, status=status.HTTP_400_BAD_REQUEST)
+
+        expected_icon_id = request.data["expected_current_icon_id"]
+        with transaction.atomic():
+            feast = get_object_or_404(
+                Feast.objects.select_for_update().select_related("day", "day__church"),
+                pk=feast_id,
+            )
+            icon = get_object_or_404(Icon.objects.select_for_update(), pk=icon_id)
+
+            if icon.church_id != feast.day.church_id:
+                return Response(
+                    {"icon_id": "Icon must belong to the feast's church."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if feast.icon_id != expected_icon_id:
+                return Response(
+                    {
+                        "error": "The feast icon changed after preflight.",
+                        "code": "stale_assignment",
+                        "current_icon_id": feast.icon_id,
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            previous_icon_id = feast.icon_id
+            if previous_icon_id == icon.id:
+                return Response(
+                    {
+                        "status": "unchanged",
+                        "feast_id": feast.id,
+                        "previous_icon_id": previous_icon_id,
+                        "current_icon_id": icon.id,
+                        "current_icon": self._icon_snapshot(icon),
+                    },
+                    status=status.HTTP_200_OK,
+                )
+
+            if previous_icon_id is not None and replace is not True:
+                return Response(
+                    {
+                        "error": "The feast already has a different icon; set replace to true.",
+                        "code": "replacement_required",
+                        "current_icon_id": previous_icon_id,
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            feast.icon = icon
+            feast.save(update_fields=["icon"])
+            assignment_status = "replaced" if previous_icon_id is not None else "assigned"
+            return Response(
+                {
+                    "status": assignment_status,
+                    "feast_id": feast.id,
+                    "previous_icon_id": previous_icon_id,
+                    "current_icon_id": icon.id,
+                    "current_icon": self._icon_snapshot(icon),
+                },
+                status=status.HTTP_200_OK,
+            )
 
 
 class FeastContextFeedbackView(APIView):


### PR DESCRIPTION
## What changed

Adds a staff-only API for explicitly assigning an existing icon to a feast:

- `GET /api/feasts/<id>/assign-icon/` returns the current assignment for a safe CLI preflight.
- `POST /api/feasts/<id>/assign-icon/` assigns or replaces an icon after validating church ownership and the expected current icon.
- Existing assignments require explicit replacement, and stale preflights receive a conflict rather than overwriting newer work.

The automatic icon matcher now rechecks under a lock so a manual assignment wins if both operations overlap. Cache invalidation is deferred until commit, avoiding stale or invalid cache state on rollback.

## Why

Staff need a supported operational path to replace a feast's icon deliberately, without relying on automatic matching or direct database access.

## Validation

- `bash scripts/crabbox-validate.sh ci` — Ruff and 1,210 Django tests passing (2 skipped)
- 12 targeted API tests passing
- CLI companion: 18 tests and Ruff passing
- Review pass: no blocking findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches staff mutation of feast data and concurrency between Celery matching and the API; mitigated by locks, optimistic checks, and on-commit cache invalidation.
> 
> **Overview**
> Adds a **staff-only** `GET`/`POST` endpoint at `feasts/<id>/assign-icon/` so operators can preflight the current icon and assign or replace one deliberately. `POST` requires `expected_current_icon_id` (optimistic concurrency), enforces same-church icons, returns **409** for stale preflights or when `replace` is missing on an existing icon, and supports an idempotent **unchanged** path.
> 
> **Feast save** cache invalidation now runs via `transaction.on_commit`, so rolled-back icon writes do not clear feast API cache. The **auto icon matcher** re-locks the feast before save and skips if an icon was set meanwhile (e.g. manual assign).
> 
> New API tests cover auth, validation, conflicts, cache-on-commit, and matcher vs manual assign; existing feast cache tests assert invalidation only after commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 977e056601502671ef9343dabcbf01085280ac86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->