### PR TITLE
Stitch NKJV Romans doxology (16:25-27) for Armenian-numbered 14:24-26 readings

### DIFF
--- a/hub/services/bible_api_service.py
+++ b/hub/services/bible_api_service.py
@@ -22,6 +22,15 @@ BASE_URL = "https://rest.api.bible/v1"
 NKJV_BIBLE_ID = "63097d2a0a2f7db3-01"
 KJVAIC_BIBLE_ID = "a6aee10bb058511c-01"  # KJV with Apocrypha, American Edition
 
+# The Armenian liturgical tradition numbers the closing doxology of Romans as part
+# of chapter 14 (verses 24-26). NKJV -- like most Western Bibles -- ends chapter 14
+# at verse 23 and places the same doxology at 16:25-27. Citations that reach past
+# 14:23 are split into two segments (main text + doxology) and stitched back
+# together; see resolve_reading_segments / get_composite_passage.
+ROMANS_CH14_LAST_VERSE = 23
+ROMANS_DOXOLOGY_CHAPTER = 16
+ROMANS_DOXOLOGY_START_VERSE = 25
+
 
 class BibleAPIService:
     """Client for extracting verses from API.Bible.
@@ -97,6 +106,38 @@ class BibleAPIService:
             "fums_token": fums_token,
         }
 
+    def get_composite_passage(
+        self, segments: list[tuple[str, int, int, int, int]]
+    ) -> dict:
+        """Fetch one or more passage segments and stitch them into a single result.
+
+        The common case is a single segment, returned unchanged from ``get_passage``.
+        Multiple segments (e.g. the Romans doxology split produced by
+        ``resolve_reading_segments``) are concatenated in citation order. The first
+        segment's FUMS token, version, and copyright are used for the combined
+        result -- API.Bible issues one token per call, and the primary segment is
+        the bulk of what a viewer reads.
+
+        Args:
+            segments: One or more ``(usfm_book_id, start_chapter, start_verse,
+                       end_chapter, end_verse)`` tuples, in reading order.
+
+        Returns:
+            Same shape as ``get_passage``: "reference", "content", "copyright",
+            "version", "fums_token".
+        """
+        results = [self.get_passage(*segment) for segment in segments]
+        if len(results) == 1:
+            return results[0]
+
+        return {
+            "reference": " / ".join(r["reference"] for r in results),
+            "content": " ".join(r["content"] for r in results),
+            "copyright": results[0]["copyright"],
+            "version": results[0]["version"],
+            "fums_token": results[0]["fums_token"],
+        }
+
     @staticmethod
     def resolve_book_name(book_name: str) -> str:
         """Resolve a book name (as stored in Reading.book) to its 3-letter USFM ID.
@@ -145,6 +186,46 @@ class BibleAPIService:
         ):
             return "ESG", 1, start_verse, 1, end_verse
         return usfm_id, start_chapter, start_verse, end_chapter, end_verse
+
+    @staticmethod
+    def resolve_reading_segments(
+        book_name: str,
+        start_chapter: int,
+        start_verse: int,
+        end_chapter: int,
+        end_verse: int,
+    ) -> list[tuple[str, int, int, int, int]]:
+        """Resolve a Reading reference into one or more API.Bible passage segments.
+
+        Almost every reading is a single contiguous segment, so this defers to
+        ``resolve_reading_passage`` (which also handles the Esther/ESG remap).
+        Romans citations that follow the Armenian liturgical tradition's
+        versification of the closing doxology (numbered as part of chapter 14,
+        e.g. "13.11-14.26") don't exist in NKJV: its chapter 14 ends at verse 23,
+        and the same doxology is at 16:25-27. Those readings are split into a
+        main-text segment and a doxology segment here, to be stitched back
+        together by ``get_composite_passage``.
+        """
+        usfm_id = BibleAPIService.resolve_book_name(book_name)
+        if usfm_id == "ROM" and end_chapter == 14 and end_verse > ROMANS_CH14_LAST_VERSE:
+            segments = []
+            if start_chapter < 14 or start_verse <= ROMANS_CH14_LAST_VERSE:
+                segments.append(
+                    (usfm_id, start_chapter, start_verse, 14, ROMANS_CH14_LAST_VERSE)
+                )
+            doxology_end_verse = ROMANS_DOXOLOGY_START_VERSE + (
+                end_verse - (ROMANS_CH14_LAST_VERSE + 1)
+            )
+            segments.append((
+                usfm_id, ROMANS_DOXOLOGY_CHAPTER, ROMANS_DOXOLOGY_START_VERSE,
+                ROMANS_DOXOLOGY_CHAPTER, doxology_end_verse,
+            ))
+            return segments
+        return [
+            BibleAPIService.resolve_reading_passage(
+                book_name, start_chapter, start_verse, end_chapter, end_verse,
+            )
+        ]
 
     @staticmethod
     def _bible_id_for_book(usfm_book_id: str) -> tuple[str, str]:
