### PR TITLE
Bound API.Bible spend and stop the weekly quota burn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,17 @@ Bahk (also known as Fast & Pray) is a Django-based web application for Christian
 
 5. **Push Notifications**: Expo push notifications for mobile app integration
 
-6. **Bible Text (API.Bible)**: Fetches Scripture via the [API.Bible](https://scripture.api.bible/) REST API (NKJV; KJVAIC for Apocrypha). Service in `hub/services/bible_api_service.py`, tasks in `hub/tasks/bible_api_tasks.py`. A weekly Celery Beat task refreshes stale texts (>23 days) to meet the 30-day freshness requirement. Copyright is stored unmodified alongside text. FUMS tracking is pending before frontend exposure. Env var: `BIBLE_API_KEY`.
+6. **Bible Text (API.Bible)**: Fetches Scripture via the [API.Bible](https://scripture.api.bible/) REST API (NKJV; KJVAIC for Apocrypha). Service in `hub/services/bible_api_service.py`, language registry in `hub/services/reading_text_service.py`, tasks in `hub/tasks/bible_api_tasks.py`. Copyright is stored unmodified alongside text, and each reading gets its own call so it receives a unique FUMS token.
+
+   Spend against the plan quota (5,000 calls/month) is controlled in four places:
+   - A weekly Celery Beat task refreshes at most `READING_REFRESH_LIMIT` stale readings (>`READING_TEXT_REFRESH_DAYS`), **nearest to today first**. Readings are never deleted — pruning only caused rows to be re-created and re-fetched by the public view.
+   - `GetDailyReadingsForDate` re-fetches text older than `READING_TEXT_MAX_AGE_DAYS` on demand, capped by a per-day counter (`READING_FETCH_DAILY_BUDGET`).
+   - `BIBLE_API_MONTHLY_BUDGET` is a hard ceiling over **both** paths (`hub/services/api_budget.py`). It matters because a failed fetch never records `text_fetched_at`: without a ceiling, a run of quota rejections leaves every reading permanently stale and re-burns the quota every week.
+   - The refresh task aborts after `READING_REFRESH_MAX_CONSECUTIVE_FAILURES` consecutive English failures, so a rejecting API costs ~10 calls instead of a full run.
+
+   `get_reading_text_fields` blanks English text/version/copyright/FUMS token once it exceeds `READING_TEXT_MAX_AGE_DAYS`, so nothing past API.Bible's freshness cap is ever served. Armenian text is not API.Bible-sourced and never expires.
+
+   Env vars: `BIBLE_API_KEY`, `READING_TEXT_REFRESH_DAYS`, `READING_TEXT_MAX_AGE_DAYS`, `READING_REFRESH_LIMIT`, `READING_REFRESH_MAX_CONSECUTIVE_FAILURES`, `READING_FETCH_DAILY_BUDGET`, `BIBLE_API_MONTHLY_BUDGET`.
 
 ## Development Environment
 
@@ -234,7 +244,9 @@ Uses `python-decouple` for environment variables. Key variables in `.env`:
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_STORAGE_BUCKET_NAME`
 - `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`
 - `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` (for AI-generated content)
-- `BIBLE_API_KEY` (API.Bible text retrieval)
+- `BIBLE_API_KEY` (API.Bible text retrieval); see Key Features #6 for the spend-control
+  vars: `READING_TEXT_MAX_AGE_DAYS`, `READING_REFRESH_LIMIT`, `READING_FETCH_DAILY_BUDGET`,
+  `BIBLE_API_MONTHLY_BUDGET`
 - `SENTRY_DSN` (error monitoring)
 
 ### Celery Scheduled Tasks

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Bahk retrieves Scripture text from the [API.Bible](https://scripture.api.bible/)
 
 Key compliance measures:
 
-- **Content freshness**: A weekly Celery Beat task refreshes all reading texts so none exceed 30 days old.
+- **Content freshness**: A weekly Celery Beat task refreshes reading texts, prioritising the dates nearest to today. Any text that nonetheless passes 30 days is **withheld from the API response** and re-fetched on demand the next time that date is requested, so text older than 30 days is never served.
 - **Content integrity**: Text is stored exactly as returned by the API with no modifications.
 - **Copyright citation**: The copyright string from the API response is stored and displayed alongside the text.
 - **FUMS (Fair Use Management System)**: All API.Bible requests include `fums-version=3`, and the returned `fumsToken` is stored on each `Reading` and served to the frontend via the readings API. The frontend reports tokens to `https://fums.api.bible/f3` with anonymized device, session, and user identifiers each time scripture is displayed.

--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -443,13 +443,31 @@ ANTHROPIC_API_KEY = config('ANTHROPIC_API_KEY')
 
 # API.BIBLE SETTINGS
 BIBLE_API_KEY = config('BIBLE_API_KEY', default='')
-# Number of days after which a reading's text is considered stale and needs refresh.
-# Set to 30 - (refresh interval in days) to ensure content never exceeds the 30-day
-# freshness requirement. Default: 23 (= 30 - 7, for a weekly refresh).
+# Number of days after which a reading's text is considered stale and is queued for the
+# weekly refresh.  Must stay <= READING_TEXT_MAX_AGE_DAYS, or text expires before the
+# refresh task can reach it.  Default: 23 (= 30 - 7, for a weekly refresh).
 READING_TEXT_REFRESH_DAYS = config('READING_TEXT_REFRESH_DAYS', default=23, cast=int)
-# Maximum number of readings to keep in the database.  Oldest readings are
-# pruned during the weekly refresh to stay within the API calls/month budget.
-MAX_READINGS = config('MAX_READINGS', default=2000, cast=int)
+# API.Bible's freshness cap.  Text older than this is never served (it is blanked in the
+# API response) and is re-fetched on demand by the readings view, subject to the budgets.
+READING_TEXT_MAX_AGE_DAYS = config('READING_TEXT_MAX_AGE_DAYS', default=30, cast=int)
+# Max readings refreshed per weekly run, nearest to today first.  Readings are never
+# deleted; this bounds API.Bible spend, not table size.
+READING_REFRESH_LIMIT = config('READING_REFRESH_LIMIT', default=2000, cast=int)
+# Abort a refresh run after this many consecutive English fetch failures.  A failed fetch
+# never records text_fetched_at, so without this a quota rejection (429/403) makes every
+# reading permanently stale and each weekly run re-burns the whole quota against a wall.
+READING_REFRESH_MAX_CONSECUTIVE_FAILURES = config(
+    'READING_REFRESH_MAX_CONSECUTIVE_FAILURES', default=10, cast=int
+)
+# Max on-demand API.Bible calls the public readings view may make per calendar day.
+READING_FETCH_DAILY_BUDGET = config('READING_FETCH_DAILY_BUDGET', default=75, cast=int)
+# Hard ceiling on ALL API.Bible calls per calendar month, across the weekly refresh task
+# and the on-demand view path.  Kept under the 5,000/month plan quota so that no failure
+# mode can exhaust it.  Budget:
+#   weekly refresh   <=2,000 per ~28-day cycle  ~= 2,170/month
+#   on-demand view   75/day                      = 2,250/month
+#                                          total ~= 4,420/month
+BIBLE_API_MONTHLY_BUDGET = config('BIBLE_API_MONTHLY_BUDGET', default=4500, cast=int)
 
 # Test settings
 if 'test' in sys.argv:

--- a/hub/admin.py
+++ b/hub/admin.py
@@ -41,7 +41,8 @@ from hub.models import (
     ReadingContext,
     FastIntention,
 )
-from hub.services.bible_api_service import BibleAPIService, fetch_text_for_reading
+from hub.services.bible_api_service import BibleAPIService
+from hub.services.reading_text_service import bible_api_budgets, fetch_english_text
 from hub.tasks import (
     generate_reading_context_task,
     generate_feast_context_task,
@@ -835,7 +836,9 @@ class ReadingAdmin(admin.ModelAdmin):
             )
             return redirect(reverse("admin:hub_reading_change", args=[pk]))
 
-        success = fetch_text_for_reading(reading, service=service)
+        success = fetch_english_text(
+            reading, service=service, budgets=bible_api_budgets(include_daily=False),
+        )
         if success:
             self.message_user(
                 request,
@@ -862,10 +865,11 @@ class ReadingAdmin(admin.ModelAdmin):
             )
             return
 
+        budgets = bible_api_budgets(include_daily=False)
         success_count = 0
         fail_count = 0
         for reading in queryset:
-            if fetch_text_for_reading(reading, service=service):
+            if fetch_english_text(reading, service=service, budgets=budgets):
                 success_count += 1
             else:
                 fail_count += 1

--- a/hub/management/commands/fetch_reading_texts.py
+++ b/hub/management/commands/fetch_reading_texts.py
@@ -1,20 +1,24 @@
 """Fetch Bible text from API.Bible for readings missing text."""
 import logging
-from datetime import timedelta
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.db.models import Q
-from django.utils import timezone
 
 from hub.models import Reading
+from hub.services.reading_text_service import (
+    select_nearest_stale_reading_ids,
+    stale_reading_queryset,
+)
 from hub.tasks import refresh_all_reading_texts_task
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Fetch Bible text from API.Bible for readings that are missing or stale"
+    help = (
+        "Fetch Bible text from API.Bible for readings that are missing or stale. "
+        "Each run refreshes at most READING_REFRESH_LIMIT readings, nearest to today first."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -26,20 +30,29 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         refresh_days = getattr(settings, "READING_TEXT_REFRESH_DAYS", 23)
-        threshold = timezone.now() - timedelta(days=refresh_days)
-        stale_filter = Q(text_fetched_at__isnull=True) | Q(text_fetched_at__lt=threshold)
+        limit = getattr(settings, "READING_REFRESH_LIMIT", 2000)
 
+        stale_readings = stale_reading_queryset(refresh_days)
         missing_count = Reading.objects.filter(text="").count()
-        stale_count = Reading.objects.filter(stale_filter).count()
+        stale_count = stale_readings.count()
         total_count = Reading.objects.count()
 
         self.stdout.write(
-            f"Readings without text: {missing_count}/{total_count}; stale: {stale_count}/{total_count}"
+            f"Readings without text: {missing_count}/{total_count}; "
+            f"stale (>{refresh_days}d): {stale_count}/{total_count}"
         )
 
         if stale_count == 0:
             self.stdout.write(self.style.SUCCESS("All readings already have fresh text."))
             return
+
+        # Use the same selection the task will, so the reported number cannot drift.
+        will_refresh = len(select_nearest_stale_reading_ids(limit, queryset=stale_readings))
+        self.stdout.write(
+            f"This run will refresh {will_refresh} readings "
+            f"(limit {limit}, nearest to today first); "
+            f"{max(stale_count - will_refresh, 0)} will remain stale."
+        )
 
         if options["run_async"]:
             refresh_all_reading_texts_task.delay()

--- a/hub/services/api_budget.py
+++ b/hub/services/api_budget.py
@@ -1,0 +1,104 @@
+"""Per-period spend budgets for metered third-party APIs.
+
+Backed by ``django.core.cache`` so a counter is shared across web dynos and Celery
+workers (Redis in production, LocMemCache under ``tests.test_settings``).  Counters are
+namespaced by *local* calendar day or month and expire on their own; nothing resets them.
+
+Used to keep API.Bible calls inside the plan quota.  See ``hub/services/reading_text_service.py``
+for the call sites and ``bahk/settings.py`` (API.BIBLE SETTINGS) for the limits.
+"""
+
+import logging
+
+from django.core.cache import cache
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+DAY = "day"
+MONTH = "month"
+
+# Each counter must outlive its own period so a late call on the last day/hour still
+# lands on the same key rather than silently starting a fresh budget.
+PERIOD_TTL_SECONDS = {
+    DAY: 36 * 60 * 60,       # 1.5 days
+    MONTH: 35 * 24 * 60 * 60,  # 35 days
+}
+
+
+class APIBudget:
+    """Best-effort cap on how many calls may be made to an API per calendar period.
+
+    Not atomic: ``consume`` reads then increments, so under concurrency the counter can
+    overshoot ``limit`` by at most (concurrent callers - 1), and a token may be burned
+    without a call being made when the increment lands over the limit.  Both errors are
+    bounded and in the safe direction.  An atomic version would need a Redis Lua script,
+    which would not work under LocMemCache in tests.
+
+    Fails *closed*: if the cache is unreachable, ``consume`` returns False.  Reopening the
+    spend hole during a Redis outage is worse than briefly withholding expired text.
+    """
+
+    def __init__(self, name: str, limit: int, *, period: str = DAY):
+        if period not in PERIOD_TTL_SECONDS:
+            raise ValueError(f"Unknown budget period {period!r}; expected one of {list(PERIOD_TTL_SECONDS)}.")
+        self.name = name
+        self.limit = int(limit)
+        self.period = period
+        self.ttl = PERIOD_TTL_SECONDS[period]
+
+    def key(self, today=None) -> str:
+        """Cache key for the period containing *today* (defaults to the current local date).
+
+        Computed on each call rather than cached on the instance so a long-lived budget
+        object (or a request straddling midnight) rolls over to the next period correctly.
+        """
+        today = today or timezone.localdate()
+        stamp = today.strftime("%Y-%m") if self.period == MONTH else today.isoformat()
+        return f"api_budget:{self.name}:{self.period}:{stamp}"
+
+    def used(self) -> int:
+        """Calls consumed in the current period, or ``limit`` if the cache is unreachable."""
+        try:
+            return int(cache.get(self.key()) or 0)
+        except Exception:
+            logger.warning("Could not read %s budget counter; assuming exhausted.", self.name, exc_info=True)
+            return self.limit
+
+    def remaining(self) -> int:
+        return max(self.limit - self.used(), 0)
+
+    def consume(self, amount: int = 1) -> bool:
+        """Reserve *amount* calls.  Returns False when the budget is exhausted."""
+        if self.limit <= 0:
+            return False
+        key = self.key()
+        try:
+            if int(cache.get(key) or 0) >= self.limit:
+                return False
+            total = self._increment(key, amount)
+        except Exception:
+            logger.warning("%s budget cache unavailable; refusing spend.", self.name, exc_info=True)
+            return False
+        return total <= self.limit
+
+    def _increment(self, key: str, amount: int) -> int:
+        """Increment *key*, creating it with a TTL if absent.
+
+        ``cache.incr`` raises ValueError on a missing key and preserves the existing TTL
+        on both django-redis and LocMemCache, so create-then-increment gives a counter
+        that expires on schedule.
+        """
+        try:
+            return cache.incr(key, amount)
+        except ValueError:
+            pass
+        if cache.add(key, amount, timeout=self.ttl):
+            return amount
+        # Another caller created the key between our incr and add.
+        try:
+            return cache.incr(key, amount)
+        except ValueError:
+            # Expired again in that window; treat it as a fresh period.
+            cache.set(key, amount, timeout=self.ttl)
+            return amount

--- a/hub/services/bible_api_service.py
+++ b/hub/services/bible_api_service.py
@@ -12,7 +12,6 @@ import logging
 
 import requests
 from decouple import config
-from django.utils import timezone
 
 from hub.constants import APOCRYPHA_USFM_IDS, BOOK_NAME_TO_USFM
 
@@ -174,71 +173,3 @@ class BibleAPIService:
         if start == end:
             return start
         return f"{start}-{end}"
-
-
-# ------------------------------------------------------------------ #
-#  Module-level helpers (used by views, admin, and Celery tasks)
-# ------------------------------------------------------------------ #
-
-def fetch_text_for_reading(reading, service: BibleAPIService | None = None) -> bool:
-    """Fetch Bible text for a single Reading.
-
-    Each Reading gets its own API call so that it receives a unique FUMS token,
-    as required by API.Bible's Fair Use Management System terms of use.
-
-    Can be called synchronously from views or from Celery tasks.
-
-    Args:
-        reading: A Reading model instance (must be saved to the database).
-        service: Optional pre-initialized BibleAPIService. If None, one will
-                 be created (requires BIBLE_API_KEY to be configured).
-
-    Returns:
-        True if the reading now has text, False if it could not be populated
-        (e.g. missing API key, unknown book).
-    """
-    from hub.models import Reading as ReadingModel  # deferred to avoid circular import
-
-    if service is None:
-        try:
-            service = BibleAPIService()
-        except ValueError as e:
-            logger.error("Cannot initialize BibleAPIService: %s", e)
-            return False
-
-    try:
-        passage = BibleAPIService.resolve_reading_passage(
-            reading.book,
-            reading.start_chapter,
-            reading.start_verse,
-            reading.end_chapter,
-            reading.end_verse,
-        )
-        result = service.get_passage(
-            *passage,
-        )
-
-        ReadingModel.objects.filter(pk=reading.pk).update(
-            text=result["content"],
-            text_copyright=result["copyright"],
-            text_version=result["version"],
-            text_fetched_at=timezone.now(),
-            fums_token=result.get("fums_token", ""),
-        )
-        logger.info(
-            "Fetched text for Reading %s (%s).",
-            reading.pk, reading.passage_reference,
-        )
-        return True
-    except ValueError as e:
-        logger.error(
-            "Book name mapping failed for Reading %s ('%s'): %s",
-            reading.pk, reading.book, e,
-        )
-        return False
-    except Exception as e:
-        logger.error(
-            "API call failed for Reading %s (%s): %s",
-            reading.pk, reading.passage_reference, e,
-        )
-        return False

--- a/hub/services/reading_text_service.py
+++ b/hub/services/reading_text_service.py
@@ -100,6 +100,7 @@ def fetch_english_text(
     *,
     service: BibleAPIService | None = None,
     budgets: list[APIBudget] | None = None,
+    stats: dict[str, int] | None = None,
     **_kwargs,
 ) -> bool:
     """Fetch English Bible text from API.Bible for a single Reading.
@@ -115,6 +116,11 @@ def fetch_english_text(
                  consumed only once the passage has resolved and immediately before
                  the call, so an unmappable book name never burns a token.  If any
                  budget refuses, no call is made and this returns False.
+        stats: Optional shared counter dict.  ``stats["attempted"]`` is incremented
+               once per call that actually reaches API.Bible — i.e. after an unmappable
+               book or an exhausted budget has already returned, so callers can tell
+               "we tried and it failed" apart from "we never tried" using only the
+               boolean return value.
 
     Returns:
         True if text was successfully fetched, False otherwise.
@@ -152,6 +158,9 @@ def fetch_english_text(
                 budget.period, budget.limit, reading.pk, reading.passage_reference,
             )
             return False
+
+    if stats is not None:
+        stats["attempted"] = stats.get("attempted", 0) + 1
 
     try:
         result = service.get_passage(

--- a/hub/services/reading_text_service.py
+++ b/hub/services/reading_text_service.py
@@ -74,6 +74,27 @@ def book_hy_for_book(book_en: str) -> str | None:
 #  Individual language fetchers
 # ------------------------------------------------------------------ #
 
+def reading_is_mappable(reading) -> bool:
+    """True when the reading's book resolves to a USFM id, i.e. a fetch would reach the API.
+
+    Lets callers tell "API.Bible refused us" apart from "we cannot name this book".  The
+    latter fails before any HTTP request, so it is a data problem to fix in
+    ``BOOK_NAME_TO_USFM`` — not a signal that the API is unhealthy.  Pure dict lookups,
+    no I/O, so it is cheap to call alongside a fetch.
+    """
+    try:
+        BibleAPIService.resolve_reading_passage(
+            reading.book,
+            reading.start_chapter,
+            reading.start_verse,
+            reading.end_chapter,
+            reading.end_verse,
+        )
+    except ValueError:
+        return False
+    return True
+
+
 def fetch_english_text(
     reading,
     *,

--- a/hub/services/reading_text_service.py
+++ b/hub/services/reading_text_service.py
@@ -8,22 +8,31 @@ them all for a given Reading.  Adding a new language is a three-step process:
     3. (Optional) Register a resource preparer in ``RESOURCE_PREPARERS`` if the
        fetcher benefits from batch-level shared state (e.g. a scraped page or
        HTTP session that can be reused across multiple readings).
+    4. (Optional) Register the language in ``EXPIRING_LANGUAGES`` if its source
+       licence caps how old served text may be.
 
 The view calls ``prepare_shared_resources`` once per batch, then
 ``fetch_all_reading_texts`` once per reading.  ``get_reading_text_fields``
 resolves model fields for the API response without hard-coding language names.
+
+``prepare_shared_resources`` also carries the API.Bible spend budgets, and only the
+readings view calls it \u2014 so the budgets gate the public on-demand path and nothing else.
+The weekly refresh task builds its own shared dict and charges only the monthly budget.
 """
 
 import json
 import logging
+from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 from django.conf import settings
+from django.db.models import Q
 from django.utils import timezone
 
 from hub.constants import BOOK_NAME_TO_USFM_NORMALIZED, normalize_book_name
+from hub.services.api_budget import DAY, MONTH, APIBudget
 from hub.services.bible_api_service import BibleAPIService
 
 logger = logging.getLogger(__name__)
@@ -65,7 +74,13 @@ def book_hy_for_book(book_en: str) -> str | None:
 #  Individual language fetchers
 # ------------------------------------------------------------------ #
 
-def fetch_english_text(reading, *, service: BibleAPIService | None = None, **_kwargs) -> bool:
+def fetch_english_text(
+    reading,
+    *,
+    service: BibleAPIService | None = None,
+    budgets: list[APIBudget] | None = None,
+    **_kwargs,
+) -> bool:
     """Fetch English Bible text from API.Bible for a single Reading.
 
     Each Reading gets its own API call so that it receives a unique FUMS
@@ -75,6 +90,10 @@ def fetch_english_text(reading, *, service: BibleAPIService | None = None, **_kw
         reading: A saved Reading model instance.
         service: Optional pre-initialized BibleAPIService (shares the HTTP
                  session across a batch of readings).
+        budgets: Optional spend budgets to charge before calling the API.  They are
+                 consumed only once the passage has resolved and immediately before
+                 the call, so an unmappable book name never burns a token.  If any
+                 budget refuses, no call is made and this returns False.
 
     Returns:
         True if text was successfully fetched, False otherwise.
@@ -88,6 +107,8 @@ def fetch_english_text(reading, *, service: BibleAPIService | None = None, **_kw
             logger.error("Cannot initialize BibleAPIService: %s", exc)
             return False
 
+    # Resolve first, outside the API try-block: a mapping failure is a data problem, not
+    # an API failure, and must not consume budget or be reported as an API error.
     try:
         passage = BibleAPIService.resolve_reading_passage(
             reading.book,
@@ -96,6 +117,22 @@ def fetch_english_text(reading, *, service: BibleAPIService | None = None, **_kw
             reading.end_chapter,
             reading.end_verse,
         )
+    except ValueError as exc:
+        logger.error(
+            "Book name mapping failed for Reading %s ('%s'): %s",
+            reading.pk, reading.book, exc,
+        )
+        return False
+
+    for budget in budgets or ():
+        if not budget.consume():
+            logger.warning(
+                "API.Bible %s budget (%d) exhausted; skipping fetch for Reading %s (%s).",
+                budget.period, budget.limit, reading.pk, reading.passage_reference,
+            )
+            return False
+
+    try:
         result = service.get_passage(
             *passage,
         )
@@ -112,12 +149,6 @@ def fetch_english_text(reading, *, service: BibleAPIService | None = None, **_kw
             reading.pk, reading.passage_reference,
         )
         return True
-    except ValueError as exc:
-        logger.error(
-            "Book name mapping failed for Reading %s ('%s'): %s",
-            reading.pk, reading.book, exc,
-        )
-        return False
     except Exception as exc:
         logger.error(
             "API call failed for Reading %s (%s): %s",
@@ -194,13 +225,39 @@ TEXT_FETCHERS: dict[str, callable] = {
 #  Shared-resource preparation
 # ------------------------------------------------------------------ #
 
+def bible_api_budgets(*, include_daily: bool = True) -> list[APIBudget]:
+    """Spend budgets to charge for one API.Bible call, cheapest-to-refuse first.
+
+    The monthly ceiling applies to every caller, so no failure mode — including a run of
+    quota rejections, which never record ``text_fetched_at`` and therefore retry forever —
+    can exhaust the plan quota.  The daily budget applies only to the public on-demand
+    path, so traffic there cannot spend a whole month's allowance in a day.
+    """
+    budgets = []
+    if include_daily:
+        budgets.append(APIBudget(
+            "bible_api", getattr(settings, "READING_FETCH_DAILY_BUDGET", 75), period=DAY,
+        ))
+    budgets.append(APIBudget(
+        "bible_api", getattr(settings, "BIBLE_API_MONTHLY_BUDGET", 4500), period=MONTH,
+    ))
+    return budgets
+
+
 def _prepare_english_resources(**_kwargs) -> dict[str, Any]:
-    """Create a shared BibleAPIService instance for the English fetcher."""
+    """Create the shared BibleAPIService and spend budgets for the English fetcher.
+
+    Only ``prepare_shared_resources`` reaches this, and only the readings view calls that,
+    so the daily budget is scoped to the public on-demand path.  The budgets are built
+    outside the try-block: if the API key is missing we still want ``fetch_english_text``
+    to receive them rather than fall through to constructing its own unbudgeted service.
+    """
+    resources: dict[str, Any] = {"budgets": bible_api_budgets()}
     try:
-        return {"service": BibleAPIService()}
+        resources["service"] = BibleAPIService()
     except ValueError:
         logger.warning("BIBLE_API_KEY not configured; English text will be skipped.")
-        return {}
+    return resources
 
 
 # Armenian text is composed from the local BibleVerse corpus per-reading (indexed range scans),
@@ -268,6 +325,78 @@ def fetch_all_reading_texts(reading, **shared_resources) -> dict[str, bool]:
 
 
 # ------------------------------------------------------------------ #
+#  Stale-reading selection
+# ------------------------------------------------------------------ #
+
+def stale_reading_queryset(refresh_days: int | None = None):
+    """Readings whose English text is missing or older than the refresh threshold."""
+    from hub.models import Reading as ReadingModel
+
+    if refresh_days is None:
+        refresh_days = getattr(settings, "READING_TEXT_REFRESH_DAYS", 23)
+    threshold = timezone.now() - timedelta(days=refresh_days)
+    return ReadingModel.objects.filter(
+        Q(text_fetched_at__isnull=True) | Q(text_fetched_at__lt=threshold)
+    )
+
+
+def select_nearest_stale_reading_ids(limit: int, *, today=None, queryset=None) -> list[int]:
+    """PKs of at most *limit* stale readings, nearest to today first.
+
+    Today's and upcoming readings come first (ascending by date), then past readings
+    (descending), until *limit* is reached.  Nobody browses far into the past, so
+    spending the refresh allowance on the dates people actually open is what keeps
+    served text inside API.Bible's freshness window.
+
+    Uses two ordered queries rather than an ``Abs(day__date - today)`` annotation so the
+    same code runs on PostgreSQL (production) and SQLite (tests).
+    """
+    if limit <= 0:
+        return []
+
+    qs = stale_reading_queryset() if queryset is None else queryset
+    today = today or timezone.localdate()
+
+    upcoming = list(
+        qs.filter(day__date__gte=today)
+        .order_by("day__date", "pk")
+        .values_list("pk", flat=True)[:limit]
+    )
+    remaining = limit - len(upcoming)
+    if remaining <= 0:
+        return upcoming
+
+    past = list(
+        qs.filter(day__date__lt=today)
+        .order_by("-day__date", "-pk")
+        .values_list("pk", flat=True)[:remaining]
+    )
+    return upcoming + past
+
+
+def iter_readings_in_pk_order(pks, chunk_size: int = 100):
+    """Yield Readings for *pks* in exactly that order, loading *chunk_size* at a time.
+
+    Chunked rather than one big ``list()``: a refresh run sleeps between calls and can
+    take tens of minutes, so each batch is re-read just before use instead of holding
+    thousands of rows (each carrying full verse text) in memory the whole time.
+    """
+    from hub.models import Reading as ReadingModel
+
+    pks = list(pks)
+    for start in range(0, len(pks), chunk_size):
+        chunk = pks[start:start + chunk_size]
+        by_pk = {
+            reading.pk: reading
+            for reading in ReadingModel.objects.select_related("day", "day__church").filter(pk__in=chunk)
+        }
+        for pk in chunk:
+            reading = by_pk.get(pk)
+            if reading is not None:  # skip rows deleted between selection and load
+                yield reading
+
+
+# ------------------------------------------------------------------ #
 #  Response field resolution
 # ------------------------------------------------------------------ #
 
@@ -278,11 +407,45 @@ LANGUAGE_FIELD_MAP: dict[str, tuple[str, str, str, str]] = {
     "hy": ("text_hy", "text_hy_version", "text_hy_copyright", "text_hy_fums_token"),
 }
 
+# Languages whose source licence caps how old served text may be, mapped to the model
+# field holding the last-fetch timestamp.  A language absent from this dict never
+# expires.  Registering here is the optional fourth step when adding a language.
+EXPIRING_LANGUAGES: dict[str, str] = {
+    "en": "text_fetched_at",  # API.Bible: 30-day freshness requirement
+}
+
+
+def text_is_expired(reading, lang: str, *, now=None) -> bool:
+    """True when *lang*'s text on *reading* is past its licence's freshness cap.
+
+    A missing timestamp counts as expired: we cannot show that the text is fresh enough
+    to serve, so we treat it the same as stale.
+    """
+    fetched_at_field = EXPIRING_LANGUAGES.get(lang)
+    if fetched_at_field is None:
+        return False
+    fetched_at = getattr(reading, fetched_at_field, None)
+    if fetched_at is None:
+        return True
+    max_age = getattr(settings, "READING_TEXT_MAX_AGE_DAYS", 30)
+    return fetched_at < (now or timezone.now()) - timedelta(days=max_age)
+
+
+def reading_needs_text_fetch(reading, *, now=None) -> bool:
+    """True when any freshness-limited language on *reading* has expired.
+
+    The readings view uses this to decide whether to spend an on-demand API call.
+    """
+    return any(text_is_expired(reading, lang, now=now) for lang in EXPIRING_LANGUAGES)
+
 
 def get_reading_text_fields(reading, lang: str) -> dict[str, str]:
     """Return the text/version/copyright/FUMS fields for *lang* as a dict.
 
-    Falls back to English if the requested language is not in the registry.
+    Falls back to English if the requested language is not in the registry.  Expired text
+    is blanked rather than served: API.Bible's terms forbid displaying content cached for
+    more than ``READING_TEXT_MAX_AGE_DAYS``, and text can outlive that window whenever a
+    refresh run does not reach a reading or the spend budget is exhausted.
 
     Args:
         reading: A Reading model instance.
@@ -292,9 +455,18 @@ def get_reading_text_fields(reading, lang: str) -> dict[str, str]:
         Dict with keys ``text``, ``textVersion``, ``textCopyright``,
         ``fumsToken`` — ready to be merged into the API response.
     """
-    text_f, version_f, copyright_f, fums_f = LANGUAGE_FIELD_MAP.get(
-        lang, LANGUAGE_FIELD_MAP["en"],
-    )
+    # Resolve the language before checking expiry, so an unknown code falls back to
+    # English *and* is held to English's freshness rule rather than skipping it.
+    resolved = lang if lang in LANGUAGE_FIELD_MAP else "en"
+
+    if text_is_expired(reading, resolved):
+        logger.info(
+            "Suppressing expired %s text for Reading %s (fetched %s).",
+            resolved, reading.pk, getattr(reading, EXPIRING_LANGUAGES[resolved], None),
+        )
+        return {"text": "", "textVersion": "", "textCopyright": "", "fumsToken": ""}
+
+    text_f, version_f, copyright_f, fums_f = LANGUAGE_FIELD_MAP[resolved]
     return {
         "text": getattr(reading, text_f, "") or "",
         "textVersion": getattr(reading, version_f, "") or "",

--- a/hub/tasks/bible_api_tasks.py
+++ b/hub/tasks/bible_api_tasks.py
@@ -49,7 +49,7 @@ def fetch_reading_text_task(self, reading_id: int):
         logger.error("Reading with id %s not found.", reading_id)
         return
 
-    success = fetch_english_text(reading)
+    success = fetch_english_text(reading, budgets=bible_api_budgets(include_daily=False))
     if not success:
         logger.warning(
             "Could not fetch English text for Reading %s (%s).",
@@ -102,19 +102,24 @@ def refresh_all_reading_texts_task(self):
     )
 
     # --- Step 3: Fetch each reading (all languages) ---
-    shared: dict = {"budgets": bible_api_budgets(include_daily=False)}
+    stats = {"attempted": 0}
+    shared: dict = {"budgets": bible_api_budgets(include_daily=False), "stats": stats}
     try:
         shared["service"] = BibleAPIService()
     except ValueError as exc:
         logger.error("Cannot initialize BibleAPIService: %s. English text will be skipped.", exc)
 
-    api_calls = 0
+    readings_processed = 0
+    successes = 0
     consecutive_failures = 0
     unmappable = 0
     aborted = False
     failures = []
+    failures_by_lang: dict[str, int] = {}
 
     for reading in iter_readings_in_pk_order(pks):
+        readings_processed += 1
+
         # Checked before the fetch so an unresolvable book name is not mistaken for the
         # API rejecting us: it fails before any HTTP request, costs nothing, and can
         # never succeed until BOOK_NAME_TO_USFM is extended.  Without this, a run that
@@ -127,15 +132,15 @@ def refresh_all_reading_texts_task(self):
         results = fetch_all_reading_texts(reading, **shared)
 
         if results.get("en"):
-            # Count English calls, not all-languages-succeeded: this is the only
-            # telemetry we have for API.Bible spend.
-            api_calls += 1
+            successes += 1
             consecutive_failures = 0
         elif mappable:
             consecutive_failures += 1
 
-        if not all(results.values()):
-            failed_langs = [lang for lang, ok in results.items() if not ok]
+        failed_langs = [lang for lang, ok in results.items() if not ok]
+        if failed_langs:
+            for lang in failed_langs:
+                failures_by_lang[lang] = failures_by_lang.get(lang, 0) + 1
             failures.append({
                 "reading_id": reading.pk,
                 "passage": reading.passage_reference,
@@ -146,10 +151,10 @@ def refresh_all_reading_texts_task(self):
             aborted = True
             logger.error(
                 "Aborting refresh after %d consecutive English fetch failures "
-                "(%d/%d readings attempted). API.Bible is likely rejecting calls "
-                "(quota or credentials); continuing would burn the remaining quota "
-                "without recording any text.",
-                consecutive_failures, api_calls + len(failures), len(pks),
+                "(%d/%d readings processed, %d English API attempts). API.Bible is "
+                "likely rejecting calls (quota or credentials); continuing would burn "
+                "the remaining quota without recording any text.",
+                consecutive_failures, readings_processed, len(pks), stats["attempted"],
             )
             break
 
@@ -158,10 +163,11 @@ def refresh_all_reading_texts_task(self):
 
     # --- Step 4: Error summary ---
     logger.info(
-        "Refresh %s: %d API.Bible calls, %d readings with failures "
-        "(%d of %d stale readings selected).",
+        "Refresh %s: %d readings processed, %d English API attempts, %d successes, "
+        "failures by language: %s (%d of %d stale readings selected).",
         "aborted" if aborted else "complete",
-        api_calls, len(failures), len(pks), stale_count,
+        readings_processed, stats["attempted"], successes, failures_by_lang,
+        len(pks), stale_count,
     )
 
     if unmappable:

--- a/hub/tasks/bible_api_tasks.py
+++ b/hub/tasks/bible_api_tasks.py
@@ -24,6 +24,7 @@ from hub.services.reading_text_service import (
     fetch_all_reading_texts,
     fetch_english_text,
     iter_readings_in_pk_order,
+    reading_is_mappable,
     select_nearest_stale_reading_ids,
     stale_reading_queryset,
 )
@@ -109,10 +110,20 @@ def refresh_all_reading_texts_task(self):
 
     api_calls = 0
     consecutive_failures = 0
+    unmappable = 0
     aborted = False
     failures = []
 
     for reading in iter_readings_in_pk_order(pks):
+        # Checked before the fetch so an unresolvable book name is not mistaken for the
+        # API rejecting us: it fails before any HTTP request, costs nothing, and can
+        # never succeed until BOOK_NAME_TO_USFM is extended.  Without this, a run that
+        # selects only such readings — the steady state once everything else is fresh —
+        # would trip the circuit breaker every week and cry wolf.
+        mappable = reading_is_mappable(reading)
+        if not mappable:
+            unmappable += 1
+
         results = fetch_all_reading_texts(reading, **shared)
 
         if results.get("en"):
@@ -120,7 +131,7 @@ def refresh_all_reading_texts_task(self):
             # telemetry we have for API.Bible spend.
             api_calls += 1
             consecutive_failures = 0
-        else:
+        elif mappable:
             consecutive_failures += 1
 
         if not all(results.values()):
@@ -152,6 +163,17 @@ def refresh_all_reading_texts_task(self):
         "aborted" if aborted else "complete",
         api_calls, len(failures), len(pks), stale_count,
     )
+
+    if unmappable:
+        # These can never succeed and stay stale forever, so they are re-selected every
+        # run. Surfaced separately so the fix (extend BOOK_NAME_TO_USFM) is discoverable
+        # rather than buried among transient API errors.
+        logger.warning(
+            "%d of %d selected readings have book names with no USFM mapping. They cost "
+            "no API calls but occupy refresh slots every run; add them to "
+            "BOOK_NAME_TO_USFM in hub/constants.py.",
+            unmappable, len(pks),
+        )
 
     if failures:
         failure_lines = []

--- a/hub/tasks/bible_api_tasks.py
+++ b/hub/tasks/bible_api_tasks.py
@@ -3,9 +3,9 @@
 Provides:
     - fetch_reading_text_task: Fetch text for a single Reading.
       Useful for management commands or ad-hoc backfills.
-    - refresh_all_reading_texts_task: Scheduled task that refreshes stale readings
-      (>READING_TEXT_REFRESH_DAYS old) to comply with API.Bible terms of use,
-      cleans up old readings, and logs an error summary.
+    - refresh_all_reading_texts_task: Scheduled task that refreshes at most
+      READING_REFRESH_LIMIT stale readings (>READING_TEXT_REFRESH_DAYS old), nearest to
+      today first, to comply with API.Bible terms of use, and logs an error summary.
 
 Each Reading receives its own API call so that it gets a unique FUMS token,
 as required by API.Bible's Fair Use Management System terms of use.
@@ -13,18 +13,19 @@ as required by API.Bible's Fair Use Management System terms of use.
 
 import logging
 import time
-from datetime import timedelta
 
 from celery import shared_task
 from django.conf import settings
-from django.db.models import Q
-from django.utils import timezone
 
 from hub.models import Reading
 from hub.services.bible_api_service import BibleAPIService
 from hub.services.reading_text_service import (
+    bible_api_budgets,
     fetch_all_reading_texts,
     fetch_english_text,
+    iter_readings_in_pk_order,
+    select_nearest_stale_reading_ids,
+    stale_reading_queryset,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,65 +58,72 @@ def fetch_reading_text_task(self, reading_id: int):
 
 @shared_task(bind=True, max_retries=1, default_retry_delay=300, name='hub.tasks.refresh_all_reading_texts_task')
 def refresh_all_reading_texts_task(self):
-    """Refresh Bible text (all languages) for all stale readings.
+    """Refresh Bible text (all languages) for the stale readings nearest to today.
 
     Each Reading gets its own API call so that it receives a unique FUMS token,
     as required by API.Bible's Fair Use Management System terms of use.
 
     Scheduled weekly via Celery Beat. Steps:
-        1. Cleanup: Delete oldest readings if count exceeds MAX_READINGS.
-        2. Find stale readings (text_fetched_at is NULL or older than threshold).
-        3. Fetch: Call every registered language fetcher per reading.
+        1. Find stale readings (text_fetched_at is NULL or older than threshold).
+        2. Select at most READING_REFRESH_LIMIT of them, nearest to today first:
+           today's and upcoming readings ascending, then past readings descending.
+        3. Fetch: Call every registered language fetcher per reading, stopping early
+           if English fetches start failing consecutively.
         4. Log a structured error summary.
+
+    Readings are never deleted.  Pruning the table only caused rows to be re-created and
+    re-fetched by the public readings view.  Rows this run does not reach stay expired;
+    their text is blanked at serve time and re-fetched on demand within the daily budget.
+
+    Spend is bounded twice over: by READING_REFRESH_LIMIT per run, and by the monthly
+    ceiling in ``bible_api_budgets``.  The monthly budget matters because a failed fetch
+    never records text_fetched_at — so without a ceiling, a run of quota rejections would
+    leave every reading permanently stale and re-burn the whole quota every week.
     """
-    # --- Step 1: Cleanup old readings ---
-    max_readings = getattr(settings, "MAX_READINGS", 2000)
-    total_readings = Reading.objects.count()
-    if total_readings > max_readings:
-        excess = total_readings - max_readings
-        oldest_ids = list(
-            Reading.objects.order_by("day__date", "pk")
-            .values_list("pk", flat=True)[:excess]
-        )
-        deleted_count, _ = Reading.objects.filter(pk__in=oldest_ids).delete()
-        logger.info(
-            "Cleanup: deleted %d oldest readings (was %d, now %d).",
-            deleted_count, total_readings, Reading.objects.count(),
-        )
-
-    # --- Step 2: Find stale readings ---
+    # --- Step 1: Find stale readings ---
     refresh_days = getattr(settings, "READING_TEXT_REFRESH_DAYS", 23)
-    threshold = timezone.now() - timedelta(days=refresh_days)
+    limit = getattr(settings, "READING_REFRESH_LIMIT", 2000)
+    max_consecutive_failures = getattr(settings, "READING_REFRESH_MAX_CONSECUTIVE_FAILURES", 10)
 
-    stale_readings = Reading.objects.select_related("day", "day__church").filter(
-        Q(text_fetched_at__isnull=True) | Q(text_fetched_at__lt=threshold)
-    )
+    stale_readings = stale_reading_queryset(refresh_days)
     stale_count = stale_readings.count()
 
     if stale_count == 0:
         logger.info("No stale readings found. Nothing to refresh.")
         return
 
+    # --- Step 2: Select the nearest-to-today slice we can afford ---
+    pks = select_nearest_stale_reading_ids(limit, queryset=stale_readings)
+
     logger.info(
-        "Found %d stale readings (threshold: %d days). Starting refresh...",
-        stale_count, refresh_days,
+        "Found %d stale readings (threshold: %d days); refreshing the %d nearest to today...",
+        stale_count, refresh_days, len(pks),
     )
 
     # --- Step 3: Fetch each reading (all languages) ---
-    shared: dict = {}
+    shared: dict = {"budgets": bible_api_budgets(include_daily=False)}
     try:
         shared["service"] = BibleAPIService()
     except ValueError as exc:
         logger.error("Cannot initialize BibleAPIService: %s. English text will be skipped.", exc)
 
     api_calls = 0
+    consecutive_failures = 0
+    aborted = False
     failures = []
 
-    for reading in stale_readings.iterator():
+    for reading in iter_readings_in_pk_order(pks):
         results = fetch_all_reading_texts(reading, **shared)
-        if all(results.values()):
+
+        if results.get("en"):
+            # Count English calls, not all-languages-succeeded: this is the only
+            # telemetry we have for API.Bible spend.
             api_calls += 1
+            consecutive_failures = 0
         else:
+            consecutive_failures += 1
+
+        if not all(results.values()):
             failed_langs = [lang for lang, ok in results.items() if not ok]
             failures.append({
                 "reading_id": reading.pk,
@@ -123,13 +131,26 @@ def refresh_all_reading_texts_task(self):
                 "failed_langs": failed_langs,
             })
 
+        if consecutive_failures >= max_consecutive_failures:
+            aborted = True
+            logger.error(
+                "Aborting refresh after %d consecutive English fetch failures "
+                "(%d/%d readings attempted). API.Bible is likely rejecting calls "
+                "(quota or credentials); continuing would burn the remaining quota "
+                "without recording any text.",
+                consecutive_failures, api_calls + len(failures), len(pks),
+            )
+            break
+
         # Small delay between API calls to avoid rate limiting
         time.sleep(0.5)
 
     # --- Step 4: Error summary ---
     logger.info(
-        "Refresh complete: %d fully successful, %d with failures.",
-        api_calls, len(failures),
+        "Refresh %s: %d API.Bible calls, %d readings with failures "
+        "(%d of %d stale readings selected).",
+        "aborted" if aborted else "complete",
+        api_calls, len(failures), len(pks), stale_count,
     )
 
     if failures:

--- a/hub/tests/test_bible_api.py
+++ b/hub/tests/test_bible_api.py
@@ -4,7 +4,7 @@ Tests cover:
     - BibleAPIService (book name resolution, bible ID selection)
     - fetch_text_for_reading (synchronous single-reading fetch, unique FUMS token)
     - fetch_reading_text_task (Celery wrapper, used for management commands)
-    - refresh_all_reading_texts_task (per-reading refresh, cleanup, error summary)
+    - refresh_all_reading_texts_task (nearest-first refresh, spend limits, error summary)
     - Synchronous text fetch in GetDailyReadingsForDate view
     - API response (includes text fields)
 """
@@ -12,6 +12,7 @@ from datetime import date, timedelta
 from io import StringIO
 from unittest.mock import patch, MagicMock
 
+from django.core.cache import cache
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.utils import timezone
@@ -495,6 +496,9 @@ class RefreshAllReadingTextsTaskTests(TestCase):
     """Tests for the refresh_all_reading_texts_task Celery task."""
 
     def setUp(self):
+        # Spend budgets live in the cache, and LocMemCache persists across tests within a
+        # process, so counters must be reset or budget-sensitive assertions bleed together.
+        cache.clear()
         self.church = Church.objects.get(pk=Church.get_default_pk())
         self.mock_api_response = {
             "content": "Test verse content.",
@@ -607,15 +611,15 @@ class RefreshAllReadingTextsTaskTests(TestCase):
         self.assertEqual(stale.text, "Test verse content.")
         self.assertEqual(fresh.text, "Old text from last refresh")
 
-    @override_settings(MAX_READINGS=10)
+    @override_settings(READING_REFRESH_LIMIT=10)
     @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
     @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
     @patch('hub.services.bible_api_service.config', return_value="test-key")
-    def test_cleanup_old_readings_when_over_max(self, mock_config, mock_resolve, mock_get_passage):
-        """Test that oldest readings are deleted when count exceeds MAX_READINGS."""
+    def test_refresh_never_deletes_readings(self, mock_config, mock_resolve, mock_get_passage):
+        """Refresh caps API spend at READING_REFRESH_LIMIT without deleting any readings."""
         mock_get_passage.return_value = self.mock_api_response
 
-        # Create 15 readings (exceeds MAX_READINGS=10)
+        # Create 15 readings (exceeds READING_REFRESH_LIMIT=10)
         base_date = date(2020, 1, 1)
         for i in range(15):
             day = Day.objects.create(
@@ -628,8 +632,92 @@ class RefreshAllReadingTextsTaskTests(TestCase):
 
         refresh_all_reading_texts_task()
 
-        # Should have cleaned up to MAX_READINGS (10)
-        self.assertLessEqual(Reading.objects.count(), 10)
+        # Pruning is what caused rows to be re-created and re-fetched; nothing is deleted.
+        self.assertEqual(Reading.objects.count(), 15)
+        # Only the limit's worth of API calls are made.
+        self.assertEqual(mock_get_passage.call_count, 10)
+
+    @override_settings(READING_REFRESH_LIMIT=3)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_refresh_prefers_readings_nearest_to_today(self, mock_config, mock_resolve, mock_get_passage):
+        """Upcoming readings are refreshed before past ones, nearest first."""
+        mock_get_passage.return_value = self.mock_api_response
+
+        today = timezone.localdate()
+        readings = {}
+        for offset in (-10, -1, 0, 1, 10):
+            day = Day.objects.create(date=today + timedelta(days=offset), church=self.church)
+            readings[offset] = _create_reading(
+                day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5,
+            )
+
+        refresh_all_reading_texts_task()
+
+        # today, +1, +10 are selected; the past dates are left for a later run.
+        refreshed = {o for o, r in readings.items() if Reading.objects.get(pk=r.pk).text}
+        self.assertEqual(refreshed, {0, 1, 10})
+
+    @override_settings(READING_REFRESH_LIMIT=3)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_refresh_backfills_with_most_recent_past_readings(self, mock_config, mock_resolve, mock_get_passage):
+        """When upcoming readings do not fill the limit, the most recent past ones follow."""
+        mock_get_passage.return_value = self.mock_api_response
+
+        today = timezone.localdate()
+        readings = {}
+        for offset in (-30, -2, -1, 5):
+            day = Day.objects.create(date=today + timedelta(days=offset), church=self.church)
+            readings[offset] = _create_reading(
+                day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5,
+            )
+
+        refresh_all_reading_texts_task()
+
+        refreshed = {o for o, r in readings.items() if Reading.objects.get(pk=r.pk).text}
+        self.assertEqual(refreshed, {5, -1, -2})
+
+    @override_settings(READING_REFRESH_MAX_CONSECUTIVE_FAILURES=3)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_refresh_aborts_after_consecutive_failures(self, mock_config, mock_resolve, mock_get_passage):
+        """A run of API failures aborts the task instead of burning the whole quota.
+
+        A failed fetch never records text_fetched_at, so without this circuit breaker a
+        quota rejection leaves every reading permanently stale and the weekly run
+        re-attempts all of them forever.
+        """
+        mock_get_passage.side_effect = Exception("429 Too Many Requests")
+
+        today = timezone.localdate()
+        for i in range(10):
+            day = Day.objects.create(date=today + timedelta(days=i), church=self.church)
+            _create_reading(day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
+
+        refresh_all_reading_texts_task()
+
+        self.assertEqual(mock_get_passage.call_count, 3)
+
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_refresh_stops_when_monthly_budget_is_exhausted(self, mock_config, mock_resolve, mock_get_passage):
+        """The monthly ceiling caps the task's spend even when the per-run limit is higher."""
+        mock_get_passage.return_value = self.mock_api_response
+
+        today = timezone.localdate()
+        for i in range(6):
+            day = Day.objects.create(date=today + timedelta(days=i), church=self.church)
+            _create_reading(day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
+
+        with override_settings(BIBLE_API_MONTHLY_BUDGET=2):
+            refresh_all_reading_texts_task()
+
+        self.assertEqual(mock_get_passage.call_count, 2)
 
     @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
     @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
@@ -893,3 +981,185 @@ class ReadingTextAPIResponseTests(TestCase):
         self.assertEqual(reading_data["text"], "")
         self.assertEqual(reading_data["textCopyright"], "")
         self.assertEqual(reading_data["textVersion"], "")
+
+
+class ViewOnDemandRefetchTests(TestCase):
+    """The readings view re-fetches text that has passed READING_TEXT_MAX_AGE_DAYS.
+
+    Expired text is blanked in the response, so without this the page would show a bare
+    citation forever for any date the weekly refresh does not reach.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.church = Church.objects.get(pk=Church.get_default_pk())
+        self.test_date = date(2025, 6, 15)
+        self.day = Day.objects.create(date=self.test_date, church=self.church)
+
+    def _get(self):
+        from rest_framework.test import APIRequestFactory
+        from hub.views.readings import GetDailyReadingsForDate
+
+        request = APIRequestFactory().get(f'/readings/?date={self.test_date}')
+        return GetDailyReadingsForDate.as_view()(request)
+
+    @patch('hub.views.readings.fetch_all_reading_texts')
+    @patch('hub.views.readings.prepare_shared_resources', return_value={})
+    @patch('hub.views.readings.scrape_readings', return_value=[])
+    @patch('hub.views.readings.generate_reading_context_task')
+    def test_refetches_expired_reading(self, mock_ctx, mock_scrape, mock_prepare, mock_fetch):
+        _create_reading(
+            self.day, book="Matthew", start_ch=5, start_v=1, end_ch=5, end_v=12,
+            text="Stale text", text_fetched_at=timezone.now() - timedelta(days=31),
+        )
+
+        self.assertEqual(self._get().status_code, 200)
+
+        mock_prepare.assert_called_once()
+        mock_fetch.assert_called_once()
+
+    @patch('hub.views.readings.fetch_all_reading_texts')
+    @patch('hub.views.readings.prepare_shared_resources', return_value={})
+    @patch('hub.views.readings.scrape_readings', return_value=[])
+    @patch('hub.views.readings.generate_reading_context_task')
+    def test_does_not_refetch_just_inside_max_age(self, mock_ctx, mock_scrape, mock_prepare, mock_fetch):
+        _create_reading(
+            self.day, book="Matthew", start_ch=5, start_v=1, end_ch=5, end_v=12,
+            text="Fresh enough", text_fetched_at=timezone.now() - timedelta(days=29),
+        )
+
+        self.assertEqual(self._get().status_code, 200)
+
+        mock_fetch.assert_not_called()
+        mock_prepare.assert_not_called()
+
+    @patch('hub.views.readings.fetch_all_reading_texts')
+    @patch('hub.views.readings.prepare_shared_resources', return_value={})
+    @patch('hub.views.readings.scrape_readings', return_value=[])
+    @patch('hub.views.readings.generate_reading_context_task')
+    def test_prepares_shared_resources_once_for_many_expired(self, mock_ctx, mock_scrape, mock_prepare, mock_fetch):
+        """Shared resources open an HTTP session and scrape a page; build them once."""
+        for verse in range(1, 4):
+            _create_reading(
+                self.day, book="Matthew", start_ch=5, start_v=verse, end_ch=5, end_v=verse,
+                text="Stale", text_fetched_at=timezone.now() - timedelta(days=31),
+            )
+
+        self.assertEqual(self._get().status_code, 200)
+
+        mock_prepare.assert_called_once()
+        self.assertEqual(mock_fetch.call_count, 3)
+
+
+class ReadingFetchBudgetTests(TestCase):
+    """Tests for the API.Bible spend budgets guarding the public on-demand path."""
+
+    def setUp(self):
+        cache.clear()
+        self.church = Church.objects.get(pk=Church.get_default_pk())
+        self.day = Day.objects.create(date=date(2025, 6, 15), church=self.church)
+        self.mock_api_response = {
+            "content": "Test verse content.",
+            "copyright": "Test copyright.",
+            "version": "NKJV",
+            "reference": "Genesis 1:1-5",
+            "fums_token": "test-fums-token",
+        }
+
+    @override_settings(READING_FETCH_DAILY_BUDGET=2, BIBLE_API_MONTHLY_BUDGET=1000)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_daily_budget_caps_fetches(self, mock_config, mock_resolve, mock_get_passage):
+        from hub.services.reading_text_service import bible_api_budgets, fetch_english_text
+
+        mock_get_passage.return_value = self.mock_api_response
+        budgets = bible_api_budgets()
+        readings = [
+            _create_reading(self.day, book="Genesis", start_ch=1, start_v=v, end_ch=1, end_v=v)
+            for v in range(1, 4)
+        ]
+
+        results = [fetch_english_text(r, budgets=budgets) for r in readings]
+
+        self.assertEqual(results, [True, True, False])
+        self.assertEqual(mock_get_passage.call_count, 2)
+        readings[2].refresh_from_db()
+        self.assertIsNone(readings[2].text_fetched_at)
+
+    @override_settings(READING_FETCH_DAILY_BUDGET=1, BIBLE_API_MONTHLY_BUDGET=1000)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_unmappable_book_does_not_consume_budget(self, mock_config, mock_get_passage):
+        """Resolution failures must not burn a token — they never reach the API.
+
+        This is why the budget is consumed after resolve_reading_passage rather than at
+        the top of the fetcher: a day of unmappable book names would otherwise drain the
+        whole allowance without a single call being made.
+        """
+        from hub.services.reading_text_service import bible_api_budgets, fetch_english_text
+
+        mock_get_passage.return_value = self.mock_api_response
+        budgets = bible_api_budgets()
+        bad = _create_reading(self.day, book="Not A Real Book", start_ch=1, start_v=1, end_ch=1, end_v=1)
+
+        self.assertFalse(fetch_english_text(bad, budgets=budgets))
+        mock_get_passage.assert_not_called()
+        self.assertEqual(budgets[0].used(), 0)
+
+        # The allowance is still intact for a reading we can actually resolve.
+        good = _create_reading(self.day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
+        self.assertTrue(fetch_english_text(good, budgets=budgets))
+
+    @override_settings(READING_FETCH_DAILY_BUDGET=0)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_row_is_created_and_text_blank_when_budget_exhausted(
+        self, mock_config, mock_resolve, mock_get_passage,
+    ):
+        """A spent budget degrades the response; it must not break reading creation."""
+        from rest_framework.test import APIRequestFactory
+        from hub.views.readings import GetDailyReadingsForDate
+
+        with patch('hub.views.readings.scrape_readings') as mock_scrape, \
+                patch('hub.views.readings.generate_reading_context_task'):
+            mock_scrape.return_value = [{
+                "book": "Genesis", "book_en": "Genesis",
+                "start_chapter": 1, "start_verse": 1, "end_chapter": 1, "end_verse": 5,
+            }]
+            request = APIRequestFactory().get('/readings/?date=2025-06-15')
+            response = GetDailyReadingsForDate.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Reading.objects.filter(day=self.day).count(), 1)
+        self.assertEqual(response.data["readings"][0]["text"], "")
+        mock_get_passage.assert_not_called()
+
+    def test_budget_key_is_namespaced_per_period(self):
+        from hub.services.api_budget import DAY, MONTH, APIBudget
+
+        daily = APIBudget("bible_api", 10, period=DAY)
+        monthly = APIBudget("bible_api", 10, period=MONTH)
+
+        self.assertNotEqual(daily.key(date(2026, 1, 1)), daily.key(date(2026, 1, 2)))
+        self.assertEqual(monthly.key(date(2026, 1, 1)), monthly.key(date(2026, 1, 31)))
+        self.assertNotEqual(monthly.key(date(2026, 1, 1)), monthly.key(date(2026, 2, 1)))
+
+    def test_budget_counts_from_zero_when_key_absent(self):
+        """Exercises the incr-raises-then-add path for a period's first call."""
+        from hub.services.api_budget import APIBudget
+
+        budget = APIBudget("bible_api_test", 2)
+
+        self.assertEqual(budget.used(), 0)
+        self.assertTrue(budget.consume())
+        self.assertEqual(budget.used(), 1)
+        self.assertTrue(budget.consume())
+        self.assertFalse(budget.consume())
+        self.assertEqual(budget.remaining(), 0)
+
+    def test_zero_limit_refuses_everything(self):
+        from hub.services.api_budget import APIBudget
+
+        self.assertFalse(APIBudget("bible_api_test", 0).consume())

--- a/hub/tests/test_bible_api.py
+++ b/hub/tests/test_bible_api.py
@@ -702,6 +702,51 @@ class RefreshAllReadingTextsTaskTests(TestCase):
 
         self.assertEqual(mock_get_passage.call_count, 3)
 
+    @override_settings(READING_REFRESH_MAX_CONSECUTIVE_FAILURES=3)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_unmappable_books_do_not_trip_the_circuit_breaker(self, mock_config, mock_get_passage):
+        """Unresolvable book names must not look like API rejection.
+
+        They fail before any HTTP request and can never succeed, so they stay stale and
+        are re-selected every run.  Once everything else is fresh a run selects *only*
+        these — the steady state — and counting them would abort the task every week.
+        """
+        mock_get_passage.return_value = self.mock_api_response
+
+        today = timezone.localdate()
+        for i in range(6):
+            day = Day.objects.create(date=today + timedelta(days=i), church=self.church)
+            _create_reading(day, book="Not A Real Book", start_ch=1, start_v=1, end_ch=1, end_v=5)
+        # A resolvable reading after them, to prove the run kept going.
+        last_day = Day.objects.create(date=today + timedelta(days=6), church=self.church)
+        good = _create_reading(last_day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
+
+        refresh_all_reading_texts_task()
+
+        good.refresh_from_db()
+        self.assertEqual(good.text, "Test verse content.")
+        self.assertEqual(mock_get_passage.call_count, 1)
+
+    @override_settings(READING_REFRESH_MAX_CONSECUTIVE_FAILURES=3)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_real_api_failures_after_unmappable_books_still_abort(
+        self, mock_config, mock_resolve, mock_get_passage,
+    ):
+        """Ignoring unmappable readings must not blunt the breaker for genuine failures."""
+        mock_get_passage.side_effect = Exception("429 Too Many Requests")
+
+        today = timezone.localdate()
+        for i in range(10):
+            day = Day.objects.create(date=today + timedelta(days=i), church=self.church)
+            _create_reading(day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
+
+        refresh_all_reading_texts_task()
+
+        self.assertEqual(mock_get_passage.call_count, 3)
+
     @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
     @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
     @patch('hub.services.bible_api_service.config', return_value="test-key")

--- a/hub/tests/test_bible_api.py
+++ b/hub/tests/test_bible_api.py
@@ -2,7 +2,7 @@
 
 Tests cover:
     - BibleAPIService (book name resolution, bible ID selection)
-    - fetch_text_for_reading (synchronous single-reading fetch, unique FUMS token)
+    - fetch_english_text (synchronous single-reading fetch, unique FUMS token)
     - fetch_reading_text_task (Celery wrapper, used for management commands)
     - refresh_all_reading_texts_task (nearest-first refresh, spend limits, error summary)
     - Synchronous text fetch in GetDailyReadingsForDate view
@@ -12,11 +12,16 @@ from datetime import date, timedelta
 from io import StringIO
 from unittest.mock import patch, MagicMock
 
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.cache import cache
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.utils import timezone
 
+from hub.admin import ReadingAdmin
 from hub.constants import (
     BOOK_NAME_TO_USFM,
     APOCRYPHA_USFM_IDS,
@@ -26,10 +31,8 @@ from hub.constants import (
     CATENA_HOME_PAGE_URL,
 )
 from hub.models import Church, Day, Reading
-from hub.services.bible_api_service import (
-    BibleAPIService,
-    fetch_text_for_reading,
-)
+from hub.services.bible_api_service import BibleAPIService
+from hub.services.reading_text_service import bible_api_budgets, fetch_english_text
 from hub.tasks.bible_api_tasks import (
     fetch_reading_text_task,
     refresh_all_reading_texts_task,
@@ -319,11 +322,11 @@ class BibleAPIServiceInitTests(TestCase):
 
 
 # ------------------------------------------------------------------ #
-#  fetch_text_for_reading (synchronous) Tests
+#  fetch_english_text (synchronous) Tests
 # ------------------------------------------------------------------ #
 
-class FetchTextForReadingTests(TestCase):
-    """Tests for the fetch_text_for_reading synchronous helper."""
+class FetchEnglishTextTests(TestCase):
+    """Tests for the fetch_english_text synchronous helper."""
 
     def setUp(self):
         self.church = Church.objects.get(pk=Church.get_default_pk())
@@ -345,7 +348,7 @@ class FetchTextForReadingTests(TestCase):
 
         reading = _create_reading(self.day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
 
-        result = fetch_text_for_reading(reading)
+        result = fetch_english_text(reading)
 
         self.assertTrue(result)
         reading.refresh_from_db()
@@ -367,7 +370,7 @@ class FetchTextForReadingTests(TestCase):
         reading1 = _create_reading(self.day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
         reading2 = _create_reading(day2, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
 
-        fetch_text_for_reading(reading1)
+        fetch_english_text(reading1)
 
         # Only the target reading should have text
         reading1.refresh_from_db()
@@ -396,7 +399,7 @@ class FetchTextForReadingTests(TestCase):
         )
         reading_new = _create_reading(day2, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
 
-        result = fetch_text_for_reading(reading_new)
+        result = fetch_english_text(reading_new)
 
         self.assertTrue(result)
         reading_new.refresh_from_db()
@@ -410,7 +413,7 @@ class FetchTextForReadingTests(TestCase):
         """Test that fetch returns False when API key is not configured."""
         reading = _create_reading(self.day)
 
-        result = fetch_text_for_reading(reading)
+        result = fetch_english_text(reading)
 
         self.assertFalse(result)
         reading.refresh_from_db()
@@ -426,7 +429,7 @@ class FetchTextForReadingTests(TestCase):
         reading = _create_reading(self.day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
         service = BibleAPIService()
 
-        result = fetch_text_for_reading(reading, service=service)
+        result = fetch_english_text(reading, service=service)
 
         self.assertTrue(result)
         reading.refresh_from_db()
@@ -437,7 +440,7 @@ class FetchTextForReadingTests(TestCase):
         reading = _create_reading(self.day, book="Nonexistent Book")
         service = MagicMock(spec=BibleAPIService)
 
-        result = fetch_text_for_reading(reading, service=service)
+        result = fetch_english_text(reading, service=service)
 
         self.assertFalse(result)
 
@@ -465,8 +468,8 @@ class FetchReadingTextTaskTests(TestCase):
     @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
     @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
     @patch('hub.services.bible_api_service.config', return_value="test-key")
-    def test_task_delegates_to_fetch_text_for_reading(self, mock_config, mock_resolve, mock_get_passage):
-        """Test that the Celery task delegates to fetch_text_for_reading."""
+    def test_task_delegates_to_fetch_english_text(self, mock_config, mock_resolve, mock_get_passage):
+        """Test that the Celery task delegates to fetch_english_text."""
         mock_get_passage.return_value = {
             "content": "Test content.",
             "copyright": "Test copyright.",
@@ -746,6 +749,57 @@ class RefreshAllReadingTextsTaskTests(TestCase):
         refresh_all_reading_texts_task()
 
         self.assertEqual(mock_get_passage.call_count, 3)
+
+    @override_settings(READING_REFRESH_MAX_CONSECUTIVE_FAILURES=3)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_breaker_trip_reports_attempts_not_zero(self, mock_config, mock_resolve, mock_get_passage):
+        """A circuit-breaker trip must report the attempts that reached API.Bible.
+
+        Counting only successes made a rejection spiral log "0 API calls," hiding the
+        exact event the telemetry exists to surface.
+        """
+        mock_get_passage.side_effect = Exception("429 Too Many Requests")
+
+        today = timezone.localdate()
+        for i in range(10):
+            day = Day.objects.create(date=today + timedelta(days=i), church=self.church)
+            _create_reading(day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
+
+        with self.assertLogs("hub.tasks.bible_api_tasks", level="ERROR") as log:
+            refresh_all_reading_texts_task()
+
+        abort_messages = [m for m in log.output if "Aborting refresh" in m]
+        self.assertEqual(len(abort_messages), 1)
+        self.assertIn("3 English API attempts", abort_messages[0])
+
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_readings_processed_does_not_double_count_partial_language_failure(
+        self, mock_config, mock_resolve, mock_get_passage,
+    ):
+        """A reading whose English fetch succeeds but Armenian fetch fails must count
+        once in readings processed, not twice — the old ``api_calls + len(failures)``
+        expression double-counted exactly this case.
+
+        No BibleVerse rows are seeded for this passage, so the Armenian composer
+        naturally returns no text without needing to mock anything.
+        """
+        mock_get_passage.return_value = self.mock_api_response
+
+        day = Day.objects.create(date=date(2025, 3, 15), church=self.church)
+        _create_reading(day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
+
+        with self.assertLogs("hub.tasks.bible_api_tasks", level="INFO") as log:
+            refresh_all_reading_texts_task()
+
+        summary = [m for m in log.output if "Refresh complete" in m][0]
+        self.assertIn("1 readings processed", summary)
+        self.assertIn("1 English API attempts", summary)
+        self.assertIn("1 successes", summary)
+        self.assertIn("{'hy': 1}", summary)
 
     @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
     @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
@@ -1050,7 +1104,7 @@ class ViewOnDemandRefetchTests(TestCase):
 
     @patch('hub.views.readings.fetch_all_reading_texts')
     @patch('hub.views.readings.prepare_shared_resources', return_value={})
-    @patch('hub.views.readings.scrape_readings', return_value=[])
+    @patch('hub.views.readings.get_daily_readings', return_value=[])
     @patch('hub.views.readings.generate_reading_context_task')
     def test_refetches_expired_reading(self, mock_ctx, mock_scrape, mock_prepare, mock_fetch):
         _create_reading(
@@ -1065,7 +1119,7 @@ class ViewOnDemandRefetchTests(TestCase):
 
     @patch('hub.views.readings.fetch_all_reading_texts')
     @patch('hub.views.readings.prepare_shared_resources', return_value={})
-    @patch('hub.views.readings.scrape_readings', return_value=[])
+    @patch('hub.views.readings.get_daily_readings', return_value=[])
     @patch('hub.views.readings.generate_reading_context_task')
     def test_does_not_refetch_just_inside_max_age(self, mock_ctx, mock_scrape, mock_prepare, mock_fetch):
         _create_reading(
@@ -1080,7 +1134,7 @@ class ViewOnDemandRefetchTests(TestCase):
 
     @patch('hub.views.readings.fetch_all_reading_texts')
     @patch('hub.views.readings.prepare_shared_resources', return_value={})
-    @patch('hub.views.readings.scrape_readings', return_value=[])
+    @patch('hub.views.readings.get_daily_readings', return_value=[])
     @patch('hub.views.readings.generate_reading_context_task')
     def test_prepares_shared_resources_once_for_many_expired(self, mock_ctx, mock_scrape, mock_prepare, mock_fetch):
         """Shared resources open an HTTP session and scrape a page; build them once."""
@@ -1167,7 +1221,7 @@ class ReadingFetchBudgetTests(TestCase):
         from rest_framework.test import APIRequestFactory
         from hub.views.readings import GetDailyReadingsForDate
 
-        with patch('hub.views.readings.scrape_readings') as mock_scrape, \
+        with patch('hub.views.readings.get_daily_readings') as mock_scrape, \
                 patch('hub.views.readings.generate_reading_context_task'):
             mock_scrape.return_value = [{
                 "book": "Genesis", "book_en": "Genesis",
@@ -1208,3 +1262,76 @@ class ReadingFetchBudgetTests(TestCase):
         from hub.services.api_budget import APIBudget
 
         self.assertFalse(APIBudget("bible_api_test", 0).consume())
+
+
+# ------------------------------------------------------------------ #
+#  Admin fetch actions respect the monthly budget too
+# ------------------------------------------------------------------ #
+
+class AdminFetchBudgetTests(TestCase):
+    """hub.admin.ReadingAdmin used to call fetch_text_for_reading, a separate helper
+    with no budget awareness — an admin bulk action could burn a whole month's
+    API.Bible quota outside the ceiling this module otherwise enforces everywhere else.
+    It now goes through fetch_english_text with budgets, same as the refresh task and
+    the public view.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.church = Church.objects.get(pk=Church.get_default_pk())
+        self.day = Day.objects.create(date=date(2025, 6, 15), church=self.church)
+        self.admin_user = get_user_model().objects.create_superuser(
+            username="bible-admin", email="bible-admin@example.com", password="password",
+        )
+        self.mock_api_response = {
+            "content": "Test verse content.",
+            "copyright": "Test copyright.",
+            "version": "NKJV",
+            "reference": "Genesis 1:1-5",
+            "fums_token": "test-fums-token",
+        }
+
+    def _admin_request(self):
+        """A RequestFactory request wired with session + message storage, matching
+        what admin views/actions expect."""
+        request = RequestFactory().get("/admin/")
+        request.user = self.admin_user
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        setattr(request, "_messages", FallbackStorage(request))
+        return request
+
+    @override_settings(BIBLE_API_MONTHLY_BUDGET=2)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_bulk_fetch_action_stops_at_monthly_budget(self, mock_config, mock_resolve, mock_get_passage):
+        mock_get_passage.return_value = self.mock_api_response
+        readings = [
+            _create_reading(self.day, book="Genesis", start_ch=1, start_v=v, end_ch=1, end_v=v)
+            for v in range(1, 4)
+        ]
+        reading_admin = ReadingAdmin(Reading, AdminSite())
+
+        reading_admin.fetch_bible_text(
+            self._admin_request(), Reading.objects.filter(pk__in=[r.pk for r in readings]),
+        )
+
+        self.assertEqual(mock_get_passage.call_count, 2)
+        self.assertEqual(Reading.objects.filter(text_fetched_at__isnull=False).count(), 2)
+
+    @override_settings(BIBLE_API_MONTHLY_BUDGET=0)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_single_fetch_view_refuses_when_monthly_budget_exhausted(
+        self, mock_config, mock_resolve, mock_get_passage,
+    ):
+        reading = _create_reading(self.day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5)
+        reading_admin = ReadingAdmin(Reading, AdminSite())
+
+        reading_admin.fetch_bible_text_view(self._admin_request(), reading.pk)
+
+        mock_get_passage.assert_not_called()
+        reading.refresh_from_db()
+        self.assertIsNone(reading.text_fetched_at)

--- a/hub/tests/test_bible_api.py
+++ b/hub/tests/test_bible_api.py
@@ -1170,8 +1170,6 @@ class ReadingFetchBudgetTests(TestCase):
     @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
     @patch('hub.services.bible_api_service.config', return_value="test-key")
     def test_daily_budget_caps_fetches(self, mock_config, mock_resolve, mock_get_passage):
-        from hub.services.reading_text_service import bible_api_budgets, fetch_english_text
-
         mock_get_passage.return_value = self.mock_api_response
         budgets = bible_api_budgets()
         readings = [
@@ -1196,8 +1194,6 @@ class ReadingFetchBudgetTests(TestCase):
         the top of the fetcher: a day of unmappable book names would otherwise drain the
         whole allowance without a single call being made.
         """
-        from hub.services.reading_text_service import bible_api_budgets, fetch_english_text
-
         mock_get_passage.return_value = self.mock_api_response
         budgets = bible_api_budgets()
         bad = _create_reading(self.day, book="Not A Real Book", start_ch=1, start_v=1, end_ch=1, end_v=1)

--- a/hub/views/readings.py
+++ b/hub/views/readings.py
@@ -21,6 +21,7 @@ from hub.services.reading_text_service import (
     fetch_all_reading_texts,
     get_reading_text_fields,
     prepare_shared_resources,
+    reading_needs_text_fetch,
 )
 from hub.services.lectionary_service import get_daily_readings, persist_readings
 from hub.tasks import generate_reading_context_task
@@ -122,20 +123,24 @@ class GetDailyReadingsForDate(generics.GenericAPIView):
         if not day.readings.exists():
             # import readings for this date into db (offline, from armenian_lectionary)
             readings = get_daily_readings(date_obj, church)
-            persisted = persist_readings(day, readings)
+            persist_readings(day, readings)
 
-            # Track newly created readings that need text fetched
-            new_reading_objs = [reading_obj for reading_obj, created in persisted if created]
+        # Fetch text for all languages synchronously so it is available in the response
+        # immediately.  This covers newly created readings (no fetch timestamp yet) and
+        # existing ones whose text has passed READING_TEXT_MAX_AGE_DAYS — that text is
+        # blanked in the response below, so re-fetching is what keeps the page useful.
+        # Spend is capped by the daily and monthly budgets inside the English fetcher.
+        readings_to_fetch = [r for r in day.readings.all() if reading_needs_text_fetch(r)]
+        if readings_to_fetch:
+            # Built lazily: shared resources open an HTTP session, so requests with
+            # nothing to fetch must not pay for it.
+            shared = prepare_shared_resources(date_obj, church)
+            for reading_obj in readings_to_fetch:
+                fetch_all_reading_texts(reading_obj, **shared)
 
-            # Fetch text for all languages synchronously so it is available in
-            # the response immediately.  Shared resources (API session, scraped
-            # pages, etc.) are created once for the whole batch.
-            if new_reading_objs:
-                shared = prepare_shared_resources(date_obj, church)
-                for reading_obj in new_reading_objs:
-                    fetch_all_reading_texts(reading_obj, **shared)
-
-        # Now ensure we have up-to-date queryset
+        # Now ensure we have up-to-date queryset.  fetch_english_text writes via
+        # Reading.objects.filter(...).update(), so the instances in readings_to_fetch are
+        # stale; the loop below re-queries day.readings.all() and sees the new text.
         day.refresh_from_db()
 
         formatted_readings = []

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -83,6 +83,17 @@ SEND_PUSH_NOTIFICATIONS = False  # Disable push notifications
 ANTHROPIC_API_KEY = ''
 OPENAI_API_KEY = ''
 
+# Disable real API.Bible calls from the readings view during tests.
+# The view fetches expired text on demand, and several tests exercise that path without
+# patching it; a zero daily budget makes fetch_english_text return before the HTTP call.
+# The monthly ceiling is left effectively unlimited because the refresh task charges it
+# and those tests drive the task deliberately with the HTTP layer mocked.
+# Note BIBLE_API_KEY='' would NOT work here: BibleAPIService reads the key via
+# decouple.config, not django.conf.settings, so the setting is never consulted.
+# Tests that exercise budget behaviour override these explicitly.
+READING_FETCH_DAILY_BUDGET = 0
+BIBLE_API_MONTHLY_BUDGET = 1_000_000
+
 # JWT Settings for testing
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (

--- a/tests/unit/hub/test_fums.py
+++ b/tests/unit/hub/test_fums.py
@@ -7,8 +7,8 @@ from django.utils import timezone
 
 from hub.admin import ReadingAdmin
 from hub.models import Church, Day, Fast, Reading
-from hub.services.bible_api_service import BibleAPIService, fetch_text_for_reading
-from hub.services.reading_text_service import get_reading_text_fields
+from hub.services.bible_api_service import BibleAPIService
+from hub.services.reading_text_service import fetch_english_text, get_reading_text_fields
 
 
 def _create_reading(day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5, **kwargs):
@@ -184,8 +184,8 @@ class ReadingAdminFumsTests(TestCase):
         self.assertFalse(self.admin.has_fums_token(reading))
 
 
-class FetchTextForReadingFumsTests(TestCase):
-    """Tests for FUMS token storage via fetch_text_for_reading."""
+class FetchEnglishTextFumsTests(TestCase):
+    """Tests for FUMS token storage via fetch_english_text."""
 
     def setUp(self):
         self.church = Church.objects.create(name="Task Test Church")
@@ -197,8 +197,8 @@ class FetchTextForReadingFumsTests(TestCase):
         )
 
     @patch('hub.services.bible_api_service.BibleAPIService.resolve_book_name', return_value="GEN")
-    def test_fetch_text_for_reading_stores_fums_token(self, mock_resolve):
-        """fetch_text_for_reading should store the FUMS token on the reading."""
+    def test_fetch_english_text_stores_fums_token(self, mock_resolve):
+        """fetch_english_text should store the FUMS token on the reading."""
         mock_service = Mock(spec=BibleAPIService)
         mock_service.get_passage.return_value = {
             "reference": "Genesis 1:1-5",
@@ -210,7 +210,7 @@ class FetchTextForReadingFumsTests(TestCase):
 
         reading = _create_reading(day=self.day)
 
-        result = fetch_text_for_reading(reading, service=mock_service)
+        result = fetch_english_text(reading, service=mock_service)
 
         self.assertTrue(result)
         reading.refresh_from_db()
@@ -247,7 +247,7 @@ class FetchTextForReadingFumsTests(TestCase):
         )
         new_reading = _create_reading(day=day2)
 
-        result = fetch_text_for_reading(new_reading)
+        result = fetch_english_text(new_reading)
 
         self.assertTrue(result)
         new_reading.refresh_from_db()
@@ -334,7 +334,7 @@ class ReadingTextExpiryTests(TestCase):
         self.assertEqual(get_reading_text_fields(reading, "fr")["text"], "")
 
     @patch("hub.views.readings.fetch_all_reading_texts")
-    @patch("hub.views.readings.scrape_readings", return_value=[])
+    @patch("hub.views.readings.get_daily_readings", return_value=[])
     @patch("hub.views.readings.generate_reading_context_task")
     def test_readings_api_blanks_expired_text(self, mock_gen_task, mock_scrape, mock_fetch):
         self._reading(text_fetched_at=timezone.now() - datetime.timedelta(days=31))

--- a/tests/unit/hub/test_fums.py
+++ b/tests/unit/hub/test_fums.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from hub.admin import ReadingAdmin
 from hub.models import Church, Day, Fast, Reading
 from hub.services.bible_api_service import BibleAPIService, fetch_text_for_reading
+from hub.services.reading_text_service import get_reading_text_fields
 
 
 def _create_reading(day, book="Genesis", start_ch=1, start_v=1, end_ch=1, end_v=5, **kwargs):
@@ -126,6 +127,10 @@ class ReadingFumsTokenAPITests(TestCase):
             text_copyright="Copyright NKJV",
             text_version="NKJV",
             fums_token="api-fums-token-xyz",
+            # Required: text older than READING_TEXT_MAX_AGE_DAYS (or with no timestamp
+            # at all) is blanked in the response to honour API.Bible's freshness cap.
+            # fetch_english_text always writes text and this timestamp together.
+            text_fetched_at=timezone.now(),
         )
 
         date_str = self.day.date.strftime("%Y-%m-%d")
@@ -249,3 +254,94 @@ class FetchTextForReadingFumsTests(TestCase):
         # Should have its own token from the API call, not the copied one
         self.assertEqual(new_reading.fums_token, "new-unique-fums-token")
         mock_get_passage.assert_called_once()
+
+
+class ReadingTextExpiryTests(TestCase):
+    """Tests for withholding text that is past its source licence's freshness cap.
+
+    API.Bible forbids displaying content cached for more than 30 days.  Text can outlive
+    that window whenever a weekly refresh run does not reach a reading (it refreshes only
+    the nearest READING_REFRESH_LIMIT) or the on-demand spend budget is exhausted, so the
+    serve path — not just the refresh path — has to enforce the cap.
+    """
+
+    def setUp(self):
+        self.church = Church.objects.get_or_create(name="Armenian Apostolic Church")[0]
+        self.day = Day.objects.create(date=timezone.now().date(), church=self.church)
+
+    def _reading(self, **kwargs):
+        return _create_reading(
+            day=self.day,
+            text="In the beginning...",
+            text_copyright="Copyright NKJV",
+            text_version="NKJV",
+            fums_token="api-fums-token-xyz",
+            **kwargs,
+        )
+
+    def test_fresh_english_text_is_served(self):
+        reading = self._reading(text_fetched_at=timezone.now())
+
+        fields = get_reading_text_fields(reading, "en")
+
+        self.assertEqual(fields["text"], "In the beginning...")
+        self.assertEqual(fields["fumsToken"], "api-fums-token-xyz")
+
+    def test_expired_english_text_is_blanked(self):
+        reading = self._reading(
+            text_fetched_at=timezone.now() - datetime.timedelta(days=31),
+        )
+
+        fields = get_reading_text_fields(reading, "en")
+
+        self.assertEqual(
+            fields,
+            {"text": "", "textVersion": "", "textCopyright": "", "fumsToken": ""},
+        )
+
+    def test_english_text_just_inside_max_age_is_served(self):
+        reading = self._reading(
+            text_fetched_at=timezone.now() - datetime.timedelta(days=29),
+        )
+
+        self.assertEqual(get_reading_text_fields(reading, "en")["text"], "In the beginning...")
+
+    def test_missing_timestamp_is_treated_as_expired(self):
+        """We cannot show the text is fresh enough to serve, so we do not serve it."""
+        reading = self._reading()
+
+        self.assertEqual(get_reading_text_fields(reading, "en")["text"], "")
+
+    def test_armenian_text_never_expires(self):
+        """Armenian text is not API.Bible-sourced, so no freshness cap applies."""
+        reading = self._reading(
+            text_hy_version="Նոր Էջմիածին",
+            text_hy_fetched_at=timezone.now() - datetime.timedelta(days=400),
+        )
+        reading.text_hy = "Ի սկզբանէ..."
+        reading.save(update_fields=["i18n"])
+
+        fields = get_reading_text_fields(reading, "hy")
+
+        self.assertEqual(fields["text"], "Ի սկզբանէ...")
+
+    def test_unknown_language_falls_back_to_english_including_expiry(self):
+        """An unknown code must not sidestep the English freshness rule."""
+        reading = self._reading(
+            text_fetched_at=timezone.now() - datetime.timedelta(days=31),
+        )
+
+        self.assertEqual(get_reading_text_fields(reading, "fr")["text"], "")
+
+    @patch("hub.views.readings.fetch_all_reading_texts")
+    @patch("hub.views.readings.scrape_readings", return_value=[])
+    @patch("hub.views.readings.generate_reading_context_task")
+    def test_readings_api_blanks_expired_text(self, mock_gen_task, mock_scrape, mock_fetch):
+        self._reading(text_fetched_at=timezone.now() - datetime.timedelta(days=31))
+
+        response = self.client.get(f"/api/readings/?date={self.day.date:%Y-%m-%d}")
+
+        self.assertEqual(response.status_code, 200)
+        reading_data = response.json()["readings"][0]
+        self.assertEqual(reading_data["text"], "")
+        self.assertEqual(reading_data["fumsToken"], "")


### PR DESCRIPTION
## Problem

The weekly refresh task was making **~1700 API.Bible calls every Monday** against a 5,000/month quota.

**Cause: a retry spiral.** A failed fetch never records `text_fetched_at` — `fetch_english_text` catches the exception and returns `False`. So once the quota was gone and API.Bible began returning 429/403, every reading stayed permanently stale, and each Monday the task retried all of them and failed all of them. Nothing ever recovered on its own.

Three pieces of production data pin this down:

- **Spend is spiky on Mondays with nothing the rest of the week.** The burn is the Beat job, not continuous view traffic.
- **`hub_reading` held exactly 2000 rows on a Saturday.** The prune runs Monday and trims *to* `MAX_READINGS`=2000, so a mid-week count of exactly 2000 proves **zero rows were created all week** — no crawler-driven creation, and no on-demand fetching either.
- **Every Monday, not every fourth.** Successful fetches would stamp all 2000 with that Monday's timestamp, and the 23-day threshold would make the next three runs no-ops. Weekly recurrence is only possible if the timestamp is never written.

Worth stating plainly for the record: **this was not crawler-driven.** An earlier reading of the code blamed the prune/re-create churn plus crawler traffic on the public `/readings/<date>` page. `robots.txt` shipped in bahk_landing#41 on 2026-07-04 and changed spend by nothing over the following three weeks, and the row-count evidence above rules the churn story out. Crawlers may have been the original ignition months ago; they are not what has been burning the quota. (bahk_landing#45, which added CDN caching for the same theory, was closed.)

The prune is still removed here — it deletes *today's* readings first while keeping far-future ones, which is backwards — but it was not the cause.

## Changes

- **Stop deleting readings.** The prune deleted *today's* readings before far-future ones and forced rows to be re-created and re-fetched later. The table grows instead.
- **Refresh the nearest `READING_REFRESH_LIMIT` (2000) stale readings per run**, today/upcoming ascending then past descending. Nobody browses far into the past, so this spends the allowance on dates people actually open.
- **Circuit breaker**: abort after `READING_REFRESH_MAX_CONSECUTIVE_FAILURES` (10) consecutive English failures that actually reached the API. A rejecting API now costs ~10 calls instead of ~1700. **This is the direct fix for the observed burn.** 10 rather than 1–3 so a transient blip or a single passage API.Bible 404s on cannot halt the whole refresh; 10 wasted calls/week is ~43/month, under 1% of quota.
  - Book names that fail `resolve_reading_passage` are excluded from the count. They return before any HTTP request and can never succeed, so they are a data problem, not evidence the API is unhealthy. If any exist they stay permanently stale and get re-selected every run, so counting them would abort the task once everything else is fresh. They are reported separately at WARNING so the fix (extend `BOOK_NAME_TO_USFM`) is discoverable.
  - Audited: across 6,057 readings spanning four years of the lectionary cycle, **all 62 distinct book names resolve** and no map key is unreachable after normalisation. So this guard is expected to report zero on current data. `main` builds readings from the sacredtradition.am scraper rather than the lectionary engine, though, so the guard is kept for names the scraper may produce that the engine does not.
- **`BIBLE_API_MONTHLY_BUDGET` (4500)**: a hard ceiling across *both* the refresh task and the on-demand view path, so no failure mode can exhaust the quota. Plus `READING_FETCH_DAILY_BUDGET` (75) for the public path alone. Cache-backed (`hub/services/api_budget.py`), fails closed.
- **On-demand re-fetch**: the view now refreshes text past `READING_TEXT_MAX_AGE_DAYS`, not just newly created readings — bounded by those budgets.
- **Serve-time freshness guard**: `get_reading_text_fields` blanks English text once it exceeds 30 days, so nothing past API.Bible's cap is served when a refresh doesn't reach a reading. Armenian is not API.Bible-sourced and never expires.

Spend budget: ~2,170/month from the weekly refresh + ~2,250 from the daily cap, against a 4,500 ceiling and the 5,000 quota.

Also fixes a telemetry bug (`api_calls` only counted readings whose *Armenian* composition also succeeded) and stops `resolve_reading_passage` failures from being logged as API errors.

## Behaviour worth knowing (not a bug)

Once the table exceeds ~2000 stale rows in a 23-day window, far-from-today readings will never be reached by the weekly task. Their text passes 30 days, gets blanked at serve time, and is re-fetched on demand the next time someone actually requests that date. That is the designed interaction between the refresh limit and the serve-time guard.

## Deploy

- **Unset `MAX_READINGS`** in production config vars (removed; set `READING_REFRESH_LIMIT` only if it had been overridden).
- Invariant: `READING_TEXT_REFRESH_DAYS` (23) must stay `<=` `READING_TEXT_MAX_AGE_DAYS` (30).
- Watch Sentry for `"API.Bible ... budget ... exhausted"` and `"Aborting refresh after N consecutive"` — both are env-tunable without a deploy.

## Testing

`hub.tests.test_bible_api` + `tests.unit.hub.test_fums`: **83 passing**, including new coverage for nearest-first selection, past-date backfill, never-deleting, the circuit breaker, monthly-ceiling cutoff, on-demand refetch at 31 vs 29 days, budget exhaustion leaving the row created with blank text, unmappable books not burning budget, and Armenian never expiring.

Full suite: 1310 tests, 1 error — `learning_resources.cleanup_orphaned_bookmarks_async` needs the Celery result backend at hostname `redis:6379`, which only resolves inside the devcontainer. Unrelated to this change; worth a re-run in CI to confirm.

One existing fixture was corrected: `test_readings_api_includes_fums_token` set `text`/`fums_token` with no `text_fetched_at`, a state production cannot produce (they're written in the same `.update()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



