### PR TITLE
Add per-edition circuit breaker for API.Bible fetches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,13 @@ Bahk (also known as Fast & Pray) is a Django-based web application for Christian
    - `GetDailyReadingsForDate` retrieves missing or expired `(passage, language)` pairs on demand, capped per day by `READING_FETCH_DAILY_BUDGET`. A date never requested before costs nothing if its passages are already stored.
    - `BIBLE_API_MONTHLY_BUDGET` is a hard ceiling over **both** paths (`hub/services/api_budget.py`). Post-change it should never be reached; alert on it rather than raising it.
    - The refresh task aborts after `READING_REFRESH_MAX_CONSECUTIVE_FAILURES` consecutive failures on metered languages, so a rejecting API costs ~10 calls instead of a full run.
+   - A per-edition circuit breaker (`hub/services/circuit_breaker.py`) opens after `BIBLE_API_CIRCUIT_BREAKER_THRESHOLD` consecutive failures on one Bible edition (NKJV or KJVAIC) and skips further attempts — no budget charged — until `BIBLE_API_CIRCUIT_BREAKER_COOLDOWN_SECONDS` elapses. Applies everywhere `fetch_english` is called (refresh task, on-demand view, admin), so a rejected edition cannot drain the daily/monthly budget shared with a working one.
 
    `get_reading_text_fields` blanks text/version/copyright/FUMS token once it exceeds that language's cap, so nothing past API.Bible's freshness window is ever served. Armenian is locally composed and never expires.
 
    Commands: `warm_passage_texts` (enumerate the whole corpus once, then no date is ever cold; run `--dry-run` first), `backfill_reading_passage_keys` (`--all` after any change to the key derivation), `fetch_reading_texts`, `fetch_armenian_reading_texts`.
 
-   Env vars: `BIBLE_API_KEY`, `READING_TEXT_REFRESH_DAYS`, `READING_TEXT_MAX_AGE_DAYS`, `READING_REFRESH_LIMIT`, `READING_REFRESH_MAX_CONSECUTIVE_FAILURES`, `READING_FETCH_DAILY_BUDGET`, `BIBLE_API_MONTHLY_BUDGET`.
+   Env vars: `BIBLE_API_KEY`, `READING_TEXT_REFRESH_DAYS`, `READING_TEXT_MAX_AGE_DAYS`, `READING_REFRESH_LIMIT`, `READING_REFRESH_MAX_CONSECUTIVE_FAILURES`, `READING_FETCH_DAILY_BUDGET`, `BIBLE_API_MONTHLY_BUDGET`, `BIBLE_API_CIRCUIT_BREAKER_THRESHOLD`, `BIBLE_API_CIRCUIT_BREAKER_COOLDOWN_SECONDS`.
 
 ## Development Environment
 

