### PR TITLE
feat: add devotional video publishing API

### DIFF
--- a/bahk/s3_upload_urls.py
+++ b/bahk/s3_upload_urls.py
@@ -1,0 +1,29 @@
+"""Staff-protected compatibility URLs for django-s3-file-field's admin widget."""
+
+from django.contrib.admin.views.decorators import staff_member_required
+from django.urls import path
+from s3_file_field import views
+
+app_name = "s3_file_field"
+
+
+@staff_member_required
+def upload_initialize(request, *args, **kwargs):
+    return views.upload_initialize(request, *args, **kwargs)
+
+
+@staff_member_required
+def upload_complete(request, *args, **kwargs):
+    return views.upload_complete(request, *args, **kwargs)
+
+
+@staff_member_required
+def finalize(request, *args, **kwargs):
+    return views.finalize(request, *args, **kwargs)
+
+
+urlpatterns = [
+    path("upload-initialize/", upload_initialize, name="upload-initialize"),
+    path("upload-complete/", upload_complete, name="upload-complete"),
+    path("finalize/", finalize, name="finalize"),
+]

--- a/bahk/test_s3_upload_urls.py
+++ b/bahk/test_s3_upload_urls.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.http import JsonResponse
+from django.test import TestCase
+from django.urls import resolve, reverse
+from s3_file_field.widgets import S3FileInput, get_base_url
+
+
+class ProtectedS3FileFieldURLsTests(TestCase):
+    def setUp(self):
+        users = get_user_model()
+        self.staff = users.objects.create_user("legacy-upload-staff", is_staff=True)
+        self.user = users.objects.create_user("legacy-upload-user")
+
+    def test_paths_names_and_widget_base_url_are_preserved(self):
+        expected = {
+            "upload-initialize": "/api/s3-upload/upload-initialize/",
+            "upload-complete": "/api/s3-upload/upload-complete/",
+            "finalize": "/api/s3-upload/finalize/",
+        }
+        for name, path in expected.items():
+            self.assertEqual(reverse(f"s3_file_field:{name}"), path)
+            self.assertEqual(resolve(path).url_name, name)
+        get_base_url.cache_clear()
+        self.assertEqual(get_base_url(), "/api/s3-upload")
+        context = S3FileInput().get_context("video", None, {})
+        self.assertEqual(context["widget"]["attrs"]["data-s3fileinput"], "/api/s3-upload")
+
+    @patch("s3_file_field.views.upload_initialize")
+    def test_anonymous_and_non_staff_are_denied_before_delegation(self, package_view):
+        url = reverse("s3_file_field:upload-initialize")
+        self.assertEqual(self.client.post(url).status_code, 302)
+        self.client.force_login(self.user)
+        self.assertEqual(self.client.post(url).status_code, 302)
+        package_view.assert_not_called()
+
+    def test_staff_requests_delegate_to_each_installed_package_view(self):
+        self.client.force_login(self.staff)
+        for name in ("upload_initialize", "upload_complete", "finalize"):
+            url_name = name.replace("_", "-")
+            with patch(
+                f"s3_file_field.views.{name}",
+                return_value=JsonResponse({"delegated": name}),
+            ) as package_view:
+                response = self.client.post(reverse(f"s3_file_field:{url_name}"))
+            self.assertEqual(response.status_code, 200)
+            package_view.assert_called_once()