@@ -207,16 +288,14 @@ def fetch_text_for_reading(reading, service: BibleAPIService | None = None) -> b
             return False
 
     try:
-        passage = BibleAPIService.resolve_reading_passage(
+        segments = BibleAPIService.resolve_reading_segments(
             reading.book,
             reading.start_chapter,
             reading.start_verse,
             reading.end_chapter,
             reading.end_verse,
         )
-        result = service.get_passage(
-            *passage,
-        )
+        result = service.get_composite_passage(segments)
 
         ReadingModel.objects.filter(pk=reading.pk).update(
             text=result["content"],

--- a/hub/services/reading_text_service.py
+++ b/hub/services/reading_text_service.py
@@ -89,16 +89,14 @@ def fetch_english_text(reading, *, service: BibleAPIService | None = None, **_kw
             return False
 
     try:
-        passage = BibleAPIService.resolve_reading_passage(
+        segments = BibleAPIService.resolve_reading_segments(
             reading.book,
             reading.start_chapter,
             reading.start_verse,
             reading.end_chapter,
             reading.end_verse,
         )
-        result = service.get_passage(
-            *passage,
-        )
+        result = service.get_composite_passage(segments)
 
         ReadingModel.objects.filter(pk=reading.pk).update(
             text=result["content"],

--- a/hub/tests/test_bible_api.py
+++ b/hub/tests/test_bible_api.py
@@ -260,6 +260,53 @@ class BibleAPIServiceResolveReadingPassageTests(TestCase):
         )
 
 
+class BibleAPIServiceResolveReadingSegmentsTests(TestCase):
+    """Tests for resolving Readings into one or more API.Bible passage segments."""
+
+    def test_romans_doxology_full_range_splits_into_two_segments(self):
+        """Romans 13.11-14.26 (Armenian numbering) splits into main text + NKJV doxology."""
+        self.assertEqual(
+            BibleAPIService.resolve_reading_segments(
+                "St. Paul's Epistle to the Romans", 13, 11, 14, 26,
+            ),
+            [
+                ("ROM", 13, 11, 14, 23),
+                ("ROM", 16, 25, 16, 27),
+            ],
+        )
+
+    def test_romans_doxology_partial_range_maps_single_verse(self):
+        """Romans 14.20-24 only reaches the first doxology verse (NKJV 16:25)."""
+        self.assertEqual(
+            BibleAPIService.resolve_reading_segments("Romans", 14, 20, 14, 24),
+            [
+                ("ROM", 14, 20, 14, 23),
+                ("ROM", 16, 25, 16, 25),
+            ],
+        )
+
+    def test_romans_doxology_only_no_main_segment(self):
+        """A reading confined to 14.24-26 has no main-text segment to prepend."""
+        self.assertEqual(
+            BibleAPIService.resolve_reading_segments("Romans", 14, 24, 14, 26),
+            [("ROM", 16, 25, 16, 27)],
+        )
+
+    def test_romans_within_nkjv_range_stays_single_segment(self):
+        """Romans citations that stay within NKJV's chapter 14 are unaffected."""
+        self.assertEqual(
+            BibleAPIService.resolve_reading_segments("Romans", 13, 11, 14, 23),
+            [("ROM", 13, 11, 14, 23)],
+        )
+
+    def test_non_romans_reading_stays_single_segment(self):
+        """Non-Romans readings defer to resolve_reading_passage unchanged."""
+        self.assertEqual(
+            BibleAPIService.resolve_reading_segments("Esther", 10, 4, 10, 9),
+            [("ESG", 1, 4, 1, 9)],
+        )
+
+
 class BibleAPIServiceBibleIdSelectionTests(TestCase):
     """Tests for BibleAPIService._bible_id_for_book."""
 
@@ -315,6 +362,60 @@ class BibleAPIServiceInitTests(TestCase):
         mock_config.return_value = "test-api-key"
         service = BibleAPIService()
         self.assertEqual(service.api_key, "test-api-key")
+
+
+class BibleAPIServiceGetCompositePassageTests(TestCase):
+    """Tests for stitching one or more passage segments into a single result."""
+
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_single_segment_returned_unchanged(self, mock_config):
+        """A single segment should pass through get_passage's result untouched."""
+        service = BibleAPIService()
+        expected = {
+            "reference": "Genesis 1:1-5",
+            "content": "In the beginning...",
+            "copyright": "NKJV copyright",
+            "version": "NKJV",
+            "fums_token": "token-1",
+        }
+        with patch.object(service, "get_passage", return_value=expected) as mock_get_passage:
+            result = service.get_composite_passage([("GEN", 1, 1, 1, 5)])
+
+        mock_get_passage.assert_called_once_with("GEN", 1, 1, 1, 5)
+        self.assertEqual(result, expected)
+
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_multiple_segments_are_concatenated(self, mock_config):
+        """Multiple segments concatenate content and keep the first segment's metadata."""
+        service = BibleAPIService()
+        main_text = {
+            "reference": "Romans 13:11-14:23",
+            "content": "[11] And do this... [23] ...is sin.",
+            "copyright": "NKJV copyright",
+            "version": "NKJV",
+            "fums_token": "main-token",
+        }
+        doxology = {
+            "reference": "Romans 16:25-27",
+            "content": "[25] Now to Him... [27] ...glory forever. Amen.",
+            "copyright": "NKJV copyright",
+            "version": "NKJV",
+            "fums_token": "doxology-token",
+        }
+        with patch.object(service, "get_passage", side_effect=[main_text, doxology]) as mock_get_passage:
+            result = service.get_composite_passage([
+                ("ROM", 13, 11, 14, 23),
+                ("ROM", 16, 25, 16, 27),
+            ])
+
+        self.assertEqual(mock_get_passage.call_count, 2)
+        self.assertEqual(
+            result["content"],
+            "[11] And do this... [23] ...is sin. [25] Now to Him... [27] ...glory forever. Amen.",
+        )
+        self.assertEqual(result["fums_token"], "main-token")
+        self.assertEqual(result["version"], "NKJV")
+        self.assertEqual(result["copyright"], "NKJV copyright")
 
 
 # ------------------------------------------------------------------ #
@@ -694,6 +795,51 @@ class RefreshAllReadingTextsTaskTests(TestCase):
         reading.refresh_from_db()
         self.assertEqual(reading.text, "Then Mordecai said...")
         self.assertEqual(reading.text_version, "KJVAIC")
+
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_refresh_stitches_romans_doxology_from_nkjv_16(self, mock_config, mock_get_passage):
+        """Romans 13.11-14.26 (Armenian numbering) stitches NKJV 13:11-14:23 + 16:25-27."""
+        mock_get_passage.side_effect = [
+            {
+                "content": "[11] And do this... [23] ...is sin.",
+                "copyright": "NKJV copyright",
+                "version": "NKJV",
+                "reference": "Romans 13:11-14:23",
+                "fums_token": "main-token",
+            },
+            {
+                "content": "[25] Now to Him... [27] ...glory forever. Amen.",
+                "copyright": "NKJV copyright",
+                "version": "NKJV",
+                "reference": "Romans 16:25-27",
+                "fums_token": "doxology-token",
+            },
+        ]
+
+        day = Day.objects.create(date=date(2025, 3, 15), church=self.church)
+        reading = _create_reading(
+            day,
+            book="St. Paul's Epistle to the Romans",
+            start_ch=13,
+            start_v=11,
+            end_ch=14,
+            end_v=26,
+        )
+
+        refresh_all_reading_texts_task()
+
+        self.assertEqual(
+            [call.args for call in mock_get_passage.call_args_list],
+            [("ROM", 13, 11, 14, 23), ("ROM", 16, 25, 16, 27)],
+        )
+        reading.refresh_from_db()
+        self.assertEqual(
+            reading.text,
+            "[11] And do this... [23] ...is sin. [25] Now to Him... [27] ...glory forever. Amen.",
+        )
+        self.assertEqual(reading.text_version, "NKJV")
+        self.assertEqual(reading.fums_token, "main-token")
 
     @patch('hub.services.bible_api_service.config', return_value="")
     def test_no_api_key_aborts_refresh(self, mock_config):


### PR DESCRIPTION
## Goal

Document and patch a specific versification discrepancy: the Armenian liturgical lectionary numbers the closing Romans doxology as part of chapter 14 (e.g. `"13.11-14.26"`), but NKJV ends chapter 14 at verse 23 and places the same doxology text at 16:25-27. Before this fix, fetching NKJV text for such a reading would ask API.Bible for verses (`ROM.14.24`-`ROM.14.26`) that don't exist in NKJV's numbering, silently failing and leaving `Reading.text` empty while the Armenian side (sourced from the offline Nor Ejmiatsin corpus, which does number the doxology within chapter 14) populated fine.

**Stacked on #467** (`feat/reading-sequence-order`) — based on that branch since it depends on the `reading_text_service.py` / `fetch_english_text` refactor introduced there.

## What changed

- `BibleAPIService.resolve_reading_segments()`: resolves a Reading into one or more API.Bible passage segments. Romans citations reaching past NKJV's 14:23 split into `[main text through 14:23, doxology at 16:25-27]` (with correct partial-range handling). Everything else (including the existing Esther/`ESG` remap) still resolves to a single segment.
- `BibleAPIService.get_composite_passage()`: fetches each segment and concatenates their content. For multi-segment reads, only the **first segment's** FUMS token/version/copyright is kept — API.Bible issues one token per call, and the primary segment is the bulk of what's read.
- `fetch_text_for_reading` (admin) and `fetch_english_text` (Celery refresh, readings view) both now route through the new segment-based resolution.

## Why this may not be the final shape

This is a targeted, one-off fix for a single known book/reading. There may be other liturgical-vs-NKJV versification mismatches lurking elsewhere that would hit the same silent-failure mode. Given the Daniel 3 / Prayer of Azariah composite-reading work already in this codebase (deriving a standalone `S3Y` book from the Armenian corpus), a more general "composite/versification override" layer might be worth building instead of accumulating book-specific special cases in `resolve_reading_segments`. Opening this now mainly to close the immediate gap and put the discrepancy on record — happy to fold it into a broader abstraction if/when more cases turn up.

## Test plan

- [x] `hub/tests/test_bible_api.py` — 6 new tests: segment resolution (full/partial/doxology-only/in-range/non-Romans), passage stitching (single + multi-segment), and an end-to-end refresh-task test confirming NKJV text is `[11]...[23]... [25]...[27]` for Romans 13.11-14.26.
- [x] Full `test_bible_api.py` suite (58 tests) passes.
- [x] Related reading/lectionary suites (`test_import_readings`, `test_reading_context`, `test_lectionary_service`, `test_armenian_text`; 41 tests) pass unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)