--- a/bahk/settings.py
+++ b/bahk/settings.py
@@ -482,6 +482,20 @@ READING_FETCH_DAILY_BUDGET = config('READING_FETCH_DAILY_BUDGET', default=25, ca
 # alert on it rather than raising it.  Held at 4,500 for the first post-deploy cycle, which
 # includes the one-time corpus warm-up, then dropped to 3,000.
 BIBLE_API_MONTHLY_BUDGET = config('BIBLE_API_MONTHLY_BUDGET', default=4500, cast=int)
+# Consecutive failures on one edition (NKJV or KJVAIC) before its circuit breaker opens
+# and further attempts are skipped without charging budget. Protects the shared budgets
+# above from being drained by a source that is currently rejecting every call (e.g. a
+# missing entitlement) -- without this, a stuck edition can burn READING_FETCH_DAILY_BUDGET
+# entirely on doomed retries, starving a healthy edition sharing the same day's budget.
+BIBLE_API_CIRCUIT_BREAKER_THRESHOLD = config(
+    'BIBLE_API_CIRCUIT_BREAKER_THRESHOLD', default=3, cast=int
+)
+# How long a tripped breaker stays open before allowing another attempt. Short enough that
+# a real fix (e.g. restoring an entitlement) is picked up quickly; long enough that one
+# request's worth of retries does not immediately re-trip it.
+BIBLE_API_CIRCUIT_BREAKER_COOLDOWN_SECONDS = config(
+    'BIBLE_API_CIRCUIT_BREAKER_COOLDOWN_SECONDS', default=900, cast=int
+)
 
 # Test settings
 if 'test' in sys.argv:

--- a/hub/management/commands/warm_passage_texts.py
+++ b/hub/management/commands/warm_passage_texts.py
@@ -20,7 +20,6 @@ from hub.services.lectionary_service import (
 )
 from hub.services.reading_text_service import (
     TEXT_FETCHERS,
-    bible_api_budgets,
     fetch_passage_text,
     prepare_shared_resources,
 )
@@ -172,11 +171,6 @@ class Command(BaseCommand):
                 continue
 
             shared = prepare_shared_resources()
-            # This is a deliberate, operator-run bulk backfill, not organic public
-            # traffic -- charge only the monthly ceiling, same as the refresh task
-            # (hub/tasks/bible_api_tasks.py), so it isn't throttled to
-            # READING_FETCH_DAILY_BUDGET and left to trickle in over weeks.
-            shared["budgets"] = bible_api_budgets(include_daily=False)
             retrieved = failed = 0
             for key in todo:
                 if fetch_passage_text(key, citations[key], langs=[language], **shared).get(language):

--- a/hub/management/commands/warm_passage_texts.py
+++ b/hub/management/commands/warm_passage_texts.py
@@ -20,6 +20,7 @@ from hub.services.lectionary_service import (
 )
 from hub.services.reading_text_service import (
     TEXT_FETCHERS,
+    bible_api_budgets,
     fetch_passage_text,
     prepare_shared_resources,
 )
@@ -171,6 +172,11 @@ class Command(BaseCommand):
                 continue
 
             shared = prepare_shared_resources()
+            # This is a deliberate, operator-run bulk backfill, not organic public
+            # traffic -- charge only the monthly ceiling, same as the refresh task
+            # (hub/tasks/bible_api_tasks.py), so it isn't throttled to
+            # READING_FETCH_DAILY_BUDGET and left to trickle in over weeks.
+            shared["budgets"] = bible_api_budgets(include_daily=False)
             retrieved = failed = 0
             for key in todo:
                 if fetch_passage_text(key, citations[key], langs=[language], **shared).get(language):

--- a/hub/services/circuit_breaker.py
+++ b/hub/services/circuit_breaker.py
@@ -1,0 +1,99 @@
+"""Per-source circuit breaker so a persistent failure cannot drain a shared spend budget.
+
+``APIBudget`` (see ``hub/services/api_budget.py``) caps *total* spend; it says nothing
+about whether calls are succeeding.  Without this, a source that is rejecting every
+call (bad credentials, a missing entitlement, an outage) still burns one budget slot
+per attempt, and a small shared daily budget can be exhausted entirely on doomed
+retries before an unrelated, healthy source gets a turn.  This stops attempts to a
+source once it has failed ``threshold`` times in a row, until ``cooldown_seconds`` has
+passed -- so a rejected source stops spending budget quickly, and self-heals once
+whatever was wrong is fixed, without needing a manual reset.
+"""
+
+import logging
+
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+
+class ConsecutiveFailureBreaker:
+    """Opens after *threshold* consecutive failures for one *name*; auto-closes after
+    *cooldown_seconds*.
+
+    Backed by ``django.core.cache`` (Redis in production), so state is shared across
+    web dynos and Celery workers -- unlike a local loop variable, this catches failures
+    that accumulate across separate requests, which is exactly the case a shared daily
+    budget needs protecting from.
+
+    Fails *open* (permits the attempt) if the cache is unreachable.  This differs from
+    ``APIBudget``, which fails closed: a budget's job is to guarantee a ceiling is never
+    exceeded, so it must refuse spend it cannot verify.  A breaker's job is only to stop
+    wasting spend on a source known to be failing; if the cache itself is down, calls
+    already can't be budgeted (``APIBudget.consume`` also fails closed on that same
+    outage), so failing open here adds no new exposure.
+    """
+
+    def __init__(self, name: str, *, threshold: int, cooldown_seconds: int):
+        self.name = name
+        self.threshold = threshold
+        self.cooldown_seconds = cooldown_seconds
+
+    def _failures_key(self) -> str:
+        return f"circuit_breaker:{self.name}:failures"
+
+    def _open_key(self) -> str:
+        return f"circuit_breaker:{self.name}:open"
+
+    def is_open(self) -> bool:
+        """True when further attempts should be skipped."""
+        try:
+            return bool(cache.get(self._open_key()))
+        except Exception:
+            logger.warning(
+                "Could not read %s circuit breaker state; permitting the attempt.",
+                self.name, exc_info=True,
+            )
+            return False
+
+    def record_failure(self) -> None:
+        """Count one failure; open the breaker once *threshold* is reached in a row."""
+        try:
+            try:
+                count = cache.incr(self._failures_key())
+            except ValueError:
+                # Key missing or expired: this is the first failure of a new streak.
+                cache.set(self._failures_key(), 1, timeout=self.cooldown_seconds)
+                count = 1
+        except Exception:
+            logger.warning(
+                "Could not update %s circuit breaker failure count.",
+                self.name, exc_info=True,
+            )
+            return
+
+        if count >= self.threshold:
+            try:
+                cache.set(self._open_key(), True, timeout=self.cooldown_seconds)
+            except Exception:
+                logger.warning(
+                    "Could not open %s circuit breaker after %d consecutive failures.",
+                    self.name, count, exc_info=True,
+                )
+                return
+            logger.error(
+                "Circuit breaker for %s opened after %d consecutive failures; skipping "
+                "further attempts for %ds.",
+                self.name, count, self.cooldown_seconds,
+            )
+
+    def record_success(self) -> None:
+        """Reset the failure streak and close the breaker."""
+        try:
+            cache.delete(self._failures_key())
+            cache.delete(self._open_key())
+        except Exception:
+            logger.warning(
+                "Could not reset %s circuit breaker state after a success.",
+                self.name, exc_info=True,
+            )

--- a/hub/services/reading_text_service.py
+++ b/hub/services/reading_text_service.py
@@ -40,6 +40,7 @@ from django.utils import timezone
 from hub.constants import BOOK_NAME_TO_USFM_NORMALIZED, normalize_book_name
 from hub.services.api_budget import DAY, MONTH, APIBudget
 from hub.services.bible_api_service import BibleAPIService
+from hub.services.circuit_breaker import ConsecutiveFailureBreaker
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +145,18 @@ def fetch_english(
         logger.error("Book name mapping failed for %r: %s", book, exc)
         return None
 
+    # Keyed per edition (NKJV vs KJVAIC), not just "en" generally: NKJV and KJVAIC are
+    # unrelated entitlements on the API.Bible account, so a rejection on one (e.g. a
+    # missing licence) must not stop attempts on the other, which may be working fine.
+    _, version = BibleAPIService._bible_id_for_book(passage[0])
+    breaker = bible_api_breaker(version)
+    if breaker.is_open():
+        logger.warning(
+            "Circuit breaker open for %s; skipping fetch for %s %s:%s-%s:%s.",
+            version, book, start_chapter, start_verse, end_chapter, end_verse,
+        )
+        return None
+
     for budget in budgets or ():
         if not budget.consume():
             logger.warning(
@@ -159,12 +172,14 @@ def fetch_english(
     try:
         result = service.get_passage(*passage)
     except Exception as exc:
+        breaker.record_failure()
         logger.error(
             "API call failed for %s %s:%s-%s:%s: %s",
             book, start_chapter, start_verse, end_chapter, end_verse, exc,
         )
         return None
 
+    breaker.record_success()
     return {
         "text": result["content"],
         "version": result["version"],
@@ -241,6 +256,20 @@ def bible_api_budgets(*, include_daily: bool = True) -> list[APIBudget]:
         "bible_api", getattr(settings, "BIBLE_API_MONTHLY_BUDGET", 4500), period=MONTH,
     ))
     return budgets
+
+
+def bible_api_breaker(version: str) -> ConsecutiveFailureBreaker:
+    """Circuit breaker for one API.Bible edition, e.g. ``"NKJV"`` or ``"KJVAIC"``.
+
+    One breaker per edition, not per language: NKJV and KJVAIC are separate
+    entitlements on the API.Bible account, so a rejection on one must not stop
+    attempts on the other.
+    """
+    return ConsecutiveFailureBreaker(
+        f"bible_api:{version}",
+        threshold=getattr(settings, "BIBLE_API_CIRCUIT_BREAKER_THRESHOLD", 3),
+        cooldown_seconds=getattr(settings, "BIBLE_API_CIRCUIT_BREAKER_COOLDOWN_SECONDS", 900),
+    )
 
 
 def _prepare_english_resources(**_kwargs) -> dict[str, Any]:

--- a/hub/tests/test_bible_api.py
+++ b/hub/tests/test_bible_api.py
@@ -486,6 +486,114 @@ class FetchEnglishTextTests(TestCase):
 
 
 # ------------------------------------------------------------------ #
+#  Circuit breaker: a rejected edition must not drain a shared budget
+# ------------------------------------------------------------------ #
+
+class FetchEnglishCircuitBreakerTests(TestCase):
+    """A stuck NKJV entitlement (or any persistent failure) must not exhaust the
+    budget shared with KJVAIC -- the bug behind bahk issue #474's "fetched via admin,
+    never served on the frontend" symptom for Apocrypha readings."""
+
+    def setUp(self):
+        cache.clear()
+        self.church = Church.objects.get(pk=Church.get_default_pk())
+        self.day = Day.objects.create(date=date(2025, 6, 15), church=self.church)
+
+    @override_settings(BIBLE_API_CIRCUIT_BREAKER_THRESHOLD=2, READING_FETCH_DAILY_BUDGET=1000, BIBLE_API_MONTHLY_BUDGET=1000)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_breaker_opens_and_stops_charging_budget(self, mock_config, mock_get_passage):
+        import requests
+        mock_get_passage.side_effect = requests.HTTPError("403 Forbidden")
+        budgets = bible_api_budgets()
+
+        readings = [
+            _create_reading(self.day, book="Genesis", start_ch=1, start_v=v, end_ch=1, end_v=v)
+            for v in range(1, 5)
+        ]
+
+        results = [
+            fetch_all_reading_texts(r, langs=["en"], budgets=budgets).get("en")
+            for r in readings
+        ]
+
+        self.assertEqual(results, [False, False, False, False])
+        # Only the first two calls actually reach the API (threshold=2); the breaker
+        # opens after that and the rest are skipped without a call or a budget charge.
+        self.assertEqual(mock_get_passage.call_count, 2)
+        self.assertEqual(budgets[1].used(), 2)  # budgets = [daily, monthly]
+
+    @override_settings(BIBLE_API_CIRCUIT_BREAKER_THRESHOLD=2, READING_FETCH_DAILY_BUDGET=1000, BIBLE_API_MONTHLY_BUDGET=1000)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_broken_nkjv_does_not_block_kjvaic(self, mock_config, mock_get_passage):
+        """The breaker is keyed per edition, so a stuck NKJV must not stop KJVAIC --
+        this is what production issue #474 needs: KJVAIC readings kept failing on the
+        public view even though they fetched fine from the admin, because they shared
+        a daily budget with doomed NKJV attempts."""
+        import requests
+
+        def side_effect(usfm_book_id, *args, **kwargs):
+            if usfm_book_id == "TOB":
+                return {
+                    "content": "Apocrypha text.", "copyright": "", "version": "KJVAIC",
+                    "reference": "Tobit 1:1", "fums_token": "tok",
+                }
+            raise requests.HTTPError("403 Forbidden")
+
+        mock_get_passage.side_effect = side_effect
+        budgets = bible_api_budgets()
+
+        # Trip the NKJV breaker.
+        for v in range(1, 3):
+            reading = _create_reading(self.day, book="Genesis", start_ch=1, start_v=v, end_ch=1, end_v=v)
+            fetch_all_reading_texts(reading, langs=["en"], budgets=budgets)
+
+        # NKJV is now open; a further Genesis fetch is skipped without a call.
+        blocked = _create_reading(self.day, book="Genesis", start_ch=1, start_v=10, end_ch=1, end_v=10)
+        self.assertFalse(fetch_all_reading_texts(blocked, langs=["en"], budgets=budgets).get("en"))
+        calls_before_apocrypha = mock_get_passage.call_count
+
+        # KJVAIC (Tobit) must still succeed: a different edition, a different breaker.
+        apocrypha = _create_reading(self.day, book="Tobit", start_ch=1, start_v=1, end_ch=1, end_v=1)
+        self.assertTrue(fetch_all_reading_texts(apocrypha, langs=["en"], budgets=budgets).get("en"))
+        self.assertEqual(mock_get_passage.call_count, calls_before_apocrypha + 1)
+
+    @override_settings(BIBLE_API_CIRCUIT_BREAKER_THRESHOLD=2, READING_FETCH_DAILY_BUDGET=1000, BIBLE_API_MONTHLY_BUDGET=1000)
+    @patch('hub.services.bible_api_service.BibleAPIService.get_passage')
+    @patch('hub.services.bible_api_service.config', return_value="test-key")
+    def test_success_resets_the_failure_streak(self, mock_config, mock_get_passage):
+        """An intervening success must reset the *consecutive* count, not just delay it.
+
+        threshold=2: fail, succeed, fail should leave the breaker closed, because the
+        second failure is not consecutive with the first -- a transient blip must not
+        combine with an unrelated later one to trip the breaker.
+        """
+        import requests
+
+        mock_api_response = {
+            "content": "Text.", "copyright": "", "version": "NKJV",
+            "reference": "Genesis 1:1", "fums_token": "tok",
+        }
+        mock_get_passage.side_effect = [
+            requests.HTTPError("403 Forbidden"),
+            mock_api_response,
+            requests.HTTPError("403 Forbidden"),
+        ]
+        budgets = bible_api_budgets()
+
+        for start_v in (1, 2, 3):
+            reading = _create_reading(
+                self.day, book="Genesis", start_ch=1, start_v=start_v, end_ch=1, end_v=start_v,
+            )
+            fetch_all_reading_texts(reading, langs=["en"], budgets=budgets)
+
+        from hub.services.reading_text_service import bible_api_breaker
+        self.assertFalse(bible_api_breaker("NKJV").is_open())
+        self.assertEqual(mock_get_passage.call_count, 3)
+
+
+# ------------------------------------------------------------------ #
 #  fetch_reading_text_task (Celery wrapper) Tests
 # ------------------------------------------------------------------ #
 

--- a/hub/tests/test_circuit_breaker.py
+++ b/hub/tests/test_circuit_breaker.py
@@ -1,0 +1,89 @@
+"""Tests for ConsecutiveFailureBreaker (hub.services.circuit_breaker).
+
+Uses LocMemCache (tests.test_settings), which -- like Redis in production, unlike a
+local loop variable -- persists across separate calls to the breaker within a test, so
+these genuinely exercise the cross-call behavior the fix depends on.
+"""
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from hub.services.circuit_breaker import ConsecutiveFailureBreaker
+
+
+class ConsecutiveFailureBreakerTests(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def test_closed_by_default(self):
+        breaker = ConsecutiveFailureBreaker("test", threshold=3, cooldown_seconds=60)
+        self.assertFalse(breaker.is_open())
+
+    def test_opens_after_threshold_consecutive_failures(self):
+        breaker = ConsecutiveFailureBreaker("test", threshold=3, cooldown_seconds=60)
+
+        breaker.record_failure()
+        self.assertFalse(breaker.is_open())
+        breaker.record_failure()
+        self.assertFalse(breaker.is_open())
+        breaker.record_failure()
+        self.assertTrue(breaker.is_open())
+
+    def test_success_resets_failure_streak(self):
+        breaker = ConsecutiveFailureBreaker("test", threshold=3, cooldown_seconds=60)
+
+        breaker.record_failure()
+        breaker.record_failure()
+        breaker.record_success()
+        breaker.record_failure()
+        breaker.record_failure()
+
+        # Two failures since the reset -- one short of the threshold of three.
+        self.assertFalse(breaker.is_open())
+
+    def test_success_closes_an_open_breaker(self):
+        breaker = ConsecutiveFailureBreaker("test", threshold=1, cooldown_seconds=60)
+
+        breaker.record_failure()
+        self.assertTrue(breaker.is_open())
+
+        breaker.record_success()
+        self.assertFalse(breaker.is_open())
+
+    def test_separate_names_do_not_interfere(self):
+        """Distinct sources (e.g. NKJV vs KJVAIC) must not share state."""
+        nkjv = ConsecutiveFailureBreaker("bible_api:NKJV", threshold=1, cooldown_seconds=60)
+        kjvaic = ConsecutiveFailureBreaker("bible_api:KJVAIC", threshold=1, cooldown_seconds=60)
+
+        nkjv.record_failure()
+
+        self.assertTrue(nkjv.is_open())
+        self.assertFalse(kjvaic.is_open())
+
+    def test_open_expires_after_cooldown(self):
+        breaker = ConsecutiveFailureBreaker("test", threshold=1, cooldown_seconds=60)
+        breaker.record_failure()
+        self.assertTrue(breaker.is_open())
+
+        # Simulate the cooldown elapsing rather than sleeping in the test.
+        cache.delete(breaker._open_key())
+        self.assertFalse(breaker.is_open())
+
+    def test_is_open_fails_open_on_cache_error(self):
+        breaker = ConsecutiveFailureBreaker("test", threshold=1, cooldown_seconds=60)
+        breaker.record_failure()
+        self.assertTrue(breaker.is_open())
+
+        with patch("hub.services.circuit_breaker.cache.get", side_effect=Exception("boom")):
+            self.assertFalse(breaker.is_open())
+
+    def test_record_failure_does_not_raise_on_cache_error(self):
+        breaker = ConsecutiveFailureBreaker("test", threshold=1, cooldown_seconds=60)
+        with patch("hub.services.circuit_breaker.cache.incr", side_effect=Exception("boom")):
+            breaker.record_failure()  # must not raise
+
+    def test_record_success_does_not_raise_on_cache_error(self):
+        breaker = ConsecutiveFailureBreaker("test", threshold=1, cooldown_seconds=60)
+        with patch("hub.services.circuit_breaker.cache.delete", side_effect=Exception("boom")):
+            breaker.record_success()  # must not raise


### PR DESCRIPTION
## Summary
- Adds a per-edition (NKJV vs KJVAIC) circuit breaker (`hub/services/circuit_breaker.py`) that opens after `BIBLE_API_CIRCUIT_BREAKER_THRESHOLD` (default 3) consecutive failures and skips further attempts for `BIBLE_API_CIRCUIT_BREAKER_COOLDOWN_SECONDS` (default 900s) without charging budget
- Fixes a starvation bug found while investigating #474: a rejected NKJV entitlement was burning the whole `READING_FETCH_DAILY_BUDGET` (25/day) on doomed retries, starving KJVAIC (Apocrypha) fetches that share the same budget and would otherwise succeed
- Split out of #475 — that PR's `warm_passage_texts` fix is independent and already unblocks the immediate issue (NKJV access itself is now confirmed working again), so this is general hardening rather than something blocking the current fix
- New tests: `hub/tests/test_circuit_breaker.py` (unit) + `FetchEnglishCircuitBreakerTests` in `hub/tests/test_bible_api.py`, including the test pinning the actual bug (stuck NKJV must not block working KJVAIC)

## Test plan
- [x] `tests.unit.hub`, `hub.tests.test_bible_api`, `hub.tests.test_circuit_breaker`, `hub.tests.test_armenian_text`, `hub.tests.test_task_imports` — 184 tests, all passing (native venv, no Docker)
- [x] Manual repro against live API.Bible: breaker stays closed on real NKJV/KJVAIC success

🤖 Generated with [Claude Code](https://claude.com/claude-code)