--- a/bahk/urls.py
+++ b/bahk/urls.py
@@ -147,7 +147,7 @@ urlpatterns += [
 
 # S3FileField URLs
 urlpatterns += [
-    path('api/s3-upload/', include('s3_file_field.urls')),
+    path('api/s3-upload/', include('bahk.s3_upload_urls')),
 ]
 
 # for serving media files during development

--- a/docs/DEVOTIONAL_VIDEO_WRITE_API.md
+++ b/docs/DEVOTIONAL_VIDEO_WRITE_API.md
@@ -1,0 +1,58 @@
+# Staff devotional-video API
+
+Public video list and detail `GET` requests are unchanged. Authenticated staff may
+`POST /api/learning-resources/videos/` and `PATCH
+/api/learning-resources/videos/<id>/`. The strict write fields are `title`,
+`description`, `language_code`, `upload_token`, and optional `thumbnail`.
+`clear_thumbnail: true` is PATCH-only and cannot accompany `thumbnail`. Create
+requires all metadata and `upload_token`; PATCH requires at least one change.
+Client-provided category, IDs/timestamps, video paths/URLs, and unknown fields are
+rejected. Every created or edited resource is devotional.
+
+Direct video transfer uses staff-only POST endpoints:
+
+1. `/api/learning-resources/devotional-videos/uploads/initialize/` with
+   `file_name`, `file_size`, and `content_type`.
+2. `.../complete/` with the opaque `upload_session`, returned `upload_id`, and
+   ordered `parts` (`part_number`, `size`, `etag`). Submit its body directly to
+   the returned S3 URL.
+3. `.../finalize/` with only `upload_session`; this returns an opaque,
+   user-bound, one-use `upload_token`, filename, and size.
+
+Only basename `.mp4`/`video/mp4` and `.webm`/`video/webm` pairs from 1 through
+500 MiB are accepted. Sessions expire after one hour and final tokens after 24
+hours. Finalization verifies object existence and exact size. Video bytes never
+pass through Django, and object keys are never accepted or returned by this API.
+Each returned part includes its exact `size`; the client must upload exactly that
+many bytes because the size is bound into the S3 signature.
+
+Production requires django-storages S3 storage with the boto3 client contract
+used by `django-s3-file-field` 1.0.1. The bucket must have an S3 lifecycle rule
+that aborts incomplete multipart uploads after one day, covering clients that
+initialize and then disappear. The API also makes a best-effort abort when a
+server-side preparation failure makes an upload unusable. Aborting an already
+completed multipart upload does not delete its completed object.
+
+Every dedicated upload is recorded in a private database ledger before its
+session is returned. Its object key is always below `videos/devotional-cli/`.
+Final tokens are owner-bound, and token consumption, video persistence, and the
+ledger transition to `attached` occur in one transaction. A failed video save
+therefore leaves the ready ledger available for retry or audited cleanup.
+
+Run `python manage.py cleanup_devotional_video_uploads` for a dry-run listing of
+expired initialized/ready uploads. Run
+`python manage.py cleanup_devotional_video_uploads --execute` daily to abort the
+recorded incomplete multipart upload or delete the exact completed object, then
+mark the ledger `cleaned`. The command is idempotent and never scans general
+`videos/` keys, attached uploads, or legacy/admin uploads. Keep the 24-hour token
+retention and the bucket's one-day incomplete-multipart lifecycle rule aligned.
+
+Success is 200 (PATCH/upload steps) or 201 (create); malformed, expired, or used
+capabilities return 400; authentication/authorization returns 401/403; missing
+devotional video returns 404; unsupported methods return 405.
+
+The installed package's legacy `/api/s3-upload/upload-initialize/`,
+`upload-complete/`, and `finalize/` routes remain available to `S3FileInput` in
+Django admin with their original names and paths. A Django staff-session gate
+protects all three before delegating to `django-s3-file-field`; they are not CLI
+publishing endpoints. The dedicated endpoints above also require staff access.

--- a/docs/DEVOTIONAL_WRITE_API.md
+++ b/docs/DEVOTIONAL_WRITE_API.md
@@ -1,0 +1,26 @@
+# Devotional write API
+
+The existing devotional collection and detail routes remain publicly readable.
+Creating and editing devotionals requires an authenticated staff user.
+
+## Create
+
+`POST /api/devotionals/` accepts a JSON object with required `day`, `video`,
+`language_code`, and non-negative `order` fields. `order` cannot be `null`.
+`description` is optional and may be `null`. The day and video must be existing
+object IDs, and the language must be configured by the application.
+
+A successful create returns `201` with the normal public devotional
+representation.
+
+## Partial update
+
+`PATCH /api/devotionals/<id>/` accepts one or more of the same fields. Omitted
+fields, including `order`, are unchanged. If supplied, `order` cannot be `null`.
+An empty object is rejected. A successful update returns `200` with the normal
+public devotional representation. `PUT` and `DELETE` are not supported.
+
+Unknown fields (including IDs, timestamps, categories, and video URLs/paths),
+invalid fields, missing related objects, and duplicate `(day, order,
+language_code)` combinations return `400`. A missing devotional returns `404`.
+Unauthenticated and non-staff writes return `401` or `403` as appropriate.

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -141,7 +141,7 @@ class CombinedDevotionalForm(forms.Form):
                 required=False,
                 widget=S3FileInput(attrs={'accept': 'video/*', 'data-field-id': video_field_id}),
                 label=f"Video file ({code.upper()})",
-                help_text="Supported formats: MP4, WebM. Portrait orientation (9:16). Files up to 20MB.",
+                help_text="Supported formats: MP4, WebM. Portrait orientation (9:16). Files up to 500 MiB.",
             )
             self.fields[f'video_thumbnail_{code}'] = forms.ImageField(
                 required=False, label=f"Video thumbnail ({code.upper()})",

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -1,6 +1,7 @@
 """Serializers for handling API requests."""
 import logging
 import pytz
+from django.conf import settings
 from django.utils import timezone  # Add missing timezone import
 
 from better_profanity import profanity
@@ -600,6 +601,51 @@ class DevotionalSerializer(serializers.ModelSerializer):
         if obj.video:
             return getattr(obj.video, 'description_i18n', obj.video.description)
         return None
+
+
+class DevotionalWriteSerializer(serializers.ModelSerializer):
+    """Strict input contract for staff devotional create and partial update."""
+
+    day = serializers.PrimaryKeyRelatedField(queryset=models.Day.objects.all())
+    video = serializers.PrimaryKeyRelatedField(queryset=models.Video.objects.all())
+    language_code = serializers.ChoiceField(
+        choices=tuple(
+            dict.fromkeys(
+                [
+                    *getattr(settings, "MODELTRANS_AVAILABLE_LANGUAGES", []),
+                    *(code for code, _name in getattr(settings, "LANGUAGES", [])),
+                ]
+            )
+        ),
+        required=True,
+    )
+    order = serializers.IntegerField(
+        min_value=0,
+        required=True,
+        allow_null=False,
+    )
+
+    class Meta:
+        model = models.Devotional
+        fields = ["day", "video", "language_code", "description", "order"]
+        extra_kwargs = {
+            "description": {
+                "required": False,
+                "allow_null": True,
+                "allow_blank": True,
+            },
+        }
+
+    def validate(self, attrs):
+        unknown = set(self.initial_data) - set(self.fields)
+        if unknown:
+            raise serializers.ValidationError(
+                {name: "Unknown field." for name in sorted(unknown)}
+            )
+        if self.partial and not self.initial_data:
+            raise serializers.ValidationError("PATCH body must contain at least one field.")
+        return super().validate(attrs)
+
 
 class FastParticipantMapSerializer(serializers.ModelSerializer):
     """Serializer for the FastParticipantMap model."""

--- a/hub/tests/test_combined_devotional_form.py
+++ b/hub/tests/test_combined_devotional_form.py
@@ -15,3 +15,7 @@ class CombinedDevotionalFormTest(SimpleTestCase):
             self.assertIsInstance(field.widget, S3FileInput)
             self.assertEqual(field.widget.attrs["data-field-id"], expected_field_id)
             self.assertEqual(field.widget.attrs["accept"], "video/*")
+            self.assertIn("500 MiB", field.help_text)
+
+    def test_model_video_help_text_matches_publishing_limit(self):
+        self.assertIn("500 MiB", Video._meta.get_field("video").help_text)

--- a/hub/tests/test_devotional_write_api.py
+++ b/hub/tests/test_devotional_write_api.py
@@ -1,0 +1,379 @@
+from contextlib import nullcontext
+from datetime import date
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from hub.models import Church, Day, Devotional
+from learning_resources.models import Video
+
+
+@override_settings(MODELTRANS_AVAILABLE_LANGUAGES=["en", "hy"])
+class DevotionalWriteAPITests(APITestCase):
+    def setUp(self):
+        self.church = Church.objects.create(name="Write Test Church")
+        self.day = Day.objects.create(date=date(2026, 8, 8), church=self.church)
+        self.other_day = Day.objects.create(date=date(2026, 8, 9), church=self.church)
+        self.video = Video.objects.create(
+            title="Write test video",
+            description="Video fallback",
+            category="general",
+            language_code="en",
+        )
+        self.other_video = Video.objects.create(
+            title="Other video",
+            category="general",
+            language_code="en",
+        )
+        users = get_user_model()
+        self.staff = users.objects.create_user(username="staff", is_staff=True)
+        self.user = users.objects.create_user(username="ordinary")
+        self.create_payload = {
+            "day": self.day.pk,
+            "video": self.video.pk,
+            "language_code": "en",
+            "description": "New devotional",
+            "order": 1,
+        }
+
+    def test_anonymous_and_non_staff_create_are_rejected_without_mutation(self):
+        anonymous = self.client.post(
+            "/api/devotionals/", self.create_payload, format="json"
+        )
+        self.client.force_login(self.user)
+        non_staff = self.client.post("/api/devotionals/", self.create_payload, format="json")
+
+        self.assertIn(
+            anonymous.status_code,
+            {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN},
+        )
+        self.assertEqual(non_staff.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(Devotional.objects.exists())
+
+    def test_staff_create_returns_public_representation_and_updates_video_category(self):
+        self.client.force_login(self.staff)
+        response = self.client.post("/api/devotionals/", self.create_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            set(response.data),
+            {
+                "id",
+                "title",
+                "description",
+                "thumbnail",
+                "thumbnail_small",
+                "video",
+                "date",
+                "fast_id",
+                "created_at",
+                "updated_at",
+            },
+        )
+        self.assertEqual(response.data["title"], "Write test video")
+        self.assertEqual(response.data["description"], "New devotional")
+        self.video.refresh_from_db()
+        self.assertEqual(self.video.category, "devotional")
+
+    def test_staff_patch_is_partial_and_returns_public_representation(self):
+        devotional = Devotional.objects.create(
+            day=self.day,
+            video=self.video,
+            language_code="en",
+            description="Before",
+            order=1,
+        )
+        self.client.force_login(self.staff)
+
+        response = self.client.patch(
+            f"/api/devotionals/{devotional.pk}/",
+            {"description": "After"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["description"], "After")
+        devotional.refresh_from_db()
+        self.assertEqual(devotional.day, self.day)
+        self.assertEqual(devotional.video, self.video)
+        self.assertEqual(devotional.order, 1)
+        self.assertEqual(devotional.language_code, "en")
+
+    def test_anonymous_and_non_staff_patch_are_rejected_without_mutation(self):
+        devotional = Devotional.objects.create(
+            day=self.day, video=self.video, language_code="en", description="Before", order=1
+        )
+        url = f"/api/devotionals/{devotional.pk}/"
+        anonymous = self.client.patch(url, {"description": "Nope"}, format="json")
+        self.client.force_login(self.user)
+        non_staff = self.client.patch(url, {"description": "Nope"}, format="json")
+
+        self.assertIn(
+            anonymous.status_code,
+            {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN},
+        )
+        self.assertEqual(non_staff.status_code, status.HTTP_403_FORBIDDEN)
+        devotional.refresh_from_db()
+        self.assertEqual(devotional.description, "Before")
+
+    def test_create_requires_relationships_language_and_order(self):
+        self.client.force_login(self.staff)
+        response = self.client.post("/api/devotionals/", {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(set(response.data), {"day", "video", "language_code", "order"})
+
+    def test_create_rejects_omitted_and_null_order(self):
+        self.client.force_login(self.staff)
+        without_order = {
+            key: value
+            for key, value in self.create_payload.items()
+            if key != "order"
+        }
+
+        omitted = self.client.post("/api/devotionals/", without_order, format="json")
+        explicit_null = self.client.post(
+            "/api/devotionals/", {**self.create_payload, "order": None}, format="json"
+        )
+
+        self.assertEqual(omitted.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(explicit_null.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("order", omitted.data)
+        self.assertIn("order", explicit_null.data)
+        self.assertFalse(Devotional.objects.exists())
+
+    def test_create_rejects_unknown_fields_without_mutation(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(
+            "/api/devotionals/",
+            {**self.create_payload, "id": 9, "video_url": "https://invalid"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(set(response.data), {"id", "video_url"})
+        self.assertFalse(Devotional.objects.exists())
+
+    def test_patch_rejects_unknown_fields_without_mutation(self):
+        devotional = Devotional.objects.create(
+            day=self.day, video=self.video, language_code="en", description="Before", order=1
+        )
+        self.client.force_login(self.staff)
+        response = self.client.patch(
+            f"/api/devotionals/{devotional.pk}/",
+            {"description": "After", "created_at": "2026-01-01", "category": "x"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(set(response.data), {"category", "created_at"})
+        devotional.refresh_from_db()
+        self.assertEqual(devotional.description, "Before")
+
+    def test_invalid_relationships_language_and_negative_order_are_rejected(self):
+        self.client.force_login(self.staff)
+        invalid_payloads = [
+            {**self.create_payload, "day": 999999},
+            {**self.create_payload, "video": 999999},
+            {**self.create_payload, "language_code": "fr"},
+            {**self.create_payload, "order": -1},
+        ]
+
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                response = self.client.post("/api/devotionals/", payload, format="json")
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(Devotional.objects.exists())
+
+    def test_duplicate_day_order_language_is_a_validation_error(self):
+        Devotional.objects.create(
+            day=self.day, video=self.other_video, language_code="en", order=1
+        )
+        self.client.force_login(self.staff)
+
+        response = self.client.post("/api/devotionals/", self.create_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Devotional.objects.count(), 1)
+
+    def test_empty_patch_invalid_fields_and_missing_target_do_not_mutate(self):
+        devotional = Devotional.objects.create(
+            day=self.day, video=self.video, language_code="en", description="Before", order=1
+        )
+        self.client.force_login(self.staff)
+        url = f"/api/devotionals/{devotional.pk}/"
+
+        responses = [
+            self.client.patch(url, {}, format="json"),
+            self.client.patch(url, {"day": 999999}, format="json"),
+            self.client.patch(url, {"video": 999999}, format="json"),
+            self.client.patch(url, {"language_code": "fr"}, format="json"),
+            self.client.patch(url, {"order": -1}, format="json"),
+        ]
+
+        self.assertTrue(
+            all(
+                response.status_code == status.HTTP_400_BAD_REQUEST
+                for response in responses
+            )
+        )
+        missing = self.client.patch(
+            "/api/devotionals/999999/", {"description": "x"}, format="json"
+        )
+        self.assertEqual(missing.status_code, status.HTTP_404_NOT_FOUND)
+        devotional.refresh_from_db()
+        self.assertEqual(devotional.description, "Before")
+
+    def test_patch_rejects_duplicate_day_order_language(self):
+        Devotional.objects.create(
+            day=self.day, video=self.video, language_code="en", order=1
+        )
+        target = Devotional.objects.create(
+            day=self.other_day, video=self.other_video, language_code="en", order=1
+        )
+        self.client.force_login(self.staff)
+
+        response = self.client.patch(
+            f"/api/devotionals/{target.pk}/", {"day": self.day.pk}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        target.refresh_from_db()
+        self.assertEqual(target.day, self.other_day)
+        self.assertEqual(Devotional.objects.count(), 2)
+
+    def test_patch_rejects_explicit_null_order_but_may_omit_it(self):
+        devotional = Devotional.objects.create(
+            day=self.day, video=self.video, language_code="en", order=1
+        )
+        self.client.force_login(self.staff)
+        url = f"/api/devotionals/{devotional.pk}/"
+
+        response = self.client.patch(url, {"order": None}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        devotional.refresh_from_db()
+        self.assertEqual(devotional.order, 1)
+
+    def test_create_matching_duplicate_integrity_error_returns_validation_error(self):
+        self.client.force_login(self.staff)
+
+        def create_conflict_then_raise(*_args, **_kwargs):
+            Devotional.objects.create(
+                day=self.day,
+                video=self.other_video,
+                language_code="en",
+                order=1,
+            )
+            raise IntegrityError("database constraint details")
+
+        with patch(
+            "hub.views.devotionals.DevotionalWriteSerializer.save",
+            side_effect=create_conflict_then_raise,
+        ), patch(
+            "hub.views.devotionals.transaction.atomic", return_value=nullcontext()
+        ):
+            response = self.client.post(
+                "/api/devotionals/", self.create_payload, format="json"
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    "A devotional with this day, order, and language code already exists."
+                ]
+            },
+        )
+        self.assertNotIn("database constraint details", str(response.data))
+
+    def test_create_nonmatching_integrity_error_is_propagated(self):
+        self.client.force_login(self.staff)
+        error = IntegrityError("unrelated database constraint")
+
+        with patch(
+            "hub.views.devotionals.DevotionalWriteSerializer.save",
+            side_effect=error,
+        ):
+            with self.assertRaises(IntegrityError) as raised:
+                self.client.post("/api/devotionals/", self.create_payload, format="json")
+
+        self.assertIs(raised.exception, error)
+
+    def test_patch_matching_duplicate_integrity_error_returns_validation_error(self):
+        devotional = Devotional.objects.create(
+            day=self.other_day, video=self.video, language_code="en", order=1
+        )
+        self.client.force_login(self.staff)
+
+        def create_conflict_then_raise(*_args, **_kwargs):
+            Devotional.objects.create(
+                day=self.day,
+                video=self.other_video,
+                language_code=devotional.language_code,
+                order=devotional.order,
+            )
+            raise IntegrityError("database constraint details")
+
+        with patch(
+            "hub.views.devotionals.DevotionalWriteSerializer.save",
+            side_effect=create_conflict_then_raise,
+        ), patch(
+            "hub.views.devotionals.transaction.atomic", return_value=nullcontext()
+        ):
+            response = self.client.patch(
+                f"/api/devotionals/{devotional.pk}/",
+                {"day": self.day.pk, "description": "After"},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    "A devotional with this day, order, and language code already exists."
+                ]
+            },
+        )
+        devotional.refresh_from_db()
+        self.assertNotEqual(devotional.description, "After")
+
+    def test_patch_nonmatching_integrity_error_is_propagated(self):
+        devotional = Devotional.objects.create(
+            day=self.day, video=self.video, language_code="en", order=1
+        )
+        self.client.force_login(self.staff)
+        error = IntegrityError("unrelated database constraint")
+
+        with patch(
+            "hub.views.devotionals.DevotionalWriteSerializer.save",
+            side_effect=error,
+        ):
+            with self.assertRaises(IntegrityError) as raised:
+                self.client.patch(
+                    f"/api/devotionals/{devotional.pk}/",
+                    {"description": "After"},
+                    format="json",
+                )
+
+        self.assertIs(raised.exception, error)
+
+    def test_put_and_delete_remain_unsupported(self):
+        devotional = Devotional.objects.create(
+            day=self.day, video=self.video, language_code="en", order=1
+        )
+        self.client.force_login(self.staff)
+        url = f"/api/devotionals/{devotional.pk}/"
+
+        self.assertEqual(
+            self.client.put(url, self.create_payload, format="json").status_code,
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+        )
+        self.assertEqual(
+            self.client.delete(url).status_code,
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+        )

--- a/hub/views/devotionals.py
+++ b/hub/views/devotionals.py
@@ -2,9 +2,10 @@
 import datetime
 import logging
 from django.conf import settings
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.utils import timezone
-from rest_framework import generics, permissions
+from rest_framework import generics, permissions, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
@@ -12,7 +13,33 @@ from django.utils.translation import activate, get_language_from_request
 
 from .mixins import ChurchContextMixin, TimezoneMixin
 from hub.models import Devotional, Fast
-from hub.serializers import DevotionalSerializer
+from hub.serializers import DevotionalSerializer, DevotionalWriteSerializer
+from icons.views import IsAdminOrReadOnly
+
+
+DUPLICATE_DEVOTIONAL_ERROR = {
+    "non_field_errors": [
+        "A devotional with this day, order, and language code already exists."
+    ]
+}
+
+
+def _matching_devotional_exists(serializer, *, exclude_id=None):
+    """Return whether the validated write candidate conflicts with a stored row."""
+    instance = serializer.instance
+    day = serializer.validated_data.get("day", getattr(instance, "day", None))
+    order = serializer.validated_data.get("order", getattr(instance, "order", None))
+    language_code = serializer.validated_data.get(
+        "language_code", getattr(instance, "language_code", None)
+    )
+    matches = Devotional.objects.filter(
+        day=day,
+        order=order,
+        language_code=language_code,
+    )
+    if exclude_id is not None:
+        matches = matches.exclude(pk=exclude_id)
+    return matches.exists()
 
 
 class LargeResultsSetPagination(PageNumberPagination):
@@ -116,10 +143,11 @@ class DevotionalDetailView(generics.RetrieveAPIView):
 
     Permissions:
         - GET: Any user can view devotional
-        - POST/PUT/PATCH/DELETE: Not supported
+        - PATCH: Staff users only
+        - POST/PUT/DELETE: Not supported
     """
     serializer_class = DevotionalSerializer
-    permission_classes = [permissions.AllowAny]
+    permission_classes = [IsAdminOrReadOnly]
     queryset = Devotional.objects.all()
     
     def get(self, request, *args, **kwargs):
@@ -127,17 +155,43 @@ class DevotionalDetailView(generics.RetrieveAPIView):
         activate(lang)
         return super().get(request, *args, **kwargs)
 
+    def get_serializer_class(self):
+        if self.request.method == "PATCH":
+            return DevotionalWriteSerializer
+        return DevotionalSerializer
 
-class DevotionalListView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView):
+    def patch(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        try:
+            with transaction.atomic():
+                instance = serializer.save()
+        except IntegrityError:
+            if _matching_devotional_exists(serializer, exclude_id=instance.pk):
+                raise ValidationError(DUPLICATE_DEVOTIONAL_ERROR)
+            raise
+        return Response(
+            DevotionalSerializer(instance, context=self.get_serializer_context()).data,
+            status=status.HTTP_200_OK,
+        )
+
+
+class DevotionalListView(
+    ChurchContextMixin,
+    TimezoneMixin,
+    generics.ListAPIView,
+):
     """
     API endpoint that provides a list of devotionals for a given church.
 
     Permissions:
         - GET: Any user can view devotional
-        - POST/PUT/PATCH/DELETE: Not supported
+        - POST: Staff users only
+        - PUT/PATCH/DELETE: Not supported
     """
     serializer_class = DevotionalSerializer
-    permission_classes = [permissions.AllowAny]
+    permission_classes = [IsAdminOrReadOnly]
     pagination_class = PageNumberPagination
     queryset = Devotional.objects.all()
     ORDERING_ALIASES = {
@@ -145,6 +199,26 @@ class DevotionalListView(ChurchContextMixin, TimezoneMixin, generics.ListAPIView
         "-date": "-day__date",
     }
     ALLOWED_ORDERING = {"day__date", "-day__date"}
+
+    def get_serializer_class(self):
+        if self.request.method == "POST":
+            return DevotionalWriteSerializer
+        return DevotionalSerializer
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            with transaction.atomic():
+                instance = serializer.save()
+        except IntegrityError:
+            if _matching_devotional_exists(serializer):
+                raise ValidationError(DUPLICATE_DEVOTIONAL_ERROR)
+            raise
+        return Response(
+            DevotionalSerializer(instance, context=self.get_serializer_context()).data,
+            status=status.HTTP_201_CREATED,
+        )
 
     def _build_search_query(self, search_term, lang):
         """

--- a/learning_resources/devotional_video_uploads.py
+++ b/learning_resources/devotional_video_uploads.py
@@ -1,0 +1,271 @@
+"""Persistent capability flow for dedicated devotional-video uploads."""
+
+import os
+import re
+import uuid
+from datetime import timedelta
+from xml.sax.saxutils import escape
+
+from django.core import signing
+from django.core.exceptions import ImproperlyConfigured
+from django.db import transaction
+from django.utils import timezone
+
+from .models import DevotionalVideoUpload, Video
+from .utils import generate_unique_filename
+
+
+MIN_FILE_SIZE = 1024 * 1024
+MAX_FILE_SIZE = 500 * 1024 * 1024
+SESSION_MAX_AGE = 60 * 60
+TOKEN_MAX_AGE = 24 * 60 * 60
+SESSION_SALT = "learning-resources.devotional-video-upload-session"
+TOKEN_SALT = "learning-resources.devotional-video-upload-token"
+DEDICATED_PREFIX = "videos/devotional-cli/"
+ALLOWED_TYPES = {".mp4": "video/mp4", ".webm": "video/webm"}
+SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._ -]{0,199}$")
+
+
+class UploadError(Exception):
+    pass
+
+
+def validate_file(file_name, file_size, content_type):
+    if not isinstance(file_name, str) or not SAFE_NAME.fullmatch(file_name):
+        raise UploadError("file_name must be a safe basename of at most 200 characters.")
+    if os.path.basename(file_name) != file_name or any(ord(char) < 32 for char in file_name):
+        raise UploadError("file_name must be a safe basename of at most 200 characters.")
+    if isinstance(file_size, bool) or not isinstance(file_size, int):
+        raise UploadError("file_size must be an integer.")
+    if not MIN_FILE_SIZE <= file_size <= MAX_FILE_SIZE:
+        raise UploadError("file_size must be between 1 MiB and 500 MiB.")
+    if ALLOWED_TYPES.get(os.path.splitext(file_name)[1].lower()) != content_type:
+        raise UploadError("Only exact .mp4 + video/mp4 and .webm + video/webm pairs are supported.")
+
+
+def _signed_nonce(value, *, salt, max_age, user_id):
+    try:
+        payload = signing.loads(value, salt=salt, max_age=max_age)
+    except signing.BadSignature as exc:
+        raise UploadError("Upload capability is invalid or expired.") from exc
+    if payload.get("user_id") != user_id or payload.get("purpose") != "video.video":
+        raise UploadError("Upload capability does not belong to this user or field.")
+    return payload.get("nonce")
+
+
+def _get_upload(value, *, salt, max_age, user_id, lock=False):
+    nonce = _signed_nonce(value, salt=salt, max_age=max_age, user_id=user_id)
+    queryset = DevotionalVideoUpload.objects.select_for_update() if lock else DevotionalVideoUpload.objects
+    try:
+        upload = queryset.get(nonce=nonce, owner_id=user_id)
+    except DevotionalVideoUpload.DoesNotExist as exc:
+        raise UploadError("Upload capability is invalid, expired, or already used.") from exc
+    if upload.expires_at <= timezone.now():
+        raise UploadError("Upload capability is invalid or expired.")
+    return upload
+
+
+class MultipartUploadAdapter:
+    """Small mockable boundary over the django-storages S3 client contract."""
+
+    def __init__(self):
+        field = Video._meta.get_field("video")
+        self.field = field
+        self.storage = field.storage
+        try:
+            self.client = self.storage.connection.meta.client
+            self.bucket_name = self.storage.bucket_name
+        except AttributeError as exc:
+            raise ImproperlyConfigured("Devotional direct upload requires S3-backed storage.") from exc
+
+    def initialize(self, *, file_name, file_size, content_type):
+        key = DEDICATED_PREFIX + generate_unique_filename(None, file_name)
+        response = self.client.create_multipart_upload(
+            Bucket=self.bucket_name, Key=key, ContentType=content_type
+        )
+        upload_id = response["UploadId"]
+        try:
+            url = self.client.generate_presigned_url(
+                "upload_part",
+                Params={"Bucket": self.bucket_name, "Key": key, "UploadId": upload_id,
+                        "PartNumber": 1, "ContentLength": file_size},
+                ExpiresIn=SESSION_MAX_AGE,
+            )
+        except Exception:
+            self.abort(key=key, upload_id=upload_id)
+            raise
+        return {"key": key, "upload_id": upload_id,
+                "parts": [{"part_number": 1, "size": file_size, "url": url}]}
+
+    def completion_request(self, *, key, upload_id, parts):
+        aws_parts = [{"PartNumber": p["part_number"], "ETag": p["etag"]} for p in parts]
+        url = self.client.generate_presigned_url(
+            "complete_multipart_upload",
+            Params={"Bucket": self.bucket_name, "Key": key, "UploadId": upload_id},
+            ExpiresIn=SESSION_MAX_AGE,
+        )
+        body = '<?xml version="1.0" encoding="UTF-8"?>'
+        body += '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        body += "".join(
+            f"<Part><PartNumber>{p['PartNumber']}</PartNumber><ETag>{escape(p['ETag'])}</ETag></Part>"
+            for p in aws_parts
+        ) + "</CompleteMultipartUpload>"
+        return {"url": url, "body": body}
+
+    def abort(self, *, key, upload_id):
+        try:
+            self.client.abort_multipart_upload(
+                Bucket=self.bucket_name, Key=key, UploadId=upload_id
+            )
+        except Exception:
+            pass
+
+    def abort_for_cleanup(self, *, key, upload_id):
+        self.client.abort_multipart_upload(Bucket=self.bucket_name, Key=key, UploadId=upload_id)
+
+    def delete_object(self, *, key):
+        self.client.delete_object(Bucket=self.bucket_name, Key=key)
+
+    def object_size(self, *, key):
+        return self.client.head_object(Bucket=self.bucket_name, Key=key)["ContentLength"]
+
+
+def initialize_upload(*, user_id, file_name, file_size, content_type, adapter=None):
+    validate_file(file_name, file_size, content_type)
+    upload_adapter = adapter or MultipartUploadAdapter()
+    try:
+        result = upload_adapter.initialize(
+            file_name=file_name, file_size=file_size, content_type=content_type
+        )
+    except Exception as exc:
+        raise UploadError("Upload could not be initialized; try a fresh upload.") from exc
+    if not result["key"].startswith(DEDICATED_PREFIX):
+        upload_adapter.abort(key=result["key"], upload_id=result["upload_id"])
+        raise UploadError("Storage generated an invalid devotional video key.")
+    nonce = uuid.uuid4().hex
+    try:
+        DevotionalVideoUpload.objects.create(
+            nonce=nonce, owner_id=user_id, storage_key=result["key"], file_name=file_name,
+            expected_size=file_size, content_type=content_type, upload_id=result["upload_id"],
+            expires_at=timezone.now() + timedelta(seconds=SESSION_MAX_AGE),
+        )
+    except Exception:
+        upload_adapter.abort(key=result["key"], upload_id=result["upload_id"])
+        raise
+    session = signing.dumps(
+        {"nonce": nonce, "user_id": user_id, "purpose": "video.video"}, salt=SESSION_SALT
+    )
+    return {"upload_session": session, "upload_id": result["upload_id"], "parts": result["parts"]}
+
+
+def complete_upload(*, user_id, upload_session, upload_id, parts, adapter=None):
+    preparation_error = None
+    aborted_upload = None
+    with transaction.atomic():
+        upload = _get_upload(upload_session, salt=SESSION_SALT, max_age=SESSION_MAX_AGE,
+                             user_id=user_id, lock=True)
+        if (upload.state != DevotionalVideoUpload.State.INITIALIZED
+                or upload.completion_requested_at is not None):
+            raise UploadError("Upload completion has already been requested.")
+        if upload_id != upload.upload_id:
+            raise UploadError("upload_id does not match this upload session.")
+        if not isinstance(parts, list) or not parts:
+            raise UploadError("parts must be a non-empty list.")
+        total = 0
+        for expected, part in enumerate(parts, start=1):
+            if (not isinstance(part, dict) or set(part) != {"part_number", "size", "etag"}
+                    or part["part_number"] != expected):
+                raise UploadError("parts must be ordered, contiguous, and contain only part_number, size, and etag.")
+            if isinstance(part["size"], bool) or not isinstance(part["size"], int) or part["size"] < 1:
+                raise UploadError("Each part size must be a positive integer.")
+            if not isinstance(part["etag"], str) or not part["etag"]:
+                raise UploadError("Each part must have an etag.")
+            total += part["size"]
+        if total != upload.expected_size:
+            raise UploadError("Part sizes do not match the initiated file size.")
+        upload_adapter = adapter or MultipartUploadAdapter()
+        try:
+            result = upload_adapter.completion_request(
+                key=upload.storage_key, upload_id=upload.upload_id, parts=parts
+            )
+        except Exception as exc:
+            # Commit the terminal state before the irreversible abort. If the
+            # process stops after this commit, the expired cleanup path can
+            # still reconcile the abandoned multipart upload later.
+            upload.state = DevotionalVideoUpload.State.CLEANED
+            upload.cleaned_at = None
+            upload.save(update_fields=["state", "cleaned_at"])
+            preparation_error = exc
+            aborted_upload = (upload.storage_key, upload.upload_id)
+        else:
+            upload.completion_requested_at = timezone.now()
+            upload.save(update_fields=["completion_requested_at"])
+    if preparation_error is not None:
+        upload_adapter.abort(key=aborted_upload[0], upload_id=aborted_upload[1])
+        raise UploadError(
+            "Upload completion could not be prepared; start a fresh upload."
+        ) from preparation_error
+    return result
+
+
+def finalize_upload(*, user_id, upload_session, adapter=None):
+    size_mismatch = False
+    aborted_upload = None
+    with transaction.atomic():
+        upload = _get_upload(upload_session, salt=SESSION_SALT, max_age=SESSION_MAX_AGE,
+                             user_id=user_id, lock=True)
+        if upload.state != DevotionalVideoUpload.State.INITIALIZED or not upload.completion_requested_at:
+            raise UploadError("Upload must be completed before it can be finalized.")
+        upload_adapter = adapter or MultipartUploadAdapter()
+        try:
+            size = upload_adapter.object_size(key=upload.storage_key)
+        except Exception as exc:
+            raise UploadError("The completed object is not available.") from exc
+        if size != upload.expected_size:
+            # Persist a terminal, recoverable cleanup lease before touching S3.
+            # A crash before or during abort leaves this row eligible for the
+            # cleanup command, which also removes a completed object.
+            upload.state = DevotionalVideoUpload.State.CLEANED
+            upload.cleaned_at = None
+            upload.save(update_fields=["state", "cleaned_at"])
+            size_mismatch = True
+            aborted_upload = (upload.storage_key, upload.upload_id)
+        else:
+            upload.state = DevotionalVideoUpload.State.READY
+            upload.expires_at = timezone.now() + timedelta(seconds=TOKEN_MAX_AGE)
+            upload.save(update_fields=["state", "expires_at"])
+            token = signing.dumps(
+                {"nonce": upload.nonce, "user_id": user_id, "purpose": "video.video"},
+                salt=TOKEN_SALT,
+            )
+            result = {"upload_token": token, "file_name": upload.file_name, "file_size": size}
+    if size_mismatch:
+        upload_adapter.abort(key=aborted_upload[0], upload_id=aborted_upload[1])
+        raise UploadError(
+            "Completed object size does not match the initiated file size; start a fresh upload."
+        )
+    return result
+
+
+def attach_upload_token(token, *, user_id, save):
+    """Lock a ready upload, persist its Video, then atomically mark it attached."""
+    with transaction.atomic():
+        upload = _get_upload(token, salt=TOKEN_SALT, max_age=TOKEN_MAX_AGE,
+                             user_id=user_id, lock=True)
+        if upload.state != DevotionalVideoUpload.State.READY:
+            raise UploadError("Upload token has already been used.")
+        if not upload.storage_key.startswith(DEDICATED_PREFIX):
+            raise UploadError("Upload token contains an invalid video key.")
+        result = save(upload.storage_key)
+        upload.state = DevotionalVideoUpload.State.ATTACHED
+        upload.attached_at = timezone.now()
+        upload.save(update_fields=["state", "attached_at"])
+        return result
+
+
+def consume_upload_token(token, *, user_id):
+    """Compatibility validator; new persistence must use attach_upload_token."""
+    upload = _get_upload(token, salt=TOKEN_SALT, max_age=TOKEN_MAX_AGE, user_id=user_id)
+    if upload.state != DevotionalVideoUpload.State.READY:
+        raise UploadError("Upload token has already been used.")
+    return upload.storage_key

--- a/learning_resources/management/commands/cleanup_devotional_video_uploads.py
+++ b/learning_resources/management/commands/cleanup_devotional_video_uploads.py
@@ -1,0 +1,129 @@
+"""Clean expired, unattached objects created by the dedicated CLI upload flow."""
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from learning_resources.devotional_video_uploads import DEDICATED_PREFIX, MultipartUploadAdapter
+from learning_resources.models import DevotionalVideoUpload
+
+
+def _is_missing(exc):
+    response = getattr(exc, "response", {})
+    code = str(response.get("Error", {}).get("Code", ""))
+    return code in {"404", "NoSuchKey", "NoSuchUpload", "NotFound"}
+
+
+def _claim_cleanup(upload_id):
+    """Claim an eligible row before making irreversible storage calls."""
+    with transaction.atomic():
+        upload = DevotionalVideoUpload.objects.select_for_update().get(pk=upload_id)
+        recoverable_lease = (
+            upload.state == DevotionalVideoUpload.State.CLEANED
+            and upload.cleaned_at is None
+        )
+        eligible = (
+            upload.state in {
+                DevotionalVideoUpload.State.INITIALIZED,
+                DevotionalVideoUpload.State.READY,
+            }
+            and upload.expires_at <= timezone.now()
+        )
+        if not (recoverable_lease or eligible) or not upload.storage_key.startswith(
+            DEDICATED_PREFIX
+        ):
+            return None
+        previous_state = upload.state
+        if not recoverable_lease:
+            upload.state = DevotionalVideoUpload.State.CLEANED
+            upload.cleaned_at = None
+            upload.save(update_fields=["state", "cleaned_at"])
+        return {
+            "pk": upload.pk,
+            "storage_key": upload.storage_key,
+            "upload_id": upload.upload_id,
+            "previous_state": previous_state,
+        }
+
+
+def _finish_cleanup(upload_id):
+    DevotionalVideoUpload.objects.filter(
+        pk=upload_id,
+        state=DevotionalVideoUpload.State.CLEANED,
+        cleaned_at__isnull=True,
+    ).update(cleaned_at=timezone.now())
+
+
+def _release_cleanup(claim):
+    """Make a failed storage operation eligible for a later cleanup attempt."""
+    if claim["previous_state"] == DevotionalVideoUpload.State.CLEANED:
+        return
+    DevotionalVideoUpload.objects.filter(
+        pk=claim["pk"],
+        state=DevotionalVideoUpload.State.CLEANED,
+        cleaned_at__isnull=True,
+    ).update(state=claim["previous_state"])
+
+
+def _ignore_missing(operation):
+    try:
+        operation()
+    except Exception as exc:
+        if not _is_missing(exc):
+            raise
+
+
+class Command(BaseCommand):
+    help = "Dry-run (default) or clean expired unattached devotional CLI uploads."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--execute", action="store_true")
+
+    def handle(self, *args, **options):
+        execute = options["execute"]
+        candidates = DevotionalVideoUpload.objects.filter(
+            Q(
+                state__in=[
+                    DevotionalVideoUpload.State.INITIALIZED,
+                    DevotionalVideoUpload.State.READY,
+                ],
+                expires_at__lte=timezone.now(),
+            )
+            | Q(state=DevotionalVideoUpload.State.CLEANED, cleaned_at__isnull=True),
+            storage_key__startswith=DEDICATED_PREFIX,
+        ).order_by("pk")
+        adapter = MultipartUploadAdapter() if execute and candidates.exists() else None
+        count = 0
+        for candidate in candidates.iterator():
+            count += 1
+            self.stdout.write(
+                f"{'CLEAN' if execute else 'WOULD CLEAN'} upload={candidate.pk} "
+                f"state={candidate.state} key={candidate.storage_key}"
+            )
+            if not execute:
+                continue
+            try:
+                claim = _claim_cleanup(candidate.pk)
+                if claim is None:
+                    continue
+                try:
+                    # Both calls are safe for every claimed dedicated key. This
+                    # also lets a CLEANED/null lease recover without needing to
+                    # remember whether a crash interrupted abort or delete.
+                    _ignore_missing(
+                        lambda: adapter.abort_for_cleanup(
+                            key=claim["storage_key"], upload_id=claim["upload_id"]
+                        )
+                    )
+                    _ignore_missing(
+                        lambda: adapter.delete_object(key=claim["storage_key"])
+                    )
+                except Exception:
+                    _release_cleanup(claim)
+                    raise
+                _finish_cleanup(claim["pk"])
+            except Exception as exc:
+                self.stderr.write(f"FAILED upload={candidate.pk}: {exc}")
+                continue
+        self.stdout.write(f"{'Cleaned' if execute else 'Found'} {count} expired upload(s).")

--- a/learning_resources/migrations/0009_devotionalvideoupload_alter_video_video.py
+++ b/learning_resources/migrations/0009_devotionalvideoupload_alter_video_video.py
@@ -1,0 +1,43 @@
+import django.db.models.deletion
+import learning_resources.utils
+import s3_file_field.fields
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("learning_resources", "0008_article_i18n_recipe_i18n_video_i18n_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DevotionalVideoUpload",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("nonce", models.CharField(editable=False, max_length=64, unique=True)),
+                ("storage_key", models.CharField(max_length=1024)),
+                ("file_name", models.CharField(max_length=200)),
+                ("expected_size", models.PositiveBigIntegerField()),
+                ("content_type", models.CharField(max_length=100)),
+                ("upload_id", models.CharField(max_length=1024)),
+                ("state", models.CharField(choices=[("initialized", "Initialized"), ("ready", "Completed / ready"), ("attached", "Attached"), ("cleaned", "Cleaned")], db_index=True, default="initialized", max_length=16)),
+                ("completion_requested_at", models.DateTimeField(blank=True, null=True)),
+                ("expires_at", models.DateTimeField(db_index=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("attached_at", models.DateTimeField(blank=True, null=True)),
+                ("cleaned_at", models.DateTimeField(blank=True, null=True)),
+                ("owner", models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name="devotional_video_uploads", to=settings.AUTH_USER_MODEL)),
+            ],
+            options={"ordering": ["created_at"]},
+        ),
+        migrations.AlterField(
+            model_name="video",
+            name="video",
+            field=s3_file_field.fields.S3FileField(
+                help_text="Supported formats: MP4, WebM. Portrait orientation (9:16). Files up to 500 MiB.",
+                upload_to=learning_resources.utils.video_upload_path,
+            ),
+        ),
+    ]

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from imagekit.models import ImageSpecField
 from imagekit.processors import ResizeToFill
 from django.utils import timezone
+from django.conf import settings
 import logging
 from s3_file_field.fields import S3FileField
 from modeltrans.fields import TranslationField
@@ -42,7 +43,7 @@ class Video(models.Model):
     )
     video = S3FileField(
         upload_to=video_upload_path,
-        help_text='Supported formats: MP4, WebM. Portrait orientation (9:16). Files up to 20MB.'
+        help_text='Supported formats: MP4, WebM. Portrait orientation (9:16). Files up to 500 MiB.'
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -119,6 +120,40 @@ class Video(models.Model):
         'title',
         'description',
     ))
+
+
+class DevotionalVideoUpload(models.Model):
+    """Private audit ledger for the dedicated devotional CLI upload flow."""
+
+    class State(models.TextChoices):
+        INITIALIZED = "initialized", "Initialized"
+        READY = "ready", "Completed / ready"
+        ATTACHED = "attached", "Attached"
+        CLEANED = "cleaned", "Cleaned"
+
+    nonce = models.CharField(max_length=64, unique=True, editable=False)
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name="devotional_video_uploads",
+    )
+    storage_key = models.CharField(max_length=1024)
+    file_name = models.CharField(max_length=200)
+    expected_size = models.PositiveBigIntegerField()
+    content_type = models.CharField(max_length=100)
+    upload_id = models.CharField(max_length=1024)
+    state = models.CharField(
+        max_length=16, choices=State.choices, default=State.INITIALIZED, db_index=True
+    )
+    completion_requested_at = models.DateTimeField(null=True, blank=True)
+    expires_at = models.DateTimeField(db_index=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    attached_at = models.DateTimeField(null=True, blank=True)
+    cleaned_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["created_at"]
+
 
 class Article(models.Model):
     title = models.CharField(max_length=200)
@@ -414,4 +449,3 @@ class Bookmark(models.Model):
             representation['created_at'] = content.created_at
             
         return representation
-    

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -3,6 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from hub.mixins import ThumbnailCacheMixin
 from .models import Article, Recipe, Video, Bookmark
 from django.utils.translation import activate
+from django.conf import settings
 from .cache import BookmarkCacheManager
 from hub.models import DevotionalSet
 
@@ -78,6 +79,82 @@ class VideoSerializer(BookmarkOptimizedSerializerMixin, serializers.ModelSeriali
         data['title'] = getattr(instance, 'title_i18n', instance.title)
         data['description'] = getattr(instance, 'description_i18n', instance.description)
         return data
+
+
+class DevotionalVideoWriteSerializer(serializers.ModelSerializer):
+    """Strict staff-only input contract; storage names are capability-derived."""
+
+    upload_token = serializers.CharField(write_only=True, required=False, trim_whitespace=False)
+    clear_thumbnail = serializers.BooleanField(write_only=True, required=False, default=False)
+    language_code = serializers.ChoiceField(
+        choices=tuple(dict.fromkeys([
+            *getattr(settings, "MODELTRANS_AVAILABLE_LANGUAGES", []),
+            *(code for code, _name in getattr(settings, "LANGUAGES", [])),
+        ]))
+    )
+
+    class Meta:
+        model = Video
+        fields = [
+            "title", "description", "language_code", "upload_token",
+            "thumbnail", "clear_thumbnail",
+        ]
+        extra_kwargs = {
+            "title": {"allow_blank": False, "max_length": 200},
+            "description": {"allow_blank": False},
+            "thumbnail": {"required": False, "allow_null": False},
+        }
+
+    def validate(self, attrs):
+        unknown = set(self.initial_data) - set(self.fields)
+        if unknown:
+            raise serializers.ValidationError({name: "Unknown field." for name in sorted(unknown)})
+        if self.partial and not self.initial_data:
+            raise serializers.ValidationError("PATCH body must contain at least one field.")
+        if not self.partial and "upload_token" not in attrs:
+            raise serializers.ValidationError({"upload_token": "This field is required."})
+        if not self.partial and "clear_thumbnail" in self.initial_data:
+            raise serializers.ValidationError({"clear_thumbnail": "This field is only allowed on PATCH."})
+        if attrs.get("clear_thumbnail") and "thumbnail" in attrs:
+            raise serializers.ValidationError("thumbnail and clear_thumbnail are mutually exclusive.")
+        return attrs
+
+    def _attach(self, token, save):
+        from .devotional_video_uploads import UploadError, attach_upload_token
+        try:
+            return attach_upload_token(
+                token, user_id=self.context["request"].user.pk, save=save
+            )
+        except UploadError as exc:
+            raise serializers.ValidationError({"upload_token": str(exc)}) from exc
+
+    def create(self, validated_data):
+        token = validated_data.pop("upload_token")
+        validated_data.pop("clear_thumbnail", None)
+        validated_data["category"] = "devotional"
+        return self._attach(
+            token,
+            lambda key: super(DevotionalVideoWriteSerializer, self).create(
+                {**validated_data, "video": key}
+            ),
+        )
+
+    def update(self, instance, validated_data):
+        token = validated_data.pop("upload_token", None)
+        clear_thumbnail = validated_data.pop("clear_thumbnail", False)
+        if token:
+            validated_data["video"] = None
+        if clear_thumbnail:
+            validated_data["thumbnail"] = None
+        instance.category = "devotional"
+        def save(key=None):
+            if key is not None:
+                validated_data["video"] = key
+            return super(DevotionalVideoWriteSerializer, self).update(
+                instance, validated_data
+            )
+
+        return self._attach(token, save) if token else save()
 
 class ArticleSerializer(BookmarkOptimizedSerializerMixin, serializers.ModelSerializer, ThumbnailCacheMixin):
     thumbnail_url = serializers.SerializerMethodField()

--- a/learning_resources/tests_devotional_video_write_api.py
+++ b/learning_resources/tests_devotional_video_write_api.py
@@ -1,0 +1,565 @@
+from unittest.mock import Mock, patch
+from datetime import timedelta
+from io import StringIO
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.core import signing
+from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import call_command
+from django.db import connection
+from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from learning_resources.devotional_video_uploads import (
+    MultipartUploadAdapter, UploadError, attach_upload_token, complete_upload,
+    consume_upload_token, finalize_upload, initialize_upload, validate_file,
+)
+from learning_resources.models import DevotionalVideoUpload, Video
+
+
+class FakeMultipartAdapter:
+    def __init__(self, size=1024 * 1024):
+        self.size = size
+        self.aborted = []
+
+    def initialize(self, **kwargs):
+        return {"key": "videos/devotional-cli/server-name.mp4", "upload_id": "aws-id",
+                "parts": [{"part_number": 1, "size": kwargs["file_size"],
+                           "url": "https://s3.invalid/part"}]}
+
+    def completion_request(self, **kwargs):
+        return {"url": "https://s3.invalid/complete", "body": "<xml/>"}
+
+    def object_size(self, **kwargs):
+        return self.size
+
+    def abort(self, **kwargs):
+        self.aborted.append(kwargs)
+
+
+class MultipartUploadAdapterTests(SimpleTestCase):
+    def test_constructor_uses_django_storages_s3_resource_contract(self):
+        field = Mock()
+        expected_client = field.storage.connection.meta.client
+        field.storage.bucket_name = "video-bucket"
+        with patch.object(Video._meta, "get_field", return_value=field):
+            adapter = MultipartUploadAdapter()
+
+        self.assertIs(adapter.client, expected_client)
+        self.assertEqual(adapter.bucket_name, "video-bucket")
+
+    def setUp(self):
+        self.client = Mock()
+        self.client.create_multipart_upload.return_value = {"UploadId": "aws-id"}
+        self.client.generate_presigned_url.return_value = "https://s3.invalid/presigned"
+        self.adapter = MultipartUploadAdapter.__new__(MultipartUploadAdapter)
+        self.adapter.client = self.client
+        self.adapter.bucket_name = "video-bucket"
+        self.adapter.field = Mock()
+        self.adapter.field.generate_filename.return_value = "videos/server-name.mp4"
+
+    def test_part_presign_is_bound_to_initiated_size(self):
+        with patch("learning_resources.devotional_video_uploads.generate_unique_filename",
+                   return_value="server-name.mp4"):
+            result = self.adapter.initialize(
+                file_name="day.mp4", file_size=7 * 1024 * 1024, content_type="video/mp4"
+            )
+
+        self.assertEqual(result["parts"][0]["size"], 7 * 1024 * 1024)
+        self.client.generate_presigned_url.assert_called_once_with(
+            "upload_part",
+            Params={
+                "Bucket": "video-bucket", "Key": "videos/devotional-cli/server-name.mp4",
+                "UploadId": "aws-id", "PartNumber": 1, "ContentLength": 7 * 1024 * 1024,
+            },
+            ExpiresIn=60 * 60,
+        )
+
+    def test_completion_presign_excludes_payload_and_returns_upstream_xml(self):
+        result = self.adapter.completion_request(
+            key="videos/server-name.mp4", upload_id="aws-id",
+            parts=[{"part_number": 1, "size": 123, "etag": '"normal-etag"'}],
+        )
+
+        self.client.generate_presigned_url.assert_called_once_with(
+            "complete_multipart_upload",
+            Params={"Bucket": "video-bucket", "Key": "videos/server-name.mp4",
+                    "UploadId": "aws-id"},
+            ExpiresIn=60 * 60,
+        )
+        self.assertEqual(
+            result["body"],
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+            '<Part><PartNumber>1</PartNumber><ETag>"normal-etag"</ETag></Part>'
+            '</CompleteMultipartUpload>',
+        )
+
+    def test_abort_uses_s3_client_contract_and_swallows_cleanup_errors(self):
+        self.client.abort_multipart_upload.side_effect = RuntimeError("private S3 detail")
+        self.adapter.abort(key="videos/server-name.mp4", upload_id="aws-id")
+        self.client.abort_multipart_upload.assert_called_once_with(
+            Bucket="video-bucket", Key="videos/server-name.mp4", UploadId="aws-id"
+        )
+
+
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+class UploadCapabilityTests(TestCase):
+    size = 1024 * 1024
+
+    def setUp(self):
+        cache.clear()
+        self.owner = get_user_model().objects.create_user("capability-owner")
+
+    def test_file_policy_accepts_only_exact_pairs_and_safe_sizes(self):
+        validate_file("day-1.mp4", self.size, "video/mp4")
+        validate_file("day-1.webm", self.size, "video/webm")
+        validate_file("largest.mp4", 500 * 1024 * 1024, "video/mp4")
+        for args in [
+            ("../bad.mp4", self.size, "video/mp4"),
+            ("bad.mp4", self.size - 1, "video/mp4"),
+            ("bad.mp4", 500 * 1024 * 1024 + 1, "video/mp4"),
+            ("bad.mp4", self.size, "video/webm"),
+            ("bad.mov", self.size, "video/quicktime"),
+        ]:
+            with self.assertRaises(UploadError):
+                validate_file(*args)
+
+    def _initialized(self, user_id=None):
+        user_id = user_id or self.owner.pk
+        return initialize_upload(user_id=user_id, file_name="day.mp4", file_size=self.size,
+                                 content_type="video/mp4", adapter=FakeMultipartAdapter())
+
+    def test_protocol_order_user_binding_size_and_one_time_token(self):
+        user_id = self.owner.pk
+        initiated = self._initialized(user_id)
+        self.assertEqual(initiated["parts"][0]["size"], self.size)
+        with self.assertRaises(UploadError):
+            finalize_upload(user_id=user_id, upload_session=initiated["upload_session"], adapter=FakeMultipartAdapter())
+        with self.assertRaises(UploadError):
+            complete_upload(user_id=user_id + 1, upload_session=initiated["upload_session"],
+                            upload_id="aws-id", parts=[] , adapter=FakeMultipartAdapter())
+        completed = complete_upload(
+            user_id=user_id, upload_session=initiated["upload_session"], upload_id="aws-id",
+            parts=[{"part_number": 1, "size": self.size, "etag": '"etag"'}],
+            adapter=FakeMultipartAdapter(),
+        )
+        self.assertEqual(set(completed), {"url", "body"})
+        wrong_size_adapter = FakeMultipartAdapter(self.size + 1)
+        with self.assertRaises(UploadError):
+            finalize_upload(user_id=user_id, upload_session=initiated["upload_session"],
+                            adapter=wrong_size_adapter)
+        self.assertEqual(wrong_size_adapter.aborted, [
+            {"key": "videos/devotional-cli/server-name.mp4", "upload_id": "aws-id"}
+        ])
+
+        # A terminal size mismatch invalidates that capability; retry from a
+        # fresh upload rather than reusing a potentially inconsistent object.
+        initiated = self._initialized(user_id)
+        complete_upload(
+            user_id=user_id, upload_session=initiated["upload_session"], upload_id="aws-id",
+            parts=[{"part_number": 1, "size": self.size, "etag": '"etag"'}],
+            adapter=FakeMultipartAdapter(),
+        )
+        finalized = finalize_upload(user_id=user_id, upload_session=initiated["upload_session"],
+                                    adapter=FakeMultipartAdapter())
+        self.assertNotIn("key", finalized)
+        with self.assertRaises(UploadError):
+            consume_upload_token(finalized["upload_token"], user_id=user_id + 1)
+        self.assertEqual(consume_upload_token(finalized["upload_token"], user_id=user_id),
+                         "videos/devotional-cli/server-name.mp4")
+        self.assertEqual(
+            attach_upload_token(finalized["upload_token"], user_id=user_id, save=lambda key: key),
+            "videos/devotional-cli/server-name.mp4",
+        )
+        with self.assertRaises(UploadError):
+            consume_upload_token(finalized["upload_token"], user_id=user_id)
+
+    def test_expired_capability_is_rejected(self):
+        initiated = self._initialized()
+        with patch("learning_resources.devotional_video_uploads.signing.loads",
+                   side_effect=signing.SignatureExpired):
+            with self.assertRaises(UploadError):
+                complete_upload(user_id=1, upload_session=initiated["upload_session"],
+                                upload_id="aws-id", parts=[], adapter=FakeMultipartAdapter())
+
+    def test_completion_preparation_failure_aborts_and_invalidates_session(self):
+        initiated = self._initialized()
+        adapter = FakeMultipartAdapter()
+        adapter.completion_request = Mock(side_effect=RuntimeError("S3 detail"))
+
+        with self.assertRaisesRegex(UploadError, "start a fresh upload"):
+            complete_upload(
+                user_id=self.owner.pk, upload_session=initiated["upload_session"], upload_id="aws-id",
+                parts=[{"part_number": 1, "size": self.size, "etag": '"etag"'}],
+                adapter=adapter,
+            )
+        self.assertEqual(adapter.aborted, [
+            {"key": "videos/devotional-cli/server-name.mp4", "upload_id": "aws-id"}
+        ])
+        upload = DevotionalVideoUpload.objects.get(owner=self.owner)
+        self.assertEqual(upload.state, DevotionalVideoUpload.State.CLEANED)
+        self.assertIsNone(upload.cleaned_at)
+        with self.assertRaises(UploadError):
+            complete_upload(
+                user_id=self.owner.pk, upload_session=initiated["upload_session"], upload_id="aws-id",
+                parts=[{"part_number": 1, "size": self.size, "etag": '"etag"'}],
+                adapter=adapter,
+            )
+        with self.assertRaises(UploadError):
+            finalize_upload(
+                user_id=self.owner.pk,
+                upload_session=initiated["upload_session"],
+                adapter=adapter,
+            )
+        self.assertEqual(adapter.completion_request.call_count, 1)
+
+
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
+class FinalizeUploadFailureTests(TransactionTestCase):
+    def test_size_mismatch_is_terminal_before_abort_runs_outside_transaction(self):
+        size = 1024 * 1024
+        owner = get_user_model().objects.create_user("finalize-failure-owner")
+        initiated = initialize_upload(
+            user_id=owner.pk,
+            file_name="day.mp4",
+            file_size=size,
+            content_type="video/mp4",
+            adapter=FakeMultipartAdapter(),
+        )
+        complete_upload(
+            user_id=owner.pk,
+            upload_session=initiated["upload_session"],
+            upload_id="aws-id",
+            parts=[{"part_number": 1, "size": size, "etag": '"etag"'}],
+            adapter=FakeMultipartAdapter(),
+        )
+        upload = DevotionalVideoUpload.objects.get(owner=owner)
+        adapter = FakeMultipartAdapter(size + 1)
+
+        def assert_terminal_ledger(**kwargs):
+            self.assertFalse(connection.in_atomic_block)
+            upload.refresh_from_db()
+            self.assertEqual(upload.state, DevotionalVideoUpload.State.CLEANED)
+            self.assertIsNone(upload.cleaned_at)
+            adapter.aborted.append(kwargs)
+
+        adapter.abort = Mock(side_effect=assert_terminal_ledger)
+        with self.assertRaisesRegex(UploadError, "start a fresh upload"):
+            finalize_upload(
+                user_id=owner.pk,
+                upload_session=initiated["upload_session"],
+                adapter=adapter,
+            )
+
+        adapter.abort.assert_called_once_with(
+            key="videos/devotional-cli/server-name.mp4", upload_id="aws-id"
+        )
+        with self.assertRaisesRegex(UploadError, "completed before it can be finalized"):
+            finalize_upload(
+                user_id=owner.pk,
+                upload_session=initiated["upload_session"],
+                adapter=FakeMultipartAdapter(),
+            )
+
+
+@override_settings(
+    MODELTRANS_AVAILABLE_LANGUAGES=["en", "hy"],
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}},
+)
+class DevotionalVideoWriteAPITests(APITestCase):
+    def setUp(self):
+        users = get_user_model()
+        self.staff = users.objects.create_user("video-staff", is_staff=True)
+        self.user = users.objects.create_user("video-user")
+        self.video = Video.objects.create(title="Before", description="Before",
+                                          category="devotional", language_code="en")
+        self.payload = {"title": "New", "description": "Description",
+                        "language_code": "en", "upload_token": "opaque"}
+
+    def test_public_reads_remain_available_and_shaped_as_before(self):
+        listing = self.client.get("/api/learning-resources/videos/?category=devotional")
+        detail = self.client.get(f"/api/learning-resources/videos/{self.video.pk}/")
+        self.assertEqual(listing.status_code, status.HTTP_200_OK)
+        self.assertEqual(detail.status_code, status.HTTP_200_OK)
+        self.assertEqual(set(detail.data), {"id", "title", "description", "category", "thumbnail",
+                                            "thumbnail_small_url", "video", "created_at", "updated_at",
+                                            "is_bookmarked"})
+
+    def test_writes_require_staff(self):
+        for user, expected_status in (
+            (None, status.HTTP_401_UNAUTHORIZED),
+            (self.user, status.HTTP_403_FORBIDDEN),
+        ):
+            self.client.force_authenticate(user=user)
+            response = self.client.post("/api/learning-resources/videos/", self.payload, format="json")
+            self.assertEqual(response.status_code, expected_status)
+        self.client.force_authenticate(user=None)
+
+    @patch(
+        "learning_resources.devotional_video_uploads.attach_upload_token",
+        side_effect=lambda _token, *, user_id, save: save(
+            "videos/devotional-cli/server.mp4"
+        ),
+    )
+    def test_staff_create_forces_category_and_returns_public_shape(self, _consume):
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.post("/api/learning-resources/videos/", self.payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        created = Video.objects.get(pk=response.data["id"])
+        self.assertEqual(created.category, "devotional")
+        self.assertEqual(created.video.name, "videos/devotional-cli/server.mp4")
+        self.assertNotIn("upload_token", response.data)
+
+    def test_create_rejects_forbidden_unknown_and_invalid_fields(self):
+        self.client.force_authenticate(user=self.staff)
+        for field, value in [("category", "general"), ("video", "videos/raw.mp4"),
+                             ("id", 9), ("created_at", "now"), ("unknown", True)]:
+            response = self.client.post("/api/learning-resources/videos/",
+                                        {**self.payload, field: value}, format="json")
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, field)
+        for changes in [{"title": "x" * 201}, {"description": ""}, {"language_code": "zz"}]:
+            response = self.client.post("/api/learning-resources/videos/",
+                                        {**self.payload, **changes}, format="json")
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_metadata_clear_thumbnail_and_method_restrictions(self):
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.patch(f"/api/learning-resources/videos/{self.video.pk}/",
+                                     {"title": "After", "clear_thumbnail": True}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.video.refresh_from_db()
+        self.assertEqual(self.video.title, "After")
+        self.assertEqual(self.video.category, "devotional")
+        self.assertEqual(self.client.patch(f"/api/learning-resources/videos/{self.video.pk}/", {}, format="json").status_code,
+                         status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.client.put(f"/api/learning-resources/videos/{self.video.pk}/", self.payload, format="json").status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(self.client.delete(f"/api/learning-resources/videos/{self.video.pk}/").status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_thumbnail_rules_and_non_devotional_patch(self):
+        self.client.force_authenticate(user=self.staff)
+        thumbnail = SimpleUploadedFile(
+            "thumbnail.gif",
+            (
+                b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x00\x00\x00\x21\xf9\x04"
+                b"\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02"
+                b"\x02\x4c\x01\x00\x3b"
+            ),
+            content_type="image/gif",
+        )
+        both = self.client.patch(f"/api/learning-resources/videos/{self.video.pk}/",
+                                 {"thumbnail": thumbnail, "clear_thumbnail": True},
+                                 format="multipart")
+        self.assertEqual(both.status_code, status.HTTP_400_BAD_REQUEST)
+        general = Video.objects.create(title="G", description="G", category="general")
+        self.assertEqual(self.client.patch(f"/api/learning-resources/videos/{general.pk}/",
+                                          {"title": "No"}, format="json").status_code,
+                         status.HTTP_404_NOT_FOUND)
+
+    @patch("learning_resources.upload_views.finalize_upload", return_value={"upload_token": "t", "file_name": "day.mp4", "file_size": 1})
+    @patch("learning_resources.upload_views.complete_upload", return_value={"url": "https://s3.invalid", "body": "<xml/>"})
+    @patch("learning_resources.upload_views.initialize_upload")
+    def test_upload_endpoints_are_staff_only_strict_and_post_only(self, initialize, _complete, _finalize):
+        initialize.return_value = {"upload_session": "opaque", "upload_id": "id", "parts": []}
+        endpoints = [
+            ("initialize", {"file_name": "day.mp4", "file_size": 1024 * 1024, "content_type": "video/mp4"}),
+            ("complete", {"upload_session": "opaque", "upload_id": "id", "parts": []}),
+            ("finalize", {"upload_session": "opaque"}),
+        ]
+        for endpoint, payload in endpoints:
+            url = f"/api/learning-resources/devotional-videos/uploads/{endpoint}/"
+            self.assertIn(self.client.post(url, payload, format="json").status_code, {401, 403})
+        self.client.force_authenticate(user=self.user)
+        for endpoint, payload in endpoints:
+            url = f"/api/learning-resources/devotional-videos/uploads/{endpoint}/"
+            self.assertEqual(self.client.post(url, payload, format="json").status_code, 403)
+        self.client.force_authenticate(user=self.staff)
+        for endpoint, payload in endpoints:
+            url = f"/api/learning-resources/devotional-videos/uploads/{endpoint}/"
+            self.assertEqual(self.client.post(url, payload, format="json").status_code, 200)
+            self.assertEqual(self.client.post(url, {**payload, "key": "raw"}, format="json").status_code, 400)
+            self.assertEqual(self.client.get(url).status_code, 405)
+
+    def _ready_upload_token(self, owner=None, key="videos/devotional-cli/ready.mp4"):
+        owner = owner or self.staff
+        upload = DevotionalVideoUpload.objects.create(
+            nonce=f"nonce-{DevotionalVideoUpload.objects.count()}",
+            owner=owner,
+            storage_key=key,
+            file_name="ready.mp4",
+            expected_size=1024 * 1024,
+            content_type="video/mp4",
+            upload_id="aws-ready",
+            state=DevotionalVideoUpload.State.READY,
+            expires_at=timezone.now() + timedelta(hours=1),
+        )
+        token = signing.dumps(
+            {"nonce": upload.nonce, "user_id": owner.pk, "purpose": "video.video"},
+            salt="learning-resources.devotional-video-upload-token",
+        )
+        return upload, token
+
+    def test_real_create_and_patch_attachment_mark_ledger_attached(self):
+        self.client.force_authenticate(user=self.staff)
+        created_upload, create_token = self._ready_upload_token()
+        response = self.client.post(
+            "/api/learning-resources/videos/",
+            {**self.payload, "upload_token": create_token},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        created_upload.refresh_from_db()
+        self.assertEqual(created_upload.state, DevotionalVideoUpload.State.ATTACHED)
+
+        patch_upload, patch_token = self._ready_upload_token(
+            key="videos/devotional-cli/replacement.mp4"
+        )
+        response = self.client.patch(
+            f"/api/learning-resources/videos/{self.video.pk}/",
+            {"upload_token": patch_token},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        patch_upload.refresh_from_db()
+        self.assertEqual(patch_upload.state, DevotionalVideoUpload.State.ATTACHED)
+
+    def test_persistence_failure_leaves_ready_ledger_for_cleanup(self):
+        upload, token = self._ready_upload_token()
+        with self.assertRaises(RuntimeError):
+            attach_upload_token(
+                token,
+                user_id=self.staff.pk,
+                save=lambda _key: (_ for _ in ()).throw(RuntimeError("save failed")),
+            )
+        upload.refresh_from_db()
+        self.assertEqual(upload.state, DevotionalVideoUpload.State.READY)
+
+
+class CleanupDevotionalVideoUploadsTests(TestCase):
+    def setUp(self):
+        self.owner = get_user_model().objects.create_user("cleanup-owner")
+
+    def _upload(self, *, key, state, expired=True):
+        return DevotionalVideoUpload.objects.create(
+            nonce=uuid.uuid4().hex,
+            owner=self.owner,
+            storage_key=key,
+            file_name="orphan.mp4",
+            expected_size=1024 * 1024,
+            content_type="video/mp4",
+            upload_id="upload-id",
+            state=state,
+            expires_at=timezone.now() + timedelta(hours=-1 if expired else 1),
+        )
+
+    @patch("learning_resources.management.commands.cleanup_devotional_video_uploads.MultipartUploadAdapter")
+    def test_dry_run_execute_safety_and_idempotency(self, adapter_class):
+        adapter = adapter_class.return_value
+        ready = self._upload(
+            key="videos/devotional-cli/orphan.mp4",
+            state=DevotionalVideoUpload.State.READY,
+        )
+        attached = self._upload(
+            key="videos/devotional-cli/attached.mp4",
+            state=DevotionalVideoUpload.State.ATTACHED,
+        )
+        legacy = self._upload(
+            key="videos/legacy.mp4",
+            state=DevotionalVideoUpload.State.READY,
+        )
+        future = self._upload(
+            key="videos/devotional-cli/future.mp4",
+            state=DevotionalVideoUpload.State.READY,
+            expired=False,
+        )
+        output = StringIO()
+        call_command("cleanup_devotional_video_uploads", stdout=output)
+        self.assertIn("WOULD CLEAN", output.getvalue())
+        adapter_class.assert_not_called()
+
+        call_command("cleanup_devotional_video_uploads", "--execute")
+        adapter.abort_for_cleanup.assert_called_once_with(
+            key=ready.storage_key, upload_id=ready.upload_id
+        )
+        adapter.delete_object.assert_called_once_with(key=ready.storage_key)
+        ready.refresh_from_db()
+        self.assertEqual(ready.state, DevotionalVideoUpload.State.CLEANED)
+        for untouched in (attached, legacy, future):
+            untouched.refresh_from_db()
+            self.assertNotEqual(untouched.state, DevotionalVideoUpload.State.CLEANED)
+        call_command("cleanup_devotional_video_uploads", "--execute")
+        adapter.delete_object.assert_called_once()
+
+    @patch("learning_resources.management.commands.cleanup_devotional_video_uploads.MultipartUploadAdapter")
+    def test_missing_object_is_successful_and_repeat_is_noop(self, adapter_class):
+        missing = RuntimeError("missing")
+        missing.response = {"Error": {"Code": "NoSuchKey"}}
+        adapter = adapter_class.return_value
+        adapter.abort_for_cleanup.side_effect = missing
+        adapter.delete_object.side_effect = missing
+        upload = self._upload(
+            key="videos/devotional-cli/already-gone.mp4",
+            state=DevotionalVideoUpload.State.READY,
+        )
+
+        call_command("cleanup_devotional_video_uploads", "--execute")
+        upload.refresh_from_db()
+        self.assertEqual(upload.state, DevotionalVideoUpload.State.CLEANED)
+        self.assertIsNotNone(upload.cleaned_at)
+
+        call_command("cleanup_devotional_video_uploads", "--execute")
+        self.assertEqual(adapter.delete_object.call_count, 1)
+
+    @patch("learning_resources.management.commands.cleanup_devotional_video_uploads._finish_cleanup")
+    @patch("learning_resources.management.commands.cleanup_devotional_video_uploads.MultipartUploadAdapter")
+    def test_delete_success_then_db_failure_is_reconciled_on_retry(
+        self, adapter_class, finish_cleanup
+    ):
+        upload = self._upload(
+            key="videos/devotional-cli/reconcile.mp4",
+            state=DevotionalVideoUpload.State.READY,
+        )
+
+        def finish(upload_id):
+            if finish_cleanup.call_count == 1:
+                raise RuntimeError("database unavailable")
+            DevotionalVideoUpload.objects.filter(pk=upload_id).update(
+                cleaned_at=timezone.now()
+            )
+
+        finish_cleanup.side_effect = finish
+
+        call_command("cleanup_devotional_video_uploads", "--execute")
+        upload.refresh_from_db()
+        self.assertEqual(upload.state, DevotionalVideoUpload.State.CLEANED)
+        self.assertIsNone(upload.cleaned_at)
+
+        call_command("cleanup_devotional_video_uploads", "--execute")
+        self.assertEqual(adapter_class.return_value.delete_object.call_count, 2)
+        self.assertEqual(finish_cleanup.call_count, 2)
+        upload.refresh_from_db()
+        self.assertIsNotNone(upload.cleaned_at)
+
+    @patch("learning_resources.management.commands.cleanup_devotional_video_uploads.MultipartUploadAdapter")
+    def test_storage_failure_releases_claim_for_retry(self, adapter_class):
+        adapter = adapter_class.return_value
+        adapter.delete_object.side_effect = [RuntimeError("storage unavailable"), None]
+        upload = self._upload(
+            key="videos/devotional-cli/retry.mp4",
+            state=DevotionalVideoUpload.State.READY,
+        )
+
+        call_command("cleanup_devotional_video_uploads", "--execute")
+        upload.refresh_from_db()
+        self.assertEqual(upload.state, DevotionalVideoUpload.State.READY)
+
+        call_command("cleanup_devotional_video_uploads", "--execute")
+        upload.refresh_from_db()
+        self.assertEqual(upload.state, DevotionalVideoUpload.State.CLEANED)
+        self.assertIsNotNone(upload.cleaned_at)

--- a/learning_resources/upload_views.py
+++ b/learning_resources/upload_views.py
@@ -1,0 +1,45 @@
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework import status
+from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .devotional_video_uploads import (
+    UploadError, complete_upload, finalize_upload, initialize_upload,
+)
+
+
+class StaffUploadView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def run(self, request):
+        raise NotImplementedError
+
+    def post(self, request):
+        try:
+            return Response(self.run(request), status=status.HTTP_200_OK)
+        except (UploadError, ImproperlyConfigured) as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class InitializeUploadView(StaffUploadView):
+    def run(self, request):
+        allowed = {"file_name", "file_size", "content_type"}
+        if set(request.data) != allowed:
+            raise UploadError("Exactly file_name, file_size, and content_type are required.")
+        return initialize_upload(user_id=request.user.pk, **{key: request.data[key] for key in allowed})
+
+
+class CompleteUploadView(StaffUploadView):
+    def run(self, request):
+        allowed = {"upload_session", "upload_id", "parts"}
+        if set(request.data) != allowed:
+            raise UploadError("Exactly upload_session, upload_id, and parts are required.")
+        return complete_upload(user_id=request.user.pk, **{key: request.data[key] for key in allowed})
+
+
+class FinalizeUploadView(StaffUploadView):
+    def run(self, request):
+        if set(request.data) != {"upload_session"}:
+            raise UploadError("Exactly upload_session is required.")
+        return finalize_upload(user_id=request.user.pk, upload_session=request.data["upload_session"])

--- a/learning_resources/urls.py
+++ b/learning_resources/urls.py
@@ -8,11 +8,15 @@ from .views import (
     bookmark_delete_view, bookmark_check_view,
     VideoDetailView, ArticleDetailView, RecipeDetailView
 )
+from .upload_views import CompleteUploadView, FinalizeUploadView, InitializeUploadView
 
 urlpatterns = [
     # Content listing endpoints
     path('videos/', VideoListView.as_view(), name='video-list'),
     path('videos/<int:pk>/', VideoDetailView.as_view(), name='video-detail'),
+    path('devotional-videos/uploads/initialize/', InitializeUploadView.as_view(), name='devotional-video-upload-initialize'),
+    path('devotional-videos/uploads/complete/', CompleteUploadView.as_view(), name='devotional-video-upload-complete'),
+    path('devotional-videos/uploads/finalize/', FinalizeUploadView.as_view(), name='devotional-video-upload-finalize'),
     path('articles/', ArticleListView.as_view(), name='article-list'),
     path('articles/<int:pk>/', ArticleDetailView.as_view(), name='article-detail'),
     path('recipes/', RecipeListView.as_view(), name='recipe-list'),

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import get_object_or_404
-from rest_framework import generics, status
+from rest_framework import generics, mixins, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -8,12 +8,13 @@ from django.db.models import Q
 import logging
 from .models import Video, Article, Recipe, Bookmark
 from .serializers import (
-    VideoSerializer, ArticleSerializer, RecipeSerializer, 
+    VideoSerializer, DevotionalVideoWriteSerializer, ArticleSerializer, RecipeSerializer,
     DevotionalSetSerializer, BookmarkSerializer, BookmarkCreateSerializer
 )
 from .cache import BookmarkCacheManager
 from hub.models import DevotionalSet
 from django.utils.translation import activate, get_language_from_request
+from icons.views import IsAdminOrReadOnly
 
 
 def _get_bookmark_content_type(content_type):
@@ -95,13 +96,15 @@ class BookmarkOptimizedMixin:
         return obj
 
 
-class VideoListView(BookmarkOptimizedMixin, generics.ListAPIView):
+class VideoListView(BookmarkOptimizedMixin, mixins.ListModelMixin,
+                    mixins.CreateModelMixin, generics.GenericAPIView):
     """
     API endpoint that allows videos to be viewed.
 
     Permissions:
         - GET: Any user can view videos
-        - POST/PUT/PATCH/DELETE: Not supported
+        - POST: Authenticated staff can create devotional videos
+        - PUT/PATCH/DELETE: Not supported
 
     Query Parameters:
         - search (str): Optional. Filter videos by matching text in title or description.
@@ -137,8 +140,20 @@ class VideoListView(BookmarkOptimizedMixin, generics.ListAPIView):
         GET /api/learning-resources/videos/?search=prayer
         GET /api/learning-resources/videos/?category=tutorial
     """
-    serializer_class = VideoSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminOrReadOnly]
+
+    def get_serializer_class(self):
+        return DevotionalVideoWriteSerializer if self.request.method == "POST" else VideoSerializer
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        video = serializer.save()
+        return Response(VideoSerializer(video, context=self.get_serializer_context()).data,
+                        status=status.HTTP_201_CREATED)
     
     def get_queryset(self):
         # Activate requested language for _i18n virtual fields
@@ -272,13 +287,15 @@ class RecipeListView(BookmarkOptimizedMixin, generics.ListAPIView):
         return queryset.order_by('-created_at')
 
 
-class VideoDetailView(BookmarkOptimizedMixin, generics.RetrieveAPIView):
+class VideoDetailView(BookmarkOptimizedMixin, mixins.RetrieveModelMixin,
+                      generics.GenericAPIView):
     """
     API endpoint that allows a single video to be viewed.
 
     Permissions:
         - GET: Any user can view video details
-        - POST/PUT/PATCH/DELETE: Not supported
+        - PATCH: Authenticated staff can edit devotional videos
+        - POST/PUT/DELETE: Not supported
 
     Returns:
         A JSON response with the video details:
@@ -298,9 +315,21 @@ class VideoDetailView(BookmarkOptimizedMixin, generics.RetrieveAPIView):
     Example Requests:
         GET /api/learning-resources/videos/1/
     """
-    serializer_class = VideoSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminOrReadOnly]
     queryset = Video.objects.all()
+
+    def get_serializer_class(self):
+        return DevotionalVideoWriteSerializer if self.request.method == "PATCH" else VideoSerializer
+
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)
+
+    def patch(self, request, *args, **kwargs):
+        video = get_object_or_404(Video, pk=kwargs["pk"], category="devotional")
+        serializer = self.get_serializer(video, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        video = serializer.save()
+        return Response(VideoSerializer(video, context=self.get_serializer_context()).data)
 
 
 class ArticleDetailView(BookmarkOptimizedMixin, generics.RetrieveAPIView):


### PR DESCRIPTION
## Summary
- Add staff-only devotional create/update APIs with strict payload validation.
- Add staff-only video metadata and direct-S3 multipart upload APIs, including a persistent upload ledger and cleanup command.
- Protect legacy S3 capability routes and update the video upload policy to 500 MiB.

## Validation
- Crabbox: Ruff passed; Django suite passed (1,227 tests, 2 skipped).
- Focused devotional-video API module: 22 tests passed serially.
- Final review: clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New staff write surfaces, signed upload capabilities, and S3 multipart/cleanup logic affect auth, storage, and data integrity; requires migration and aligned bucket lifecycle rules.
> 
> **Overview**
> Adds **staff-only write APIs** for devotionals and devotional videos while keeping public **GET** behavior unchanged.
> 
> **Devotionals:** `POST /api/devotionals/` and `PATCH /api/devotionals/<id>/` use a strict `DevotionalWriteSerializer` (day, video, language, order, optional description), reject unknown fields, and map duplicate `(day, order, language_code)` to a validation error. List/detail views switch to `IsAdminOrReadOnly`.
> 
> **Devotional videos:** Staff can `POST`/`PATCH` learning-resource videos with metadata plus an **`upload_token`** from a new **direct-to-S3 multipart flow** (`initialize` → `complete` → `finalize`). Uploads are tracked in **`DevotionalVideoUpload`**, tokens are user-bound and one-use, and attachment runs in one transaction with the video save. A **`cleanup_devotional_video_uploads`** management command reclaims expired ledger rows under `videos/devotional-cli/`.
> 
> **Security & policy:** Legacy `/api/s3-upload/*` routes are re-wired through **`bahk.s3_upload_urls`** with **`staff_member_required`** before delegating to django-s3-file-field. Video upload limit messaging moves from **20MB to 500 MiB** on model, forms, and migration. Docs describe the new APIs and operational expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3775c3eb916d830430e90c8a7808e53b0d78b